### PR TITLE
fix download artifact path

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -67,5 +67,4 @@ jobs:
       - name: Attest build provenance (checksums)
         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
         with:
-          # actions/download-artifact downloads to `$path/$name` convention
-          subject-checksums: dist/dist-artifacts/checksums.txt
+          subject-checksums: dist/checksums.txt


### PR DESCRIPTION
From v5, the `download-artifact` extracts the contents of artifact to the path directly if referencing the artifact by name.

Ref: https://github.com/actions/download-artifact?tab=readme-ov-file#v5---whats-new
