### PR TITLE
fix: remove script runners from NonDownloadCommands

### DIFF
--- a/packagemanager/npm.go
+++ b/packagemanager/npm.go
@@ -21,16 +21,7 @@ func DefaultNpmPackageManagerConfig() NpmPackageManagerConfig {
 		InstallCommands: []string{"install", "i", "add"},
 		// Commands that are known to never download packages from a registry.
 		// Anything not in this list (including unknown future commands) runs with the proxy.
-		//
-		// Script runners: "run", "start", "stop", "restart", "test"/"t" are all shorthand for
-		// "npm run <script>". They spin up local processes (dev servers, test runners) that make
-		// their own HTTP calls — setting proxy env vars breaks them without providing any security
-		// benefit since they don't contact the package registry themselves.
-		//
-		// "exec" is intentionally excluded — it downloads and runs a package (npx equivalent).
 		NonDownloadCommands: []string{
-			// Script runners — may start servers or long-running processes
-			"run", "start", "stop", "restart", "test", "t",
 			// Removal — uninstalls local packages, no registry download
 			"uninstall", "remove", "rm", "r", "un", "unlink",
 			// Local operations — no registry contact
@@ -47,7 +38,6 @@ func DefaultPnpmPackageManagerConfig() NpmPackageManagerConfig {
 	return NpmPackageManagerConfig{
 		InstallCommands: []string{"install", "i", "add"},
 		NonDownloadCommands: []string{
-			"run", "start", "stop", "restart", "test",
 			"remove", "rm", "uninstall", "un",
 			"prune", "link", "unlink",
 			"ls", "list", "outdated", "info", "view", "config", "why",
@@ -60,8 +50,6 @@ func DefaultBunPackageManagerConfig() NpmPackageManagerConfig {
 	return NpmPackageManagerConfig{
 		InstallCommands: []string{"install", "i", "add"},
 		NonDownloadCommands: []string{
-			// Script runners and local operations
-			"run", "test", "build",
 			// Removal
 			"remove", "rm",
 		},
@@ -73,7 +61,6 @@ func DefaultYarnPackageManagerConfig() NpmPackageManagerConfig {
 	return NpmPackageManagerConfig{
 		InstallCommands: []string{"install", "add", ""},
 		NonDownloadCommands: []string{
-			"run", "start", "stop", "restart", "test",
 			"remove", "unlink",
 			"ls", "list", "outdated", "info", "config", "why",
 		},

--- a/packagemanager/npm_test.go
+++ b/packagemanager/npm_test.go
@@ -539,26 +539,26 @@ func TestNpmProxyBehavior(t *testing.T) {
 			isKnownNonDownloadCmd: true,
 			isInstallationCommand: false,
 		},
-		// Script execution via run
+		// Script runners are not in NonDownloadCommands — proxy runs for them
 		{
-			name:                  "npm run dev — proxy skipped (executes local script, no registry contact)",
+			name:                  "npm run dev — proxy runs (script runner)",
 			pm:                    func() (*npmPackageManager, error) { return NewNpmPackageManager(DefaultNpmPackageManagerConfig()) },
 			command:               "npm run dev",
-			isKnownNonDownloadCmd: true,
+			isKnownNonDownloadCmd: false,
 			isInstallationCommand: false,
 		},
 		{
-			name:                  "yarn run build — proxy skipped (executes local script)",
+			name:                  "yarn run build — proxy runs (script runner)",
 			pm:                    func() (*npmPackageManager, error) { return NewNpmPackageManager(DefaultYarnPackageManagerConfig()) },
 			command:               "yarn run build",
-			isKnownNonDownloadCmd: true,
+			isKnownNonDownloadCmd: false,
 			isInstallationCommand: false,
 		},
 		{
-			name:                  "bun run test — proxy skipped (executes local script)",
+			name:                  "bun run test — proxy runs (script runner)",
 			pm:                    func() (*npmPackageManager, error) { return NewNpmPackageManager(DefaultBunPackageManagerConfig()) },
 			command:               "bun run test",
-			isKnownNonDownloadCmd: true,
+			isKnownNonDownloadCmd: false,
 			isInstallationCommand: false,
 		},
 		// False positive regression: package/script names matching NonDownloadCommands words

--- a/packagemanager/pypi.go
+++ b/packagemanager/pypi.go
@@ -62,10 +62,6 @@ func DefaultPoetryPackageManagerConfig() PypiPackageManagerConfig {
 	return PypiPackageManagerConfig{
 		InstallCommands: []string{"add"},
 		NonDownloadCommands: []string{
-			// Script runners — "run" executes a command in the venv (e.g., `poetry run uvicorn app:app`).
-			// "shell" activates the venv shell. Both may start long-running processes and must not
-			// have proxy env vars set against them.
-			"run", "shell",
 			// Removal
 			"remove",
 			// Inspection / read-only


### PR DESCRIPTION
## Summary
- Removed script runner commands (`run`, `start`, `stop`, `restart`, `test`, `t`, `build`, `shell`) from `NonDownloadCommands` across all package manager configs (npm, pnpm, bun, yarn, poetry)
- These are not package management commands, so they should go through the proxy rather than being skipped
- Updated corresponding test cases to reflect the new behavior

## Test plan
- [x] All `packagemanager` tests pass (`go test ./packagemanager/ -count=1`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/safedep/pmg/pull/242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->