### PR TITLE
Title: ci: fix scorecard check by pinning codeql-action to a commit SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -65,6 +65,6 @@ jobs:
           go build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -60,6 +60,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION


### Description

Fixes: #288 

What does this PR do?
Updates .github/workflows/codeql.yml and .github/workflows/scorecard.yml to pin the github/codeql-action to the commit SHA 7211b7c8077ea37d8641b6271f6a365a22a5fbfa (which is the latest commit for the v4 tag and runs on Node 24).

Verification Link: Reviewers can verify the commit SHA here: [github/codeql-action@7211b7c](https://github.com/github/codeql-action/commit/7211b7c8077ea37d8641b6271f6a365a22a5fbfa)

Why does this fix the issue?
Previously, the action was pinned to an annotated tag SHA.

The OSSF Scorecard action performs a strict security audit with a Pinned-Dependencies check. This check mandates that all GitHub actions must be pinned to immutable commit SHAs because Git tags can be moved or deleted, making them vulnerable to supply-chain attacks.

Because the previous SHA resolved to a tag object rather than a commit object via the GitHub API, Scorecard flagged it as a vulnerability and failed the CI run. By updating the reference to the actual underlying commit SHA, this PR satisfies Scorecard's security requirement and fixes the failing check.