### PR TITLE
fix: avoid resolving symlinks in shim PMG binary path

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -26,8 +26,8 @@ func ProtectionTestCases() []ProtectionTestCase {
 		},
 		{
 			PackageManager: "pip",
-			Package:        "safedep-test-pkg==0.1.4",
-			InstallArgs:    []string{"pip", "install", "--no-cache-dir", "safedep-test-pkg==0.1.4"},
+			Package:        "safedep-test-pkg==0.0.4",
+			InstallArgs:    []string{"pip", "install", "--no-cache-dir", "safedep-test-pkg==0.0.4"},
 			NeedsVenv:      true,
 		},
 	}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -136,12 +136,7 @@ func currentExecutable() (string, error) {
 		return "", fmt.Errorf("failed to resolve pmg executable: %w", err)
 	}
 
-	resolved, err := filepath.EvalSymlinks(exe)
-	if err != nil {
-		return filepath.Abs(exe)
-	}
-
-	return resolved, nil
+	return filepath.Abs(exe)
 }
 
 func shellQuote(value string) string {


### PR DESCRIPTION
## Summary

- Shims hardcoded the resolved Homebrew Cellar path (e.g. `/opt/homebrew/Cellar/pmg/0.16.0/bin/pmg`) instead of the stable symlink (`/opt/homebrew/bin/pmg`), causing all shims to break after `brew upgrade`
- Removed `filepath.EvalSymlinks()` in `currentExecutable()` so the stable symlink path is preserved in shim scripts

Fixes #302