### PR TITLE
Fail closed for dynamic Guard Mode downloads

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,6 +192,9 @@ type RuntimeConfig struct {
 	// InsecureInstallation allows bypassing install blocking on malicious packages
 	InsecureInstallation bool
 
+	// AllowUnsafeDownload allows bypassing the safety gate for download-capable commands without targets under Guard Mode.
+	AllowUnsafeDownload bool
+
 	// SandboxProfileOverride is a runtime override for the sandbox policy profile.
 	// When set, this profile path is used instead of the configured policy for all package managers.
 	// This is a CLI-only flag (--sandbox-profile) and is not persisted to config.yml.
@@ -317,6 +320,7 @@ type SandboxAllowOverride struct {
 func DefaultConfig() RuntimeConfig {
 	// Backward compatibility for the insecure installation flag before config was introduced.
 	insecureInstallation := utils.EnvBool(pmgInsecureInstallationEnvKey, false)
+	allowUnsafeDownload := utils.EnvBool("PMG_ALLOW_UNSAFE_DOWNLOAD", false)
 
 	return RuntimeConfig{
 		Config: Config{
@@ -354,6 +358,7 @@ func DefaultConfig() RuntimeConfig {
 		},
 		DryRun:               false,
 		InsecureInstallation: insecureInstallation,
+		AllowUnsafeDownload:  allowUnsafeDownload,
 	}
 }
 
@@ -431,6 +436,7 @@ func initConfig() {
 	// PMG_INSECURE_INSTALLATION malicious-package block bypass.
 	if globalConfig.IsLocked() {
 		globalConfig.InsecureInstallation = false
+		globalConfig.AllowUnsafeDownload = false
 	}
 
 	loadConfig()

--- a/config/managed_config_test.go
+++ b/config/managed_config_test.go
@@ -188,3 +188,38 @@ func TestRemoveUserConfigFileNeverTouchesGlobal(t *testing.T) {
 	assert.NoFileExists(t, userFile, "per-user file should be removed")
 	assert.FileExists(t, globalFile, "globally managed file must be left intact")
 }
+
+func TestAllowUnsafeDownloadEnvIgnoredWhenLocked(t *testing.T) {
+	globalDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("global_lockdown: true\n"), 0o644))
+
+	useManagedConfigDir(t, globalDir)
+	t.Setenv("PMG_ALLOW_UNSAFE_DOWNLOAD", "true")
+	initConfig()
+
+	require.True(t, Get().IsLocked())
+	assert.False(t, Get().AllowUnsafeDownload, "PMG_ALLOW_UNSAFE_DOWNLOAD must not bypass a locked config")
+}
+
+func TestAllowUnsafeDownloadEnvHonoredWhenManagedNotLocked(t *testing.T) {
+	globalDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("paranoid: true\n"), 0o644))
+
+	useManagedConfigDir(t, globalDir)
+	t.Setenv("PMG_ALLOW_UNSAFE_DOWNLOAD", "true")
+	initConfig()
+
+	require.True(t, Get().IsManaged())
+	require.False(t, Get().IsLocked())
+	assert.True(t, Get().AllowUnsafeDownload, "without lockdown, PMG_ALLOW_UNSAFE_DOWNLOAD is honored")
+}
+
+func TestAllowUnsafeDownloadEnvHonoredWhenNotManaged(t *testing.T) {
+	useManagedConfigDir(t, t.TempDir()) // empty global dir -> not managed
+	t.Setenv("PMG_CONFIG_DIR", t.TempDir())
+	t.Setenv("PMG_ALLOW_UNSAFE_DOWNLOAD", "true")
+	initConfig()
+
+	require.False(t, Get().IsManaged())
+	assert.True(t, Get().AllowUnsafeDownload)
+}

--- a/guard/guard.go
+++ b/guard/guard.go
@@ -50,6 +50,10 @@ type PackageManagerGuardInteraction struct {
 	// inputReader is the reader to use for user input during confirmations.
 	// If nil, os.Stdin is used. This is set via SetInput to allow PTY input routing.
 	inputReader io.Reader
+
+	// outputWriter is the writer to use for user-visible prompts and notices.
+	// If nil, os.Stderr is used.
+	outputWriter io.Writer
 }
 
 // SetInput sets the input reader for user confirmations.
@@ -58,12 +62,25 @@ func (i *PackageManagerGuardInteraction) SetInput(r io.Reader) {
 	i.inputReader = r
 }
 
