### PR TITLE
fix: PMG use pre-resolved binary path

### DIFF
--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -17,6 +17,7 @@ const shimMarker = "PMG shims"
 type ShimConfig struct {
 	BinDir          string
 	HomeDir         string
+	PMGBin          string
 	PackageManagers []string
 	Shells          []alias.Shell
 }
@@ -36,15 +37,29 @@ func NewDefaultShimManager() (*ShimManager, error) {
 	}
 
 	aliasCfg := alias.DefaultConfig()
+	pmgBin, err := currentExecutable()
+	if err != nil {
+		return nil, err
+	}
+
 	return &ShimManager{config: ShimConfig{
 		BinDir:          filepath.Join(homeDir, ".pmg", "bin"),
 		HomeDir:         homeDir,
+		PMGBin:          pmgBin,
 		PackageManagers: aliasCfg.PackageManagers,
 		Shells:          aliasCfg.Shells,
 	}}, nil
 }
 
 func (m *ShimManager) Install() error {
+	if m.config.PMGBin == "" {
+		pmgBin, err := currentExecutable()
+		if err != nil {
+			return err
+		}
+		m.config.PMGBin = pmgBin
+	}
+
 	if err := os.MkdirAll(m.config.BinDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create shim directory %s: %w", m.config.BinDir, err)
 	}
@@ -101,20 +116,38 @@ func (m *ShimManager) GetBinDir() string {
 
 func (m *ShimManager) writeShimScript(pm string) error {
 	shimPath := filepath.Join(m.config.BinDir, pm)
+	pmgBin := shellQuote(m.config.PMGBin)
 
 	content := fmt.Sprintf(`#!/bin/sh
 # PMG shim - do not edit, managed by pmg setup
-PMG_BIN="$(command -v pmg 2>/dev/null)"
-if [ -n "$PMG_BIN" ]; then
-  exec pmg %s "$@"
+PMG_BIN=%s
+if [ ! -x "$PMG_BIN" ]; then
+  echo "[pmg] error: PMG binary not found or not executable: $PMG_BIN" >&2
+  echo "[pmg] error: run 'pmg setup install' again or remove shims with 'pmg setup remove'" >&2
+  exit 127
 fi
-echo "[pmg] warning: pmg not found, falling back to native %s" >&2
-PATH="$(echo "$PATH" | tr ':' '\n' | grep -vF "/.pmg/bin" | tr '\n' ':' | sed 's/:$//')"
-export PATH
-exec %s "$@"
-`, pm, pm, pm)
+exec "$PMG_BIN" %s "$@"
+`, pmgBin, pm)
 
 	return os.WriteFile(shimPath, []byte(content), 0o755)
+}
+
+func currentExecutable() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve pmg executable: %w", err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return filepath.Abs(exe)
+	}
+
+	return resolved, nil
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func (m *ShimManager) addPathToShells() error {

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -25,6 +25,7 @@ func TestShimManagerInstall(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(fishConfig, "config.fish"), []byte("# existing fish config\n"), 0o644))
 
 	pms := []string{"npm", "pip"}
+	pmgBin := filepath.Join(homeDir, "bin", "pmg")
 	shells := []alias.Shell{
 		&stubShell{name: "bash", path: ".bashrc", useFish: false},
 		&stubShell{name: "fish", path: ".config/fish/config.fish", useFish: true},
@@ -33,6 +34,7 @@ func TestShimManagerInstall(t *testing.T) {
 	mgr := NewShimManager(ShimConfig{
 		BinDir:          binDir,
 		HomeDir:         homeDir,
+		PMGBin:          pmgBin,
 		PackageManagers: pms,
 		Shells:          shells,
 	})
@@ -48,7 +50,11 @@ func TestShimManagerInstall(t *testing.T) {
 		content, err := os.ReadFile(shimPath)
 		require.NoError(t, err)
 		assert.Contains(t, string(content), "#!/bin/sh")
-		assert.Contains(t, string(content), "exec pmg "+pm)
+		assert.Contains(t, string(content), "PMG_BIN='"+pmgBin+"'")
+		assert.Contains(t, string(content), `exec "$PMG_BIN" `+pm+` "$@"`)
+		assert.NotContains(t, string(content), "command -v pmg")
+		assert.NotContains(t, string(content), "exec pmg")
+		assert.NotContains(t, string(content), "falling back to native")
 	}
 
 	bashContent, err := os.ReadFile(bashrc)
@@ -145,10 +151,32 @@ func TestNewDefaultShimManager(t *testing.T) {
 
 	assert.NotEmpty(t, mgr.GetBinDir())
 	assert.Contains(t, mgr.GetBinDir(), ".pmg/bin")
+	assert.NotEmpty(t, mgr.config.PMGBin)
+	assert.True(t, filepath.IsAbs(mgr.config.PMGBin))
 	assert.NotEmpty(t, mgr.config.PackageManagers)
 	assert.Contains(t, mgr.config.PackageManagers, "npm")
 	assert.Contains(t, mgr.config.PackageManagers, "pip")
 	assert.NotEmpty(t, mgr.config.Shells)
+}
+
+func TestShimManagerInstallEscapesPMGBin(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, ".pmg", "bin")
+	pmgBin := filepath.Join(homeDir, "PMG's bin", "pmg")
+
+	mgr := NewShimManager(ShimConfig{
+		BinDir:          binDir,
+		HomeDir:         homeDir,
+		PMGBin:          pmgBin,
+		PackageManagers: []string{"npm"},
+	})
+
+	require.NoError(t, mgr.Install())
+
+	content, err := os.ReadFile(filepath.Join(binDir, "npm"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `PMG_BIN='`+homeDir+`/PMG'\''s bin/pmg'`)
+	assert.NotContains(t, string(content), "command -v pmg")
 }
 
 type stubShell struct {


### PR DESCRIPTION
This PR pre-resolves PMG path and set it during shim script generation. This is to avoid shim code from resolving PMG path because the PATH order may be modified by package managers or other callers. This makes sense because if PMG is removed, shims should fail securely with proper error message, instead of fail opening.