### PR TITLE
feat(install): add support for clean installation

### DIFF
--- a/.github/workflows/pmg-e2e.yml
+++ b/.github/workflows/pmg-e2e.yml
@@ -265,6 +265,15 @@ jobs:
           test -f bun.lock
           test -d node_modules/express
           test -d node_modules/lodash
+
+          echo "Testing Bun frozen manifest installation with bun ci..."
+          rm -rf node_modules
+          pmg --proxy-mode=false bun ci
+
+          # Verification: bun lockfile and modules exist after frozen manifest install
+          test -f bun.lock
+          test -d node_modules/express
+          test -d node_modules/lodash
           cd .. && rm -rf bun-test
 
       - name: Test Yarn - Single Package & Manifest

--- a/packagemanager/npm.go
+++ b/packagemanager/npm.go
@@ -48,7 +48,7 @@ func DefaultPnpmPackageManagerConfig() NpmPackageManagerConfig {
 
 func DefaultBunPackageManagerConfig() NpmPackageManagerConfig {
 	return NpmPackageManagerConfig{
-		InstallCommands: []string{"install", "i", "add"},
+		InstallCommands: []string{"install", "i", "add", "ci"},
 		NonDownloadCommands: []string{
 			// Removal
 			"remove", "rm",

--- a/packagemanager/npm_test.go
+++ b/packagemanager/npm_test.go
@@ -414,6 +414,26 @@ func TestBunParseCommand(t *testing.T) {
 			},
 		},
 		{
+			name:    "manifest installation with short form",
+			command: "bun i",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, true, parsedCommand.IsManifestInstall)
+				assert.Equal(t, 0, len(parsedCommand.InstallTargets))
+				assert.True(t, parsedCommand.IsInstallationCommand())
+			},
+		},
+		{
+			name:    "manifest installation with ci",
+			command: "bun ci",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, true, parsedCommand.IsManifestInstall)
+				assert.Equal(t, 0, len(parsedCommand.InstallTargets))
+				assert.True(t, parsedCommand.IsInstallationCommand())
+			},
+		},
+		{
 			name:    "multiple package installations",
 			command: "bun add @types/node @types/react",
 			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
@@ -474,6 +494,13 @@ func TestNpmProxyBehavior(t *testing.T) {
 			command:               "bun update",
 			isKnownNonDownloadCmd: false,
 			isInstallationCommand: false,
+		},
+		{
+			name:                  "bun ci — manifest install",
+			pm:                    func() (*npmPackageManager, error) { return NewNpmPackageManager(DefaultBunPackageManagerConfig()) },
+			command:               "bun ci",
+			isKnownNonDownloadCmd: false,
+			isInstallationCommand: true,
 		},
 		{
 			name:                  "npm exec — proxy runs (may download and run package)",


### PR DESCRIPTION
## Summary
- Adds Bun `ci` as a recognized install command so PMG treats it as a manifest-based installation.
- Adds test coverage for `bun i` and `bun ci` parsing behavior.
- Extends the Bun e2e workflow to keep the existing `bun install` path and also verify `bun ci`.
## Changes
| File | Change |
|------|--------|
| `packagemanager/npm.go` | Adds `ci` to Bun install commands |
| `packagemanager/npm_test.go` | Covers `bun i`, `bun ci`, and proxy behavior for Bun clean installs |
| `.github/workflows/pmg-e2e.yml` | Adds Bun `ci` e2e validation without removing the existing `bun install` check |
## Commands executed for verification
- [x] `make test`