+// SetOutput sets the output writer for user prompts and notices.
+func (i *PackageManagerGuardInteraction) SetOutput(w io.Writer) {
+	i.outputWriter = w
+}
+
 // Reader returns the configured input reader, or os.Stdin if none is set.
 func (i *PackageManagerGuardInteraction) Reader() io.Reader {
 	if i.inputReader != nil {
 		return i.inputReader
 	}
 	return os.Stdin
+}
+
+// Writer returns the configured output writer, or os.Stderr if none is set.
+func (i *PackageManagerGuardInteraction) Writer() io.Writer {
+	if i.outputWriter != nil {
+		return i.outputWriter
+	}
+	return os.Stderr
 }
 
 type PackageManagerGuardConfig struct {
@@ -600,20 +617,24 @@ func (g *packageManagerGuard) checkUnsafeDownloadOptIn(pc *packagemanager.Parsed
 	}
 
 	if isTerminal {
-		fmt.Fprintf(os.Stderr, "\nDo you want to continue execution anyway (risky)? (y/N): ")
+		fmt.Fprintf(g.interaction.Writer(), "\nDo you want to continue execution anyway (risky)? (y/N): ")
 		reader := bufio.NewReader(g.interaction.Reader())
 		response, err := reader.ReadString('\n')
 		if err != nil {
 			return false, nil
 		}
 		response = strings.ToLower(strings.TrimSpace(response))
-		if response == "y" || response == "yes" || (len(response) > 0 && response[0] == 'y') {
+		if isExplicitUnsafeDownloadOptIn(response) {
 			g.showWarning(fmt.Sprintf("PMG: User explicitly opted in to run download-capable command: %s", cmdStr))
 			return true, nil
 		}
 	} else {
-		fmt.Fprintln(os.Stderr, "\nError: PMG is running without an interactive terminal and cannot prompt for opt-in.")
+		g.showWarning("Running without an interactive terminal and unable to prompt for explicit opt-in.")
 	}
 
 	return false, nil
+}
+
+func isExplicitUnsafeDownloadOptIn(response string) bool {
+	return response == "y" || response == "yes"
 }

--- a/guard/guard.go
+++ b/guard/guard.go
@@ -1,22 +1,27 @@
 package guard
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/safedep/dry/log"
+	"github.com/safedep/dry/usefulerror"
 	"github.com/safedep/pmg/analyzer"
 	"github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/errcodes"
 	"github.com/safedep/pmg/extractor"
 	"github.com/safedep/pmg/internal/audit"
 	"github.com/safedep/pmg/internal/ui"
 	"github.com/safedep/pmg/packagemanager"
+	"golang.org/x/term"
 )
 
 // CommandExecutor executes a parsed package manager command directly.
@@ -67,6 +72,8 @@ type PackageManagerGuardConfig struct {
 	AnalysisTimeout       time.Duration
 	DryRun                bool
 	InsecureInstallation  bool
+	AllowUnsafeDownload   bool
+	IsConfigLocked        bool
 }
 
 func DefaultPackageManagerGuardConfig() PackageManagerGuardConfig {
@@ -76,6 +83,8 @@ func DefaultPackageManagerGuardConfig() PackageManagerGuardConfig {
 		AnalysisTimeout:       5 * time.Minute,
 		DryRun:                false,
 		InsecureInstallation:  false,
+		AllowUnsafeDownload:   false,
+		IsConfigLocked:        false,
 	}
 }
 
@@ -130,7 +139,7 @@ func (g *packageManagerGuard) Run(ctx context.Context, args []string, parsedComm
 		audit.LogInstallStarted(g.packageManager.Name(), args)
 	}
 
