### PR TITLE
fix: invalid cross-device link

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -93,5 +93,5 @@ jobs:
       - name: Test installation
         run: |
           npm install -g @safedep/pmg@${{ steps.version.outputs.version }}
-          pmg --version
+          pmg version
           pmg --help || true

--- a/publish/npm/install.js
+++ b/publish/npm/install.js
@@ -192,8 +192,18 @@ async function install() {
       );
     }
 
-    // Move binary to final location
-    fs.renameSync(extractedBinaryPath, finalBinaryPath);
+    // Move binary to final location (handle cross-device links)
+    try {
+      fs.renameSync(extractedBinaryPath, finalBinaryPath);
+    } catch (error) {
+      if (error.code === "EXDEV") {
+        // Cross-device link not permitted, copy and delete instead
+        fs.copyFileSync(extractedBinaryPath, finalBinaryPath);
+        fs.unlinkSync(extractedBinaryPath);
+      } else {
+        throw error;
+      }
+    }
 
     // Make executable on Unix systems
     if (process.platform !== "win32") {

--- a/publish/npm/package.json
+++ b/publish/npm/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@safedep/pmg",
-  "version": "0.0.7",
   "description": "PMG protects developers from getting compromised by malicious packages",
   "main": "bin/pmg.js",
   "bin": {

--- a/publish/npm/package.json
+++ b/publish/npm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@safedep/pmg",
+  "version": "0.0.7",
   "description": "PMG protects developers from getting compromised by malicious packages",
   "main": "bin/pmg.js",
   "bin": {


### PR DESCRIPTION
Fix `EXDEV` where renaming a file across different filesystems lead to error in linux during `npm i -g @safedep/pmg`
