### PR TITLE
fix: filter pmg shim directory from child process environment

### DIFF
--- a/internal/runner/execute.go
+++ b/internal/runner/execute.go
@@ -33,6 +33,7 @@ func Execute(ctx context.Context, pc *packagemanager.ParsedCommand, pmName strin
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = shim.FilterPMGFromEnv(os.Environ())
 
 	result, err := executor.ApplySandbox(ctx, cmd, pmName)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `runner.Execute` was not filtering `~/.pmg/bin` from the environment passed to child processes, causing two bugs:
  - Sandboxed commands (bubblewrap) inherited unfiltered PATH → child processes resolved to shim instead of real binary → "file not found" errors
  - Direct `pmg npm ...` invocations spawned subprocesses that find the shim in PATH → infinite recursion (shim → pmg → shim → pmg) until OS thread limit hit
- The proxy flow already filtered via `FilterPMGFromEnv`; this applies the same filtering to the non-proxy execute path