-	if g.config.InsecureInstallation {
+	if g.config.InsecureInstallation && !g.config.IsConfigLocked {
 		log.Debugf("Bypassing block for unconfirmed malicious packages due to PMG_INSECURE_INSTALLATION")
 		g.showWarning("INSECURE INSTALLATION MODE - Malware protection bypassed!")
 		return result, g.continueExecution(ctx, parsedCommand)
@@ -141,6 +150,12 @@ func (g *packageManagerGuard) Run(ctx context.Context, args []string, parsedComm
 		if parsedCommand.ShouldExtractFromManifest() {
 			log.Debugf("Detected manifest-based installation, extracting packages from manifest files")
 			return g.handleManifestInstallation(ctx, parsedCommand)
+		}
+
+		if parsedCommand.MayDownloadPackages() {
+			if err := g.requireUnsafeDownloadOptIn(parsedCommand); err != nil {
+				return result, err
+			}
 		}
 
 		log.Debugf("No install target found, continuing execution")
@@ -260,6 +275,42 @@ func (g *packageManagerGuard) Run(ctx context.Context, args []string, parsedComm
 
 func (g *packageManagerGuard) continueExecution(ctx context.Context, pc *packagemanager.ParsedCommand) error {
 	return g.executor(ctx, pc)
+}
+
+func (g *packageManagerGuard) requireUnsafeDownloadOptIn(pc *packagemanager.ParsedCommand) error {
+	optedIn, err := g.checkUnsafeDownloadOptIn(pc)
+	if err != nil {
+		return err
+	}
+
+	if optedIn {
+		return nil
+	}
+
+	return g.unsafeDownloadError(pc)
+}
+
+func (g *packageManagerGuard) unsafeDownloadError(pc *packagemanager.ParsedCommand) error {
+	cmdStr := commandString(pc)
+	helpMsg := "Enable Proxy Mode for runtime verification, or set the environment variable PMG_ALLOW_UNSAFE_DOWNLOAD=true to bypass this safety gate if allowed by policy."
+	if g.config.IsConfigLocked {
+		helpMsg = "Enable Proxy Mode for runtime verification. This command is blocked by the locked global configuration."
+	}
+
+	return usefulerror.NewUsefulError().
+		WithCode(errcodes.PermissionDenied).
+		WithHumanError(fmt.Sprintf("Blocked execution of download-capable command '%s' due to lack of explicit opt-in under Guard Mode", cmdStr)).
+		WithHelp(helpMsg).
+		WithMsg(fmt.Sprintf("Blocked execution of download-capable command '%s' due to lack of explicit opt-in under Guard Mode", cmdStr))
+}
+
+func commandString(pc *packagemanager.ParsedCommand) string {
+	cmdStr := pc.Command.Exe
+	if len(pc.Command.Args) > 0 {
+		cmdStr += " " + strings.Join(pc.Command.Args, " ")
+	}
+
+	return cmdStr
 }
 
 func (g *packageManagerGuard) concurrentAnalyzePackages(ctx context.Context,
@@ -384,7 +435,13 @@ func (g *packageManagerGuard) handleManifestInstallation(ctx context.Context, pa
 	blockConfig := ui.NewDefaultBlockConfig()
 
 	if len(packages) == 0 {
-		log.Debugf("No packages found in manifest files, continuing execution")
+		if parsedCommand.MayDownloadPackages() {
+			if err := g.requireUnsafeDownloadOptIn(parsedCommand); err != nil {
+				return result, err
+			}
+		}
+
+		log.Debugf("No packages found in manifest files after opt-in check, continuing execution")
 		return result, g.continueExecution(ctx, parsedCommand)
 	}
 
@@ -508,4 +565,55 @@ func (g *packageManagerGuard) logMalwareDetection(result *analyzer.PackageVersio
 	} else {
 		audit.LogMalwareConfirmed(result.PackageVersion, result.AnalysisID, result.IsMalware, result.IsVerified)
 	}
+}
+
+func (g *packageManagerGuard) checkUnsafeDownloadOptIn(pc *packagemanager.ParsedCommand) (bool, error) {
+	if g.config.IsConfigLocked {
+		return false, nil
+	}
+
+	if g.config.InsecureInstallation {
+		log.Debugf("Bypassing safety gate for download-capable command due to PMG_INSECURE_INSTALLATION")
+		return true, nil
+	}
+
+	cmdStr := commandString(pc)
+
+	if g.config.AllowUnsafeDownload {
+		g.showWarning(fmt.Sprintf("PMG: Bypassing safety gate for download-capable command '%s' via PMG_ALLOW_UNSAFE_DOWNLOAD environment variable", cmdStr))
+		return true, nil
+	}
+
+	warnMsg := fmt.Sprintf("\n"+
+		"PMG WARNING: Download-capable command requires opt-in under Guard Mode\n"+
+		"Command: %s\n\n"+
+		"This command is download-capable and may fetch unanalyzed packages from the registry.\n"+
+		"Since PMG Guard Mode is active (and Proxy Mode is disabled), PMG cannot intercept\n"+
+		"or statically analyze these dynamic downloads at runtime.\n\n"+
+		"Enable Proxy Mode for runtime verification.", cmdStr)
+
+	g.showWarning(warnMsg)
+
+	isTerminal := false
+	if f, ok := g.interaction.Reader().(*os.File); ok {
+		isTerminal = term.IsTerminal(int(f.Fd()))
+	}
+
+	if isTerminal {
+		fmt.Fprintf(os.Stderr, "\nDo you want to continue execution anyway (risky)? (y/N): ")
+		reader := bufio.NewReader(g.interaction.Reader())
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			return false, nil
+		}
+		response = strings.ToLower(strings.TrimSpace(response))
+		if response == "y" || response == "yes" || (len(response) > 0 && response[0] == 'y') {
+			g.showWarning(fmt.Sprintf("PMG: User explicitly opted in to run download-capable command: %s", cmdStr))
+			return true, nil
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "\nError: PMG is running without an interactive terminal and cannot prompt for opt-in.")
+	}
+
+	return false, nil
 }

--- a/guard/guard_test.go
+++ b/guard/guard_test.go
@@ -433,4 +433,56 @@ func TestGuardUnsafeDownloadOptIn(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("allows harmless npm commands without requiring unsafe download opt-in", func(t *testing.T) {
+		pm, err := packagemanager.NewNpmPackageManager(packagemanager.DefaultNpmPackageManagerConfig())
+		require.NoError(t, err)
+
+		for _, command := range []string{
+			"npm",
+			"npm --version",
+			"npm -l",
+			"npm pack",
+		} {
+			t.Run(command, func(t *testing.T) {
+				parsedCommand, err := pm.ParseCommand(strings.Split(command, " "))
+				require.NoError(t, err)
+				require.True(t, parsedCommand.IsKnownNonDownloadCommand)
+				require.False(t, parsedCommand.MayDownloadPackages())
+
+				pg := newGuard(t, baseConfig(), nil)
+				_, err = pg.Run(context.Background(), commandArgs(parsedCommand), parsedCommand)
+
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("shows non-interactive opt-in notice through warning callback", func(t *testing.T) {
+		var warnings []string
+		interaction := PackageManagerGuardInteraction{
+			ShowWarning: func(message string) {
+				warnings = append(warnings, message)
+			},
+		}
+		interaction.SetInput(strings.NewReader(""))
+
+		pg, err := NewPackageManagerGuard(baseConfig(), nil, nil, analyzers, interaction, noopExecutor)
+		require.NoError(t, err)
+
+		parsedCommand := noTargetCommand("npm", "ci")
+		_, err = pg.Run(context.Background(), commandArgs(parsedCommand), parsedCommand)
+
+		require.Error(t, err)
+		require.Len(t, warnings, 2)
+		assert.Contains(t, warnings[1], "unable to prompt for explicit opt-in")
+	})
+}
+
+func TestIsExplicitUnsafeDownloadOptIn(t *testing.T) {
+	assert.True(t, isExplicitUnsafeDownloadOptIn("y"))
+	assert.True(t, isExplicitUnsafeDownloadOptIn("yes"))
+	assert.False(t, isExplicitUnsafeDownloadOptIn("yikes"))
+	assert.False(t, isExplicitUnsafeDownloadOptIn("yolo"))
+	assert.False(t, isExplicitUnsafeDownloadOptIn("n"))
 }

--- a/guard/guard_test.go
+++ b/guard/guard_test.go
@@ -2,6 +2,7 @@ package guard
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
@@ -9,12 +10,30 @@ import (
 	"github.com/safedep/pmg/internal/ui"
 	"github.com/safedep/pmg/packagemanager"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // noopExecutor is a no-op executor for use in tests that set DryRun=true
 // or otherwise don't reach actual command execution.
 var noopExecutor CommandExecutor = func(_ context.Context, _ *packagemanager.ParsedCommand) error {
 	return nil
+}
+
+type testPackageManager struct {
+	name      string
+	ecosystem packagev1.Ecosystem
+}
+
+func (pm testPackageManager) Name() string {
+	return pm.name
+}
+
+func (pm testPackageManager) ParseCommand(_ []string) (*packagemanager.ParsedCommand, error) {
+	return nil, nil
+}
+
+func (pm testPackageManager) Ecosystem() packagev1.Ecosystem {
+	return pm.ecosystem
 }
 
 func TestGuardConcurrentlyAnalyzePackagesMalwareQueryService(t *testing.T) {
@@ -261,5 +280,157 @@ func TestGuardInsecureInstallation(t *testing.T) {
 
 		// Verify that InsecureInstallation defaults to false
 		assert.False(t, config.InsecureInstallation, "InsecureInstallation should default to false")
+	})
+}
+
+func TestGuardUnsafeDownloadOptIn(t *testing.T) {
+	mq, err := analyzer.NewMalysisQueryAnalyzer(analyzer.MalysisQueryAnalyzerConfig{})
+	require.NoError(t, err)
+
+	analyzers := []analyzer.PackageVersionAnalyzer{mq}
+	baseConfig := func() PackageManagerGuardConfig {
+		config := DefaultPackageManagerGuardConfig()
+		config.DryRun = true
+		config.ResolveDependencies = false
+		return config
+	}
+
+	newGuard := func(t *testing.T, config PackageManagerGuardConfig, pm packagemanager.PackageManager) *packageManagerGuard {
+		t.Helper()
+		pg, err := NewPackageManagerGuard(config, pm, nil, analyzers, PackageManagerGuardInteraction{
+			ShowWarning: func(message string) {},
+		}, noopExecutor)
+		require.NoError(t, err)
+		return pg
+	}
+
+	commandArgs := func(pc *packagemanager.ParsedCommand) []string {
+		return append([]string{pc.Command.Exe}, pc.Command.Args...)
+	}
+
+	noTargetCommand := func(exe string, args ...string) *packagemanager.ParsedCommand {
+		return &packagemanager.ParsedCommand{
+			Command: packagemanager.Command{
+				Exe:  exe,
+				Args: args,
+			},
+			InstallTargets:            []*packagemanager.PackageInstallTarget{},
+			IsKnownNonDownloadCommand: false,
+		}
+	}
+
+	manifestNoPackageCommand := &packagemanager.ParsedCommand{
+		Command: packagemanager.Command{
+			Exe:  "npm",
+			Args: []string{"install"},
+		},
+		InstallTargets:            []*packagemanager.PackageInstallTarget{},
+		IsManifestInstall:         true,
+		ManifestFiles:             []string{"pmg-test-missing-package-lock.json"},
+		IsKnownNonDownloadCommand: false,
+	}
+
+	cases := []struct {
+		name           string
+		configure      func(*PackageManagerGuardConfig)
+		packageManager packagemanager.PackageManager
+		parsedCommand  *packagemanager.ParsedCommand
+		wantErr        bool
+		wantLockedHelp bool
+	}{
+		{
+			name:          "fails closed for download-capable command without install targets and no opt-in",
+			parsedCommand: noTargetCommand("npm", "ci"),
+			wantErr:       true,
+		},
+		{
+			name: "bypasses safety check when AllowUnsafeDownload is enabled in config",
+			configure: func(config *PackageManagerGuardConfig) {
+				config.AllowUnsafeDownload = true
+			},
+			parsedCommand: noTargetCommand("npm", "ci"),
+			wantErr:       false,
+		},
+		{
+			name: "bypasses safety check when InsecureInstallation is enabled",
+			configure: func(config *PackageManagerGuardConfig) {
+				config.InsecureInstallation = true
+			},
+			parsedCommand: noTargetCommand("npm", "ci"),
+			wantErr:       false,
+		},
+		{
+			name: "fails closed and does not prompt when global config is locked",
+			configure: func(config *PackageManagerGuardConfig) {
+				config.IsConfigLocked = true
+			},
+			parsedCommand:  noTargetCommand("npm", "ci"),
+			wantErr:        true,
+			wantLockedHelp: true,
+		},
+		{
+			name: "keeps locked config authoritative over InsecureInstallation",
+			configure: func(config *PackageManagerGuardConfig) {
+				config.InsecureInstallation = true
+				config.IsConfigLocked = true
+			},
+			parsedCommand: noTargetCommand("npm", "ci"),
+			wantErr:       true,
+		},
+		{
+			name:           "applies opt-in gate when manifest extraction yields no packages",
+			packageManager: testPackageManager{name: "npm", ecosystem: packagev1.Ecosystem_ECOSYSTEM_NPM},
+			parsedCommand:  manifestNoPackageCommand,
+			wantErr:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := baseConfig()
+			if tc.configure != nil {
+				tc.configure(&config)
+			}
+
+			pg := newGuard(t, config, tc.packageManager)
+			_, err := pg.Run(context.Background(), commandArgs(tc.parsedCommand), tc.parsedCommand)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "Blocked execution of download-capable command")
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.wantLockedHelp {
+				uerr, ok := err.(interface{ Help() string })
+				require.True(t, ok)
+				assert.Contains(t, uerr.Help(), "blocked by the locked global configuration")
+			}
+		})
+	}
+
+	t.Run("fails closed for npm commands that can download without install targets", func(t *testing.T) {
+		pm, err := packagemanager.NewNpmPackageManager(packagemanager.DefaultNpmPackageManagerConfig())
+		require.NoError(t, err)
+
+		for _, command := range []string{
+			"npm pack react",
+			"npm cache add react",
+		} {
+			t.Run(command, func(t *testing.T) {
+				parsedCommand, err := pm.ParseCommand(strings.Split(command, " "))
+				require.NoError(t, err)
+				require.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				require.True(t, parsedCommand.MayDownloadPackages())
+				require.Empty(t, parsedCommand.InstallTargets)
+
+				pg := newGuard(t, baseConfig(), nil)
+				_, err = pg.Run(context.Background(), commandArgs(parsedCommand), parsedCommand)
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "Blocked execution of download-capable command")
+			})
+		}
 	})
 }

--- a/internal/flows/common_flow.go
+++ b/internal/flows/common_flow.go
@@ -77,6 +77,8 @@ func (f *commonFlow) Run(ctx context.Context, args []string, parsedCmd *packagem
 	guardConfig := guard.DefaultPackageManagerGuardConfig()
 	guardConfig.DryRun = cfg.DryRun
 	guardConfig.InsecureInstallation = cfg.InsecureInstallation
+	guardConfig.AllowUnsafeDownload = cfg.AllowUnsafeDownload
+	guardConfig.IsConfigLocked = cfg.IsLocked()
 
 	pmName := f.pm.Name()
 	executor := func(ctx context.Context, pc *packagemanager.ParsedCommand) error {

--- a/packagemanager/npm.go
+++ b/packagemanager/npm.go
@@ -25,7 +25,7 @@ func DefaultNpmPackageManagerConfig() NpmPackageManagerConfig {
 			// Removal — uninstalls local packages, no registry download
 			"uninstall", "remove", "rm", "r", "un", "unlink",
 			// Local operations — no registry contact
-			"rebuild", "prune", "link", "cache",
+			"rebuild", "prune", "link", "cache", "pack",
 			// Inspection / read-only registry queries
 			"ls", "list", "outdated", "view", "info", "show", "search",
 			"config", "ping", "whoami", "version", "help",
@@ -146,7 +146,8 @@ func (npm *npmPackageManager) ParseCommand(args []string) (*ParsedCommand, error
 		}
 
 		return &ParsedCommand{
-			Command: command,
+			Command:                   command,
+			IsKnownNonDownloadCommand: true,
 		}, nil
 	}
 
@@ -163,23 +164,13 @@ func (npm *npmPackageManager) ParseCommand(args []string) (*ParsedCommand, error
 		}
 
 		if !ambiguousCommand && (firstCommandArg == "exec" || firstCommandArg == "x" || firstCommandArg == "dlx") {
-			var cmdIndex = -1
-			for idx, arg := range args {
-				if arg == firstCommandArg {
-					cmdIndex = idx
-					break
-				}
-			}
-
-			if cmdIndex != -1 {
-				subArgs := args[cmdIndex+1:]
-				installTargets, err := parseFetchAndRunTargets(npm.Config.CommandName, firstCommandArg, subArgs)
-				if err == nil && len(installTargets) > 0 {
-					return &ParsedCommand{
-						Command:        command,
-						InstallTargets: installTargets,
-					}, nil
-				}
+			subArgs := args[commandArgIndex+1:]
+			installTargets, err := parseFetchAndRunTargets(npm.Config.CommandName, firstCommandArg, subArgs)
+			if err == nil && len(installTargets) > 0 {
+				return &ParsedCommand{
+					Command:        command,
+					InstallTargets: installTargets,
+				}, nil
 			}
 		}
 
@@ -389,8 +380,11 @@ func getFirstCommandArgIndex(args []string) (int, bool) {
 
 func isKnownNpmNonDownloadCommand(args []string, nonDownloadCommands []string) bool {
 	firstNonFlagIndex, ambiguousCommand := getFirstCommandArgIndex(args)
-	if firstNonFlagIndex == -1 || ambiguousCommand {
+	if ambiguousCommand {
 		return false
+	}
+	if firstNonFlagIndex == -1 {
+		return true
 	}
 
 	firstNonFlag := args[firstNonFlagIndex]
@@ -400,6 +394,15 @@ func isKnownNpmNonDownloadCommand(args []string, nonDownloadCommands []string) b
 			return false
 		}
 		if cacheCommandIndex != -1 && args[firstNonFlagIndex+1:][cacheCommandIndex] == "add" {
+			return false
+		}
+	}
+	if firstNonFlag == "pack" {
+		packArgIndex, ambiguousPackArgs := getFirstCommandArgIndex(args[firstNonFlagIndex+1:])
+		if ambiguousPackArgs {
+			return false
+		}
+		if packArgIndex != -1 {
 			return false
 		}
 	}

--- a/packagemanager/npm.go
+++ b/packagemanager/npm.go
@@ -25,7 +25,7 @@ func DefaultNpmPackageManagerConfig() NpmPackageManagerConfig {
 			// Removal — uninstalls local packages, no registry download
 			"uninstall", "remove", "rm", "r", "un", "unlink",
 			// Local operations — no registry contact
-			"rebuild", "prune", "link", "cache", "pack",
+			"rebuild", "prune", "link", "cache",
 			// Inspection / read-only registry queries
 			"ls", "list", "outdated", "view", "info", "show", "search",
 			"config", "ping", "whoami", "version", "help",
@@ -72,6 +72,45 @@ type npmPackageManager struct {
 	Config NpmPackageManagerConfig
 }
 
+// These flag sets are intentionally narrow. Known value flags are consumed so
+// command detection is stable; unknown leading flag/value pairs fail safe.
+var npmGlobalFlagsWithValues = map[string]struct{}{
+	"cache":        {},
+	"cafile":       {},
+	"cert":         {},
+	"globalconfig": {},
+	"https-proxy":  {},
+	"key":          {},
+	"loglevel":     {},
+	"location":     {},
+	"node-options": {},
+	"noproxy":      {},
+	"otp":          {},
+	"prefix":       {},
+	"proxy":        {},
+	"registry":     {},
+	"script-shell": {},
+	"tag":          {},
+	"user-agent":   {},
+	"userconfig":   {},
+	"workspace":    {},
+}
+
+var npmShortFlagsWithValues = map[byte]struct{}{
+	'C': {},
+	'L': {},
+	'c': {},
+	'm': {},
+	'w': {},
+}
+
+var npmShortBooleanFlags = map[byte]struct{}{
+	'f': {},
+	'g': {},
+	's': {},
+	'y': {},
+}
+
 func NewNpmPackageManager(config NpmPackageManagerConfig) (*npmPackageManager, error) {
 	return &npmPackageManager{
 		Config: config,
@@ -111,17 +150,40 @@ func (npm *npmPackageManager) ParseCommand(args []string) (*ParsedCommand, error
 		}, nil
 	}
 
-	// Find the install command position
-	var installCmdIndex = -1
-	for idx, arg := range args {
-		if slices.Contains(npm.Config.InstallCommands, arg) {
-			installCmdIndex = idx
-			break
-		}
+	commandArgIndex, ambiguousCommand := getFirstCommandArgIndex(args)
+	installCmdIndex := -1
+	if commandArgIndex != -1 && !ambiguousCommand && slices.Contains(npm.Config.InstallCommands, args[commandArgIndex]) {
+		installCmdIndex = commandArgIndex
 	}
 
 	if installCmdIndex == -1 {
-		return &ParsedCommand{Command: command, IsKnownNonDownloadCommand: IsFirstNonFlagArgInList(args, npm.Config.NonDownloadCommands)}, nil
+		firstCommandArg := ""
+		if commandArgIndex != -1 {
+			firstCommandArg = args[commandArgIndex]
+		}
+
+		if !ambiguousCommand && (firstCommandArg == "exec" || firstCommandArg == "x" || firstCommandArg == "dlx") {
+			var cmdIndex = -1
+			for idx, arg := range args {
+				if arg == firstCommandArg {
+					cmdIndex = idx
+					break
+				}
+			}
+
+			if cmdIndex != -1 {
+				subArgs := args[cmdIndex+1:]
+				installTargets, err := parseFetchAndRunTargets(npm.Config.CommandName, firstCommandArg, subArgs)
+				if err == nil && len(installTargets) > 0 {
+					return &ParsedCommand{
+						Command:        command,
+						InstallTargets: installTargets,
+					}, nil
+				}
+			}
+		}
+
+		return &ParsedCommand{Command: command, IsKnownNonDownloadCommand: isKnownNpmNonDownloadCommand(args, npm.Config.NonDownloadCommands)}, nil
 	}
 
 	// Extract arguments after the install command
@@ -253,4 +315,155 @@ func npmCleanVersion(version string) string {
 	}
 
 	return version
+}
+
+func getFirstNonFlagArg(args []string) string {
+	index, _ := getFirstCommandArgIndex(args)
+	if index == -1 {
+		return ""
+	}
+
+	return args[index]
+}
+
+func getFirstCommandArgIndex(args []string) (int, bool) {
+	ambiguous := false
+	for idx := 0; idx < len(args); idx++ {
+		arg := args[idx]
+		if arg == "--" {
+			if idx+1 < len(args) {
+				return idx + 1, ambiguous
+			}
+			return -1, ambiguous
+		}
+
+		if strings.HasPrefix(arg, "--") {
+			flagName := strings.TrimPrefix(arg, "--")
+			if strings.Contains(flagName, "=") {
+				continue
+			}
+			if _, ok := npmGlobalFlagsWithValues[flagName]; ok {
+				if idx+1 < len(args) {
+					idx++
+				}
+				continue
+			}
+			if idx+1 < len(args) && !strings.HasPrefix(args[idx+1], "-") {
+				ambiguous = true
+			}
+			continue
+		}
+
+		if strings.HasPrefix(arg, "-") {
+			flagName := strings.TrimPrefix(arg, "-")
+			if len(flagName) > 0 {
+				if _, ok := npmShortFlagsWithValues[flagName[0]]; ok && len(flagName) == 1 {
+					if idx+1 < len(args) {
+						idx++
+					}
+					continue
+				}
+
+				if _, ok := npmShortFlagsWithValues[flagName[0]]; ok {
+					continue
+				}
+
+				allBoolean := true
+				for flagIdx := 0; flagIdx < len(flagName); flagIdx++ {
+					if _, ok := npmShortBooleanFlags[flagName[flagIdx]]; !ok {
+						allBoolean = false
+						break
+					}
+				}
+
+				if !allBoolean && idx+1 < len(args) && !strings.HasPrefix(args[idx+1], "-") {
+					ambiguous = true
+				}
+			}
+			continue
+		}
+		return idx, ambiguous
+	}
+	return -1, ambiguous
+}
+
+func isKnownNpmNonDownloadCommand(args []string, nonDownloadCommands []string) bool {
+	firstNonFlagIndex, ambiguousCommand := getFirstCommandArgIndex(args)
+	if firstNonFlagIndex == -1 || ambiguousCommand {
+		return false
+	}
+
+	firstNonFlag := args[firstNonFlagIndex]
+	if firstNonFlag == "cache" {
+		cacheCommandIndex, ambiguousCacheCommand := getFirstCommandArgIndex(args[firstNonFlagIndex+1:])
+		if ambiguousCacheCommand {
+			return false
+		}
+		if cacheCommandIndex != -1 && args[firstNonFlagIndex+1:][cacheCommandIndex] == "add" {
+			return false
+		}
+	}
+
+	return slices.Contains(nonDownloadCommands, firstNonFlag)
+}
+
+func parseFetchAndRunTargets(cmdName string, subCmd string, args []string) ([]*PackageInstallTarget, error) {
+	flagSet := pflag.NewFlagSet(cmdName, pflag.ContinueOnError)
+	flagSet.SetOutput(io.Discard)
+	flagSet.ParseErrorsAllowlist.UnknownFlags = true
+
+	var packages []string
+	flagSet.StringArrayVarP(&packages, "package", "p", []string{}, "Package List")
+
+	err := flagSet.Parse(args)
+	if err != nil {
+		return nil, nil
+	}
+
+	if len(packages) == 0 {
+		for _, arg := range flagSet.Args() {
+			if strings.HasPrefix(arg, "@") && !slices.Contains(packages, arg) {
+				packages = append(packages, arg)
+			}
+		}
+	}
+
+	// Fall back to the first positional argument for non-ambiguous download runners
+	// like "dlx". Ambiguous runners ("exec", "x") are skipped to avoid false positive
+	// package resolution on local binaries.
+	if len(flagSet.Args()) > 0 && len(packages) == 0 {
+		if subCmd == "dlx" {
+			pkg := flagSet.Args()[0]
+			if !slices.Contains(packages, pkg) {
+				packages = append(packages, pkg)
+			}
+		}
+	}
+
+	var installTargets []*PackageInstallTarget
+	for _, pkg := range packages {
+		packageName, version, err := npmParsePackageInfo(pkg)
+		if err != nil {
+			return nil, ErrFailedToParsePackage.Wrap(err)
+		}
+
+		if version != "" {
+			version = npmCleanVersion(version)
+		}
+
+		installTarget := &PackageInstallTarget{
+			IsExplicitVersion: version != "",
+			PackageVersion: &packagev1.PackageVersion{
+				Package: &packagev1.Package{
+					Ecosystem: packagev1.Ecosystem_ECOSYSTEM_NPM,
+					Name:      packageName,
+				},
+				Version: version,
+			},
+		}
+
+		installTargets = append(installTargets, installTarget)
+	}
+
+	return installTargets, nil
 }

--- a/packagemanager/npm_test.go
+++ b/packagemanager/npm_test.go
@@ -101,6 +101,36 @@ func TestNpmParseCommand(t *testing.T) {
 			},
 		},
 		{
+			name:    "bare npm is a known non-download command",
+			command: "npm",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.True(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.False(t, parsedCommand.MayDownloadPackages())
+				assert.False(t, parsedCommand.IsInstallationCommand())
+			},
+		},
+		{
+			name:    "flags-only version command is a known non-download command",
+			command: "npm --version",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.True(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.False(t, parsedCommand.MayDownloadPackages())
+				assert.False(t, parsedCommand.IsInstallationCommand())
+			},
+		},
+		{
+			name:    "flags-only list command is a known non-download command",
+			command: "npm -l",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.True(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.False(t, parsedCommand.MayDownloadPackages())
+				assert.False(t, parsedCommand.IsInstallationCommand())
+			},
+		},
+		{
 			name:    "exec with package flag extracts target",
 			command: "npm exec --package typescript tsc",
 			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
@@ -147,6 +177,16 @@ func TestNpmParseCommand(t *testing.T) {
 				assert.Empty(t, parsedCommand.InstallTargets)
 				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
 				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "pack without package stays local and non-download",
+			command: "npm pack",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.True(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.False(t, parsedCommand.MayDownloadPackages())
 			},
 		},
 		{
@@ -226,6 +266,15 @@ func TestNpmParseCommand(t *testing.T) {
 				assert.Equal(t, "react", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
 				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
 				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "flag value matching dlx does not replace actual dlx target",
+			command: "npm --tag dlx dlx create-react-app",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "create-react-app", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
 			},
 		},
 		{

--- a/packagemanager/npm_test.go
+++ b/packagemanager/npm_test.go
@@ -101,6 +101,94 @@ func TestNpmParseCommand(t *testing.T) {
 			},
 		},
 		{
+			name:    "exec with package flag extracts target",
+			command: "npm exec --package typescript tsc",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "typescript", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+				assert.Empty(t, parsedCommand.InstallTargets[0].PackageVersion.Version)
+			},
+		},
+		{
+			name:    "exec with package flag does not add scoped command argument",
+			command: "npm exec --package typescript @scope/cli",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "typescript", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+			},
+		},
+		{
+			name:    "exec with unscoped positional target stays ambiguous",
+			command: "npm exec create-react-app",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "exec with scoped positional target extracts target",
+			command: "npm exec @scope/cli@1.2.3",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "@scope/cli", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+				assert.Equal(t, "1.2.3", parsedCommand.InstallTargets[0].PackageVersion.Version)
+			},
+		},
+		{
+			name:    "pack with package is download-capable",
+			command: "npm pack react",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "cache add is download-capable",
+			command: "npm cache add react",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "cache add after location flag is download-capable",
+			command: "npm cache --location global add react",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "cache command with ambiguous flag value fails safe",
+			command: "npm cache --future-flag global verify",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "cache verify is non-download",
+			command: "npm cache verify",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.True(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.False(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
 			name:    "ls is a known non-download command (proxy skipped)",
 			command: "npm ls",
 			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
@@ -127,6 +215,59 @@ func TestNpmParseCommand(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, 1, len(parsedCommand.InstallTargets))
 				assert.Equal(t, "@types/node", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+			},
+		},
+		{
+			name:    "global flag value does not hide install command",
+			command: "npm --cache config install react",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "react", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "short call flag value does not hide install command",
+			command: "npm -c config install react",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "react", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "short message flag value does not hide install command",
+			command: "npm -m config install react",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "react", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "unknown leading flag with value fails safe",
+			command: "npm --future-flag config install react",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
+		{
+			name:    "unknown leading short flag with value fails safe",
+			command: "npm -z config install react",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
 			},
 		},
 		{
@@ -300,6 +441,16 @@ func TestYarnParseCommand(t *testing.T) {
 				assert.Equal(t, []string{"npm", "login"}, parsedCommand.Command.Args)
 			},
 		},
+		{
+			name:    "dlx extracts positional target",
+			command: "yarn dlx create-vite@1.2.3",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				require.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "create-vite", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+				assert.Equal(t, "1.2.3", parsedCommand.InstallTargets[0].PackageVersion.Version)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -364,6 +515,34 @@ func TestPnpmParseCommand(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, 1, len(parsedCommand.InstallTargets))
 				assert.Equal(t, "@types/node", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+			},
+		},
+		{
+			name:    "dlx extracts positional target",
+			command: "pnpm dlx create-react-app",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				require.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "create-react-app", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+			},
+		},
+		{
+			name:    "exec with package flag extracts target",
+			command: "pnpm exec --package typescript tsc",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				require.NoError(t, err)
+				require.Len(t, parsedCommand.InstallTargets, 1)
+				assert.Equal(t, "typescript", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
+			},
+		},
+		{
+			name:    "exec with unscoped positional target stays ambiguous",
+			command: "pnpm exec tsc",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
 			},
 		},
 	}
@@ -452,6 +631,16 @@ func TestBunParseCommand(t *testing.T) {
 				assert.Equal(t, "@types/node", parsedCommand.InstallTargets[0].PackageVersion.Package.Name)
 			},
 		},
+		{
+			name:    "x with unscoped positional target stays ambiguous",
+			command: "bun x create-vite",
+			assert: func(t *testing.T, parsedCommand *ParsedCommand, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, parsedCommand.InstallTargets)
+				assert.False(t, parsedCommand.IsKnownNonDownloadCommand)
+				assert.True(t, parsedCommand.MayDownloadPackages())
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -467,11 +656,11 @@ func TestBunParseCommand(t *testing.T) {
 
 func TestNpmProxyBehavior(t *testing.T) {
 	cases := []struct {
-		name                     string
-		pm                       func() (*npmPackageManager, error)
-		command                  string
-		isKnownNonDownloadCmd    bool // proxy skipped when proxy_install_only=true
-		isInstallationCommand    bool
+		name                  string
+		pm                    func() (*npmPackageManager, error)
+		command               string
+		isKnownNonDownloadCmd bool // proxy skipped when proxy_install_only=true
+		isInstallationCommand bool
 	}{
 		// Commands that proxy MUST run for (not known-safe)
 		{
@@ -514,7 +703,7 @@ func TestNpmProxyBehavior(t *testing.T) {
 			pm:                    func() (*npmPackageManager, error) { return NewNpmPackageManager(DefaultPnpmPackageManagerConfig()) },
 			command:               "pnpm dlx create-react-app",
 			isKnownNonDownloadCmd: false,
-			isInstallationCommand: false,
+			isInstallationCommand: true,
 		},
 		{
 			name:                  "pnpm exec — proxy runs (may resolve packages)",
@@ -528,12 +717,26 @@ func TestNpmProxyBehavior(t *testing.T) {
 			pm:                    func() (*npmPackageManager, error) { return NewNpmPackageManager(DefaultYarnPackageManagerConfig()) },
 			command:               "yarn dlx create-react-app",
 			isKnownNonDownloadCmd: false,
-			isInstallationCommand: false,
+			isInstallationCommand: true,
 		},
 		{
 			name:                  "bun x — proxy runs (bun's npx equivalent)",
 			pm:                    func() (*npmPackageManager, error) { return NewNpmPackageManager(DefaultBunPackageManagerConfig()) },
 			command:               "bun x create-vite",
+			isKnownNonDownloadCmd: false,
+			isInstallationCommand: false,
+		},
+		{
+			name:                  "npm pack package — proxy runs (may download tarball)",
+			pm:                    func() (*npmPackageManager, error) { return NewNpmPackageManager(DefaultNpmPackageManagerConfig()) },
+			command:               "npm pack react",
+			isKnownNonDownloadCmd: false,
+			isInstallationCommand: false,
+		},
+		{
+			name:                  "npm cache add package — proxy runs (downloads into cache)",
+			pm:                    func() (*npmPackageManager, error) { return NewNpmPackageManager(DefaultNpmPackageManagerConfig()) },
+			command:               "npm cache add react",
 			isKnownNonDownloadCmd: false,
 			isInstallationCommand: false,
 		},


### PR DESCRIPTION
## Summary

I believe the intended behavior here is:

- Proxy Mode analyzes package downloads at runtime.
- When Proxy Mode is disabled, Guard Mode still protects commands it can reason about statically.
- Commands that may download packages but do not expose a static target should not silently run without analysis.

What I found was that Guard Mode continued execution for download-capable commands when no static install target was available. That meant commands such as `npm ci`, `npm pack react`, `npm cache add react`, and some exec/dlx forms could run while PMG could neither analyze a target package nor intercept the runtime download.

This PR changes that behavior by adding an explicit opt-in gate for download-capable commands without static targets under Guard Mode.

## What Changed

- Guard Mode now fails closed for download-capable commands when no static install target is available.
- Users can still continue through interactive confirmation, `PMG_ALLOW_UNSAFE_DOWNLOAD=true`, or existing insecure mode behavior.
- Locked global config remains authoritative and blocks local opt-in paths.
- Manifest installs that produce no extractable packages go through the same opt-in path.
- npm-family exec/dlx commands now extract package targets when the target is unambiguous.
- Harmless npm invocations such as `npm`, `npm --version`, and `npm -l` remain outside the unsafe-download gate.
- npm command detection now treats `npm pack <package>` and `npm cache add <package>` as download-capable, while leaving zero-argument `npm pack` local.
- npm command parsing now handles common global flag values so flags cannot hide a later download-capable command.
- Unsafe-download confirmation now requires explicit `y` or `yes`.
- Non-interactive unsafe-download messaging stays on the guard interaction surface.
