### PR TITLE
feat: Log PMG version and config details in debug mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
+	"strings"
 
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/cmd/cloud"
@@ -71,6 +73,10 @@ func main() {
 			}
 
 			log.InitZapLogger("pmg", "cli")
+
+			if debug {
+				logDebugContext()
+			}
 
 			// Initialize event logging (silently fail if it can't be initialized)
 			var eventlogErr error
@@ -150,4 +156,20 @@ func main() {
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+func logDebugContext() {
+	cfg := config.Get()
+
+	log.Debugf("Command: pmg %s", strings.Join(os.Args[1:], " "))
+	log.Debugf("PMG %s (commit: %s) running on %s/%s with %s",
+		appVersion.Version, appVersion.Commit, runtime.GOOS, runtime.GOARCH, runtime.Version())
+	log.Debugf("Using config file: %s", cfg.ConfigFilePath())
+	log.Debugf("Proxy mode enabled: %t, install only: %t", cfg.IsProxyModeEnabled(), cfg.Config.ProxyInstallOnly)
+	log.Debugf("Sandbox enabled: %t, enforce always: %t", cfg.Config.Sandbox.Enabled, cfg.Config.Sandbox.EnforceAlways)
+	log.Debugf("Transitive analysis enabled: %t (depth: %d), paranoid: %t", cfg.Config.Transitive, cfg.Config.TransitiveDepth, cfg.Config.Paranoid)
+	log.Debugf("Dependency cooldown enabled: %t (days: %d)", cfg.Config.DependencyCooldown.Enabled, cfg.Config.DependencyCooldown.Days)
+	log.Debugf("Cloud sync enabled: %t, telemetry disabled: %t", cfg.Config.Cloud.Enabled, cfg.Config.DisableTelemetry)
+	log.Debugf("Dry run: %t, insecure installation: %t, trusted packages: %d",
+		cfg.DryRun, cfg.InsecureInstallation, len(cfg.Config.TrustedPackages))
 }

--- a/main.go
+++ b/main.go
@@ -74,10 +74,6 @@ func main() {
 
 			log.InitZapLogger("pmg", "cli")
 
-			if debug {
-				logDebugContext()
-			}
-
 			// Initialize event logging (silently fail if it can't be initialized)
 			var eventlogErr error
 			if logFile != "" {
@@ -101,6 +97,10 @@ func main() {
 			// Parse and validate --sandbox-allow flags after all flags are resolved
 			if err := config.FinalizeSandboxAllowOverrides(); err != nil {
 				ui.Fatalf("pmg: %v", err)
+			}
+
+			if debug {
+				logDebugContext()
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- Logs full execution context at startup when `--debug` is enabled: command invocation, PMG version/commit, OS/arch, Go version, config file path, and all key config values (proxy, sandbox, transitive analysis, cooldown, cloud sync, telemetry, trusted packages count)
- Extracted debug logging into a `logDebugContext()` function to keep `main()` clean
- Makes debug logs self-contained so bug reporters don't need to be asked for each detail separately

## Test plan
- [x] Run `pmg --debug npm version` and verify debug lines include command, version, config path, and all config values
- [x] Run `pmg npm version` (without `--debug`) and verify no debug output appears
- [x] Run `pmg --debug --log /tmp/pmg.log npm version` and verify debug context is written to the log file
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/safedep/pmg/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
