### PR TITLE
Fix glob parent directory allowance for patterns with glob characters

### DIFF
--- a/sandbox/platform/seatbelt_translator_darwin.go
+++ b/sandbox/platform/seatbelt_translator_darwin.go
@@ -109,8 +109,16 @@ func getAncestorDirectories(pathStr string) []string {
 	return ancestors
 }
 
-// globDoubleStarAutoAllowParentDirIfNeeded checks if a pattern ends with /** and emits a literal rule for the parent directory.
+// globDoubleStarAutoAllowParentDirIfNeeded checks if a pattern ends with /** and emits a rule for the parent directory.
 // This ensures operations like mkdir('dir') or stat('dir') succeed before accessing dir/** contents.
+//
+// When the parent itself still contains glob characters (e.g. ${CWD}/**/node_modules),
+// a literal rule can never match a real path, so a regex rule is emitted instead.
+// This grants access only to directories matching the parent pattern — strictly
+// narrower than the Linux drivers, which bind the prefix before the first /**
+// (Bubblewrap) or the glob's expansion/parent (Landlock) read-write. Deny rules
+// are emitted after allows and override them, so mandatory credential denies
+// are unaffected.
 func globDoubleStarAutoAllowParentDirIfNeeded(sb *strings.Builder, pattern string, expanded string, operation string) {
 	if !strings.HasSuffix(expanded, "/**") {
 		return
@@ -127,6 +135,12 @@ func globDoubleStarAutoAllowParentDirIfNeeded(sb *strings.Builder, pattern strin
 	sb.WriteString("\n")
 	sb.WriteString("(allow ")
 	sb.WriteString(operation)
+	if util.ContainsGlob(parentDir) {
+		sb.WriteString(" (regex #\"")
+		sb.WriteString(util.GlobToRegex(parentDir))
+		sb.WriteString("\"))\n")
+		return
+	}
 	sb.WriteString(" (literal \"")
 	sb.WriteString(parentDir)
 	sb.WriteString("\"))\n")

--- a/sandbox/platform/seatbelt_translator_darwin_test.go
+++ b/sandbox/platform/seatbelt_translator_darwin_test.go
@@ -108,6 +108,22 @@ func TestSeatbeltTranslatorDarwinFilesystemTranslation(t *testing.T) {
 			},
 		},
 		{
+			name: "glob pattern with /** and glob parent",
+			policy: &sandbox.SandboxPolicy{
+				Filesystem: sandbox.FilesystemPolicy{
+					AllowWrite: []string{"/project/**/node_modules/**"},
+				},
+			},
+			assert: func(t *testing.T, actual string, err error) {
+				assert.NoError(t, err)
+				// Parent still contains a glob, so the auto-allow must be a
+				// regex rule — a literal with ** can never match a real path.
+				assert.Contains(t, actual, `(allow file-write* (regex #"^/project/(.*/)?node_modules$"))`)
+				assert.Contains(t, actual, `^/project/(.*/)?node_modules/.*$`)
+				assert.NotContains(t, actual, `(literal "/project/**/node_modules")`)
+			},
+		},
+		{
 			name: "glob pattern with *.txt",
 			policy: &sandbox.SandboxPolicy{
 				Filesystem: sandbox.FilesystemPolicy{

--- a/sandbox/profiles/pnpm.yml
+++ b/sandbox/profiles/pnpm.yml
@@ -19,10 +19,16 @@ environment:
     - NODE_EXTRA_CA_CERTS
 
 filesystem:
+  allow_read:
+    # pnpm cache on macOS lives under ~/Library/Caches (lockfile verification,
+    # metadata). The base profile only covers the XDG path ~/.cache/pnpm.
+    - ${HOME}/Library/Caches/pnpm/**
+
   allow_write:
     # pnpm needs write access here
     - ${HOME}/Library/pnpm/.tools/**
     - ${HOME}/.pnpm-store/**
+    - ${HOME}/Library/Caches/pnpm/**
 
     # `pnpm i` creates the tmp files in local dir, at least on MacOS
     - ${CWD}/_tmp_*
@@ -38,5 +44,14 @@ filesystem:
 
     # Need access for dependency resolution
     - ${CWD}/.pnpm-store
+
+    # Workspaces (monorepos): pnpm creates a node_modules inside every
+    # workspace package to symlink its direct dependencies. The bare
+    # **/node_modules form is required in addition to **/node_modules/**:
+    # the automatic parent-directory allowance only works for literal
+    # parents, and this parent contains a glob, so mkdir of the directory
+    # itself must be matched explicitly.
+    - ${CWD}/**/node_modules
+    - ${CWD}/**/node_modules/**
 
 


### PR DESCRIPTION
## Summary

When a sandbox policy pattern ends with `/**`, the Seatbelt translator automatically emits an allow rule for the parent directory to ensure operations like `mkdir` and `stat` succeed. However, this logic incorrectly used literal rules even when the parent directory itself contained glob characters (e.g., `${CWD}/**/node_modules`), which can never match a real path. This fix emits regex rules instead when the parent contains globs.

## Changes

- **Seatbelt translator logic**: Updated `globDoubleStarAutoAllowParentDirIfNeeded` to detect glob characters in the parent directory and emit a regex rule instead of a literal rule when globs are present. This ensures the auto-allow rule can actually match real paths while remaining narrower than the Linux driver behavior.

- **Test coverage**: Added a test case validating that patterns like `/project/**/node_modules/**` correctly emit a regex rule for the parent directory and do not emit invalid literal rules.

- **pnpm profile**: Updated to explicitly allow `${CWD}/**/node_modules` (in addition to `${CWD}/**/node_modules/**`) for workspace support. Added documentation explaining that the automatic parent-directory allowance only works for literal parents, so the bare form must be matched explicitly when the parent contains globs. Also added macOS-specific pnpm cache paths under `~/Library/Caches/pnpm/`.

## Implementation Details

The fix checks `util.ContainsGlob(parentDir)` before deciding between literal and regex rules. When globs are present, `util.GlobToRegex(parentDir)` converts the glob pattern to a regex that matches the intended directory structure without requiring literal path expansion.

https://claude.ai/code/session_01PiDZzkPnCe4BSbc33nJQYy