### PR TITLE
fix: Decouple cloud sync from telemetry

### DIFF
--- a/cmd/cloud/sync.go
+++ b/cmd/cloud/sync.go
@@ -8,7 +8,6 @@ import (
 	"github.com/safedep/dry/usefulerror"
 	"github.com/safedep/pmg/config"
 	"github.com/safedep/pmg/errcodes"
-	"github.com/safedep/pmg/internal/analytics"
 	"github.com/safedep/pmg/internal/audit"
 	"github.com/safedep/pmg/internal/ui"
 	"github.com/spf13/cobra"
@@ -36,11 +35,6 @@ func newSyncCommand() *cobra.Command {
 
 func runSync(cmd *cobra.Command, args []string) error {
 	cfg := config.Get()
-
-	if analytics.IsDisabled() {
-		ui.Infof("Cloud sync is disabled because telemetry is disabled (disable_telemetry or PMG_DISABLE_TELEMETRY)")
-		return nil
-	}
 
 	if !cfg.Config.Cloud.Enabled {
 		ui.ErrorExit(usefulerror.NewUsefulError().

--- a/cmd/cloud/sync_background.go
+++ b/cmd/cloud/sync_background.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/config"
-	"github.com/safedep/pmg/internal/analytics"
 	"github.com/safedep/pmg/internal/audit"
 	"github.com/spf13/cobra"
 )
@@ -29,11 +28,6 @@ func runSyncBackground(cmd *cobra.Command, args []string) error {
 	audit.MarkBackgroundSyncChild()
 
 	cfg := config.Get()
-
-	if analytics.IsDisabled() {
-		log.Debugf("Auto-sync: telemetry disabled; exiting")
-		return nil
-	}
 
 	if !cfg.Config.Cloud.Enabled || !cfg.Config.Cloud.AutoSync.Enabled {
 		log.Debugf("Auto-sync: cloud or auto_sync disabled; exiting")

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -8,7 +8,6 @@ import (
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/config"
-	"github.com/safedep/pmg/internal/analytics"
 )
 
 var global *auditor
@@ -27,17 +26,13 @@ func Initialize(cfg *config.RuntimeConfig) error {
 	var sinks []Sink
 	sinks = append(sinks, newEventlogSink())
 
-	if cfg.Config.Cloud.Enabled && !analytics.IsDisabled() {
+	if cfg.Config.Cloud.Enabled {
 		cs, err := newCloudSink(cfg, newCloudSinkCIResolver())
 		if err != nil {
 			log.Warnf("Cloud sync initialization failed: %v", err)
 		} else {
 			sinks = append(sinks, cs)
 		}
-	}
-
-	if cfg.Config.Cloud.Enabled && analytics.IsDisabled() {
-		log.Warnf("Cloud sync is disabled because telemetry is disabled")
 	}
 
 	setGlobal(newAuditor(sinks...))

--- a/internal/audit/background_sync.go
+++ b/internal/audit/background_sync.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/config"
-	"github.com/safedep/pmg/internal/analytics"
 )
 
 // SyncBackgroundSubcommand is the cobra `Use` of the hidden child command
@@ -46,9 +45,6 @@ func MaybeSpawnBackgroundSync(cfg *config.RuntimeConfig) {
 		return
 	}
 	if !cfg.Config.Cloud.Enabled || !cfg.Config.Cloud.AutoSync.Enabled {
-		return
-	}
-	if analytics.IsDisabled() {
 		return
 	}
 

--- a/internal/audit/background_sync_test.go
+++ b/internal/audit/background_sync_test.go
@@ -83,6 +83,15 @@ func TestMaybeSpawnBackgroundSyncSpawnsByDefault(t *testing.T) {
 	assert.NotEmpty(t, rec.calls[0].name, "spawned name should be a resolved binary path")
 }
 
+func TestMaybeSpawnBackgroundSyncIgnoresTelemetryDisabled(t *testing.T) {
+	rec := withMockSpawner(t)
+	cfg := newAutoSyncConfig(t)
+	cfg.Config.DisableTelemetry = true
+
+	MaybeSpawnBackgroundSync(cfg)
+	assert.Equal(t, 1, rec.callCount())
+}
+
 func TestMaybeSpawnBackgroundSyncShortCircuits(t *testing.T) {
 	t.Run("nil config", func(t *testing.T) {
 		rec := withMockSpawner(t)
@@ -103,15 +112,6 @@ func TestMaybeSpawnBackgroundSyncShortCircuits(t *testing.T) {
 		rec := withMockSpawner(t)
 		cfg := newAutoSyncConfig(t)
 		cfg.Config.Cloud.AutoSync.Enabled = false
-
-		MaybeSpawnBackgroundSync(cfg)
-		assert.Equal(t, 0, rec.callCount())
-	})
-
-	t.Run("telemetry disabled via config", func(t *testing.T) {
-		rec := withMockSpawner(t)
-		cfg := newAutoSyncConfig(t)
-		cfg.Config.DisableTelemetry = true
 
 		MaybeSpawnBackgroundSync(cfg)
 		assert.Equal(t, 0, rec.callCount())


### PR DESCRIPTION
Decouple telemetry and cloud sync. The rationale is - They are completely different data and intention. Telemetry consists of anonymous aggregates. Enabled by default but can be disabled. However, cloud sync is an opt-in feature where the user is explicitly configuring to sync audit events with SafeDep cloud.