### PR TITLE
fix: Allow macos fsevents by default in sandbox

### DIFF
--- a/sandbox/platform/seatbelt_translator_darwin.go
+++ b/sandbox/platform/seatbelt_translator_darwin.go
@@ -203,6 +203,7 @@ func (t *seatbeltPolicyTranslator) translate(policy *sandbox.SandboxPolicy) (str
 	sb.WriteString("(allow mach-lookup\n")
 	sb.WriteString("  (global-name \"com.apple.audio.systemsoundserver\")\n")
 	sb.WriteString("  (global-name \"com.apple.distributed_notifications@Uv3\")\n")
+	sb.WriteString("  (global-name \"com.apple.FSEvents\")\n")
 	sb.WriteString("  (global-name \"com.apple.FontObjectsServer\")\n")
 	sb.WriteString("  (global-name \"com.apple.fonts\")\n")
 	sb.WriteString("  (global-name \"com.apple.logd\")\n")

--- a/sandbox/platform/seatbelt_translator_darwin_test.go
+++ b/sandbox/platform/seatbelt_translator_darwin_test.go
@@ -57,6 +57,16 @@ func TestSeatbeltTranslatorDarwinCommonTranslation(t *testing.T) {
 	assert.Contains(t, actual, "(allow process-fork)")
 }
 
+func TestSeatbeltTranslatorDarwinAlwaysAllowsFSEventsMachLookup(t *testing.T) {
+	policy := &sandbox.SandboxPolicy{}
+
+	translator := newSeatbeltPolicyTranslator()
+	actual, err := translator.translate(policy)
+	assert.NoError(t, err)
+
+	assert.Contains(t, actual, `(global-name "com.apple.FSEvents")`)
+}
+
 func TestSeatbeltTranslatorDarwinFilesystemTranslation(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/sandbox/platform/seatbelt_translator_darwin_test.go
+++ b/sandbox/platform/seatbelt_translator_darwin_test.go
@@ -62,7 +62,7 @@ func TestSeatbeltTranslatorDarwinAlwaysAllowsFSEventsMachLookup(t *testing.T) {
 
 	translator := newSeatbeltPolicyTranslator()
 	actual, err := translator.translate(policy)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, actual, `(global-name "com.apple.FSEvents")`)
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/safedep/pmg/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->