### PR TITLE
build: add Windows support for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,33 @@
 GO := go
 BIN_DIR := bin
-BIN := $(BIN_DIR)/pmg
-SHELL := /bin/bash
+
+# Platform detection
+ifeq ($(OS),Windows_NT)
+	BINARY_EXT := .exe
+	# Detect if we are in a Unix-like shell on Windows (e.g. Git Bash)
+	# If 'uname' is available, we assume a Unix-like shell
+	ifneq ($(shell uname -s 2>/dev/null),)
+		MKDIR_P := mkdir -p $(BIN_DIR)
+		RM_RF := rm -rf $(BIN_DIR)
+	else
+		MKDIR_P := if not exist $(BIN_DIR) mkdir $(BIN_DIR)
+		RM_RF := if exist $(BIN_DIR) rmdir /s /q $(BIN_DIR)
+	endif
+else
+	BINARY_EXT :=
+	MKDIR_P := mkdir -p $(BIN_DIR)
+	RM_RF := rm -rf $(BIN_DIR)
+	SHELL := /bin/bash
+endif
+
+BIN := $(BIN_DIR)/pmg$(BINARY_EXT)
 GITCOMMIT := $(shell git rev-parse HEAD)
 VERSION := "$(shell git describe --tags --abbrev=0)-$(shell git rev-parse --short HEAD)"
 
 GO_CFLAGS=-X 'github.com/safedep/pmg/internal/version.Commit=$(GITCOMMIT)' -X 'github.com/safedep/pmg/internal/version.Version=$(VERSION)'
 GO_LDFLAGS=-ldflags "-w $(GO_CFLAGS)"
 
-.PHONY: all
+.PHONY: all pmg create_bin clean test
 
 all: pmg
 
@@ -16,10 +35,10 @@ pmg: create_bin
 	$(GO) build ${GO_LDFLAGS} -o $(BIN) main.go
 
 create_bin:
-	mkdir -p $(BIN_DIR)
+	$(MKDIR_P)
 
 clean:
-	rm -rf $(BIN_DIR)
+	$(RM_RF)
 
 test:
 	go test ./...


### PR DESCRIPTION
Added cross-platform support to the Makefile, allowing developers to build and test PMG locally on Windows environments.
It works by reading and checking which os is being run and runs the associated commands for it in the Makefile.Also detects if we are an unix-like shell on windows or not.