### PR TITLE
fix: Enforce sandbox for update commands (#220)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -379,11 +379,11 @@ func Get() *RuntimeConfig {
 	return globalConfig
 }
 
-func ConfigureSandbox(isInstallationCommand bool) {
+func ConfigureSandbox(mayDownloadPackages bool) {
 	if globalConfig.Config.Sandbox.Enabled {
 		// Apply sandbox to all commands if EnforceAlways=true, otherwise only to
-		// installation commands else disable the sandbox
-		globalConfig.Config.Sandbox.Enabled = globalConfig.Config.Sandbox.EnforceAlways || isInstallationCommand
+		// commands that may download packages (install, update, etc.)
+		globalConfig.Config.Sandbox.Enabled = globalConfig.Config.Sandbox.EnforceAlways || mayDownloadPackages
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -221,6 +221,64 @@ func TestConfigPrecedence(t *testing.T) {
 	})
 }
 
+func TestConfigureSandbox(t *testing.T) {
+	tests := []struct {
+		name                 string
+		sandboxEnabled       bool
+		enforceAlways        bool
+		mayDownloadPackages  bool
+		expectedSandboxState bool
+	}{
+		{
+			name:                 "sandbox disabled stays disabled regardless of command",
+			sandboxEnabled:       false,
+			mayDownloadPackages:  true,
+			expectedSandboxState: false,
+		},
+		{
+			name:                 "sandbox enabled with download command stays enabled",
+			sandboxEnabled:       true,
+			mayDownloadPackages:  true,
+			expectedSandboxState: true,
+		},
+		{
+			name:                 "sandbox enabled with non-download command gets disabled",
+			sandboxEnabled:       true,
+			mayDownloadPackages:  false,
+			expectedSandboxState: false,
+		},
+		{
+			name:                 "enforce_always keeps sandbox enabled for non-download command",
+			sandboxEnabled:       true,
+			enforceAlways:        true,
+			mayDownloadPackages:  false,
+			expectedSandboxState: true,
+		},
+		{
+			name:                 "enforce_always with download command stays enabled",
+			sandboxEnabled:       true,
+			enforceAlways:        true,
+			mayDownloadPackages:  true,
+			expectedSandboxState: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PMG_CONFIG_DIR", "/tmp/pmg-test/random-does-not-exist")
+			initConfig()
+
+			cfg := Get()
+			cfg.Config.Sandbox.Enabled = tc.sandboxEnabled
+			cfg.Config.Sandbox.EnforceAlways = tc.enforceAlways
+
+			ConfigureSandbox(tc.mayDownloadPackages)
+
+			assert.Equal(t, tc.expectedSandboxState, cfg.Config.Sandbox.Enabled)
+		})
+	}
+}
+
 func TestWriteTemplateConfigMergesExistingConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("PMG_CONFIG_DIR", tmpDir)

--- a/internal/flows/common_flow.go
+++ b/internal/flows/common_flow.go
@@ -34,7 +34,7 @@ func (f *commonFlow) Run(ctx context.Context, args []string, parsedCmd *packagem
 	var analyzers []analyzer.PackageVersionAnalyzer
 
 	// Configure sandbox based on command type and enforcement policy
-	config.ConfigureSandbox(parsedCmd.IsInstallationCommand())
+	config.ConfigureSandbox(parsedCmd.IsInstallationCommand() || parsedCmd.MayDownloadPackages())
 
 	cfg := config.Get()
 

--- a/internal/flows/proxy_flow.go
+++ b/internal/flows/proxy_flow.go
@@ -48,7 +48,7 @@ func (f *proxyFlow) Run(ctx context.Context, args []string, parsedCmd *packagema
 	}
 
 	// Configure sandbox based on command type and enforcement policy
-	config.ConfigureSandbox(parsedCmd.IsInstallationCommand())
+	config.ConfigureSandbox(parsedCmd.IsInstallationCommand() || parsedCmd.MayDownloadPackages())
 
 	cfg := config.Get()
 


### PR DESCRIPTION
## Summary
- `ConfigureSandbox` was only triggered by `IsInstallationCommand()`, missing update commands (`npm update`, `pnpm update`, `yarn upgrade`, `poetry update`) that download new package versions and run postinstall scripts without sandbox confinement
- Updated both `commonFlow` and `proxyFlow` to use `IsInstallationCommand() || MayDownloadPackages()` as the sandbox signal
- Renamed `ConfigureSandbox` parameter from `isInstallationCommand` to `mayDownloadPackages` to reflect broader scope
- Added table-driven tests for `ConfigureSandbox` covering all sandbox state combinations

Fixes #220

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./config/ -run TestConfigureSandbox` — all 5 cases pass
- [ ] Manual: run `pmg npm update` with sandbox enabled and verify sandbox is enforced
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/safedep/pmg/pull/229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
