### PR TITLE
Respect explicitly set CI environment variable

### DIFF
--- a/internal/flows/proxy_flow.go
+++ b/internal/flows/proxy_flow.go
@@ -207,7 +207,7 @@ func (f *proxyFlow) Run(ctx context.Context, args []string, parsedCmd *packagema
 		DryRun:             cfg.DryRun,
 		Mode:               runner.ExecutionModeAuto,
 		EnvOverrides:       f.setupEnvForProxy(proxyAddr, caCertPath),
-		DirectEnvOverrides: []string{"CI=true"},
+		DirectEnvOverrides: ciEnvOverride(),
 		BeforeDirectRun: func() error {
 			log.Debugf("Executing proxy for non interactive TTY")
 
@@ -410,6 +410,16 @@ func (f *proxyFlow) createAndStartProxyServer(
 	}
 
 	return proxyServer, proxyAddr, nil
+}
+
+// ciEnvOverride forces CI=true for non-interactive runs so package managers
+// behave non-interactively. It respects an explicitly set CI value (including
+// CI=false) so we don't clobber the user's intent. See issue #335.
+func ciEnvOverride() []string {
+	if _, ok := os.LookupEnv("CI"); ok {
+		return nil
+	}
+	return []string{"CI=true"}
 }
 
 func (f *proxyFlow) setupEnvForProxy(proxyAddr, caCertPath string) []string {

--- a/internal/flows/proxy_flow_env_test.go
+++ b/internal/flows/proxy_flow_env_test.go
@@ -46,8 +46,13 @@ func TestSetupEnvForProxyConfiguresYarn(t *testing.T) {
 // explicitly (e.g. CI=false on a build server).
 func TestCIEnvOverride(t *testing.T) {
 	t.Run("sets CI=true when unset", func(t *testing.T) {
-		t.Setenv("CI", "true")
+		original, hadCI := os.LookupEnv("CI")
 		require.NoError(t, os.Unsetenv("CI"))
+		t.Cleanup(func() {
+			if hadCI {
+				require.NoError(t, os.Setenv("CI", original))
+			}
+		})
 
 		assert.Equal(t, []string{"CI=true"}, ciEnvOverride())
 	})

--- a/internal/flows/proxy_flow_env_test.go
+++ b/internal/flows/proxy_flow_env_test.go
@@ -1,10 +1,12 @@
 package flows
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func envToMap(env []string) map[string]string {
@@ -37,4 +39,26 @@ func TestSetupEnvForProxyConfiguresYarn(t *testing.T) {
 		"yarn ignores HTTPS_PROXY; YARN_HTTPS_PROXY is required to route yarn through the proxy")
 	assert.Equal(t, caCertPath, env["YARN_HTTPS_CA_FILE_PATH"],
 		"yarn ignores NODE_EXTRA_CA_CERTS; YARN_HTTPS_CA_FILE_PATH is required to trust the MITM CA")
+}
+
+// TestCIEnvOverride proves the fix for #335: pmg forces CI=true for
+// non-interactive runs but must not clobber a CI value the user set
+// explicitly (e.g. CI=false on a build server).
+func TestCIEnvOverride(t *testing.T) {
+	t.Run("sets CI=true when unset", func(t *testing.T) {
+		t.Setenv("CI", "true")
+		require.NoError(t, os.Unsetenv("CI"))
+
+		assert.Equal(t, []string{"CI=true"}, ciEnvOverride())
+	})
+
+	t.Run("does not override explicitly set CI", func(t *testing.T) {
+		t.Setenv("CI", "false")
+		assert.Nil(t, ciEnvOverride())
+	})
+
+	t.Run("does not override CI set to empty", func(t *testing.T) {
+		t.Setenv("CI", "")
+		assert.Nil(t, ciEnvOverride())
+	})
 }


### PR DESCRIPTION
## Summary
Fix issue #335 by respecting explicitly set CI environment variable values instead of unconditionally forcing `CI=true` for non-interactive runs.

## Changes
- Extract CI environment override logic into a new `ciEnvOverride()` function that only sets `CI=true` when the CI variable is not already set
- Update `proxyFlow.Run()` to use `ciEnvOverride()` instead of hardcoded `DirectEnvOverrides: []string{"CI=true"}`
- Add comprehensive test coverage for the new behavior:
  - Sets `CI=true` when unset
  - Preserves explicitly set `CI=false` (respects user intent on build servers)
  - Preserves empty `CI` value

## Implementation Details
The `ciEnvOverride()` function uses `os.LookupEnv()` to check if CI is already set in the environment. If it is set (regardless of value), the function returns `nil` to avoid overriding the user's explicit choice. This ensures package managers behave non-interactively by default while respecting user configuration.

https://claude.ai/code/session_01Pxz3DMWYqPGjtCEJxByioy