### PR TITLE
Update comparison in README capabilities table

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ PMG is the only free, open-source, install-time package firewall that covers dev
 | Capability                              | PMG | Socket  | Snyk | Dependabot |
 | --------------------------------------- | --- | ------- | ---- | ---------- |
 | OSS / built in public                   | ✓   | ✗       | ✗    | ✗          |
-| No account or API key                   | ✓   | ✗       | ✗    | ✗          |
+| No account or API key                   | ✓   | ✓       | ✗    | ✗          |
 | Install-time malicious package blocking | ✓   | ✓       | ✗    | ✗          |
 | Dependency cooldown policy              | ✓   | ✗       | ✗    | ✗          |
 | Runtime sandboxing                         | ✓   | ✗       | ✗    | ✗          |


### PR DESCRIPTION
## Summary
Updated the README comparison table to reflect that Socket, like PMG, does not require an account or API key for its core functionality.

## Changes
- Updated the "No account or API key" row in the capabilities comparison table to mark Socket (✓) as supporting this feature, matching PMG's capability

## Details
This change corrects the feature comparison between PMG and Socket in the README documentation. Socket's package security analysis can be performed without requiring users to create an account or provide API credentials, which aligns it with PMG's approach to accessibility and ease of use.

https://claude.ai/code/session_012z9PAJfSF3KHcePGoKSnBk