### PR TITLE
docs: add safe-chain to comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ PMG takes a defense in depth approach. Zero config, works across Zsh, Bash, and 
 
 PMG is the only free, open-source, install-time package firewall that covers developers and AI agents alike and ships with sandboxing and cooldown out of the box.
 
-| Capability                              | PMG | Socket  | Snyk | Dependabot |
-| --------------------------------------- | --- | ------- | ---- | ---------- |
-| OSS / built in public                   | ✓   | ✗       | ✗    | ✗          |
-| No account or API key                   | ✓   | ✓       | ✗    | ✗          |
-| Install-time malicious package blocking | ✓   | ✓       | ✗    | ✗          |
-| Dependency cooldown policy              | ✓   | ✗       | ✗    | ✗          |
-| Runtime sandboxing                         | ✓   | ✗       | ✗    | ✗          |
-| Protects AI coding agents transparently | ✓   | ✗       | ✗    | ✗          |
-| Local audit logs                        | ✓   | ✗       | ✗    | ✗          |
-| Known-CVE remediation PRs               | ✗   | ✗       | ✓    | ✓          |
+| Capability                              | PMG | Socket | safe-chain | Snyk | Dependabot |
+| --------------------------------------- | --- | ------ | ---------- | ---- | ---------- |
+| OSS / built in public                   | ✓   | ✗      | ✓          | ✗    | ✗          |
+| No account or API key                   | ✓   | ✓      | ✓          | ✗    | ✗          |
+| Install-time malicious package blocking | ✓   | ✓      | ✓          | ✗    | ✗          |
+| Dependency cooldown policy              | ✓   | ✗      | ✓          | ✗    | ✗          |
+| Runtime sandboxing                      | ✓   | ✗      | ✗          | ✗    | ✗          |
+| Protects AI coding agents transparently | ✓   | ✗      | ✗          | ✗    | ✗          |
+| Local audit logs                        | ✓   | ✗      | ✗          | ✗    | ✗          |
+| Known-CVE remediation PRs               | ✗   | ✗      | ✗          | ✓    | ✓          |
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Add Aikido's [safe-chain](https://github.com/AikidoSec/safe-chain) as a column in the "How PMG Compares" table.
- safe-chain is PMG's closest peer (OSS, tokenless, install-time blocking, configurable cooldown via `minimumPackageAgeHours`, default 48h).
- Marked ✗ for runtime sandboxing, transparent AI-agent protection, local audit logs, and CVE remediation PRs based on its current docs — default setup uses shell aliases (interactive shells only); Aikido positions AI-tool coverage under a separate "Aikido Endpoint" product.