### PR TITLE
fix: expand ${CWD}/${HOME}/${TMPDIR} in --sandbox-allow path overrides

### DIFF
--- a/config/sandbox_allow.go
+++ b/config/sandbox_allow.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/safedep/dry/log"
+	sandboxutil "github.com/safedep/pmg/sandbox/util"
 )
 
 // validSandboxAllowTypes is the set of recognized --sandbox-allow type prefixes.
@@ -217,6 +218,11 @@ func isLocalhostAddress(host string) bool {
 // resolveToAbsolute resolves a path to an absolute path relative to CWD.
 // Glob characters are preserved. The path is cleaned via filepath.Clean().
 func resolveToAbsolute(value string) (string, error) {
+	value, err := sandboxutil.ExpandVariables(value)
+	if err != nil {
+		return "", err
+	}
+
 	if filepath.IsAbs(value) {
 		return filepath.Clean(value), nil
 	}

--- a/config/sandbox_allow_test.go
+++ b/config/sandbox_allow_test.go
@@ -94,6 +94,73 @@ func TestParseSandboxAllowOverrides_ValidFormats(t *testing.T) {
 	}
 }
 
+func TestParseSingleOverride_ExpandsSandboxVariables(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tmpDir := os.TempDir()
+
+	tests := []struct {
+		name          string
+		raw           string
+		expectedType  SandboxAllowType
+		expectedValue string
+		notContains   string
+	}{
+		{
+			name:          "write expands CWD glob",
+			raw:           "write=${CWD}/**",
+			expectedType:  SandboxAllowWrite,
+			expectedValue: filepath.Clean(filepath.Join(cwd, "**")),
+			notContains:   "${CWD}",
+		},
+		{
+			name:          "read expands HOME",
+			raw:           "read=${HOME}/x",
+			expectedType:  SandboxAllowRead,
+			expectedValue: filepath.Clean(filepath.Join(home, "x")),
+			notContains:   "${HOME}",
+		},
+		{
+			name:          "write expands TMPDIR",
+			raw:           "write=${TMPDIR}/pmg-cache",
+			expectedType:  SandboxAllowWrite,
+			expectedValue: filepath.Clean(filepath.Join(tmpDir, "pmg-cache")),
+			notContains:   "${TMPDIR}",
+		},
+		{
+			name:          "exec expands CWD",
+			raw:           "exec=${CWD}/bin/tool",
+			expectedType:  SandboxAllowExec,
+			expectedValue: filepath.Clean(filepath.Join(cwd, "bin", "tool")),
+			notContains:   "${CWD}",
+		},
+		{
+			name:          "absolute path without variables is unchanged",
+			raw:           "write=/tmp/pmg-output",
+			expectedType:  SandboxAllowWrite,
+			expectedValue: filepath.Clean("/tmp/pmg-output"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSingleOverride(tt.raw)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedType, got.Type)
+			assert.Equal(t, tt.expectedValue, got.Value)
+			assert.Equal(t, tt.raw, got.Raw)
+			if tt.notContains != "" {
+				assert.NotContains(t, got.Value, tt.notContains)
+			}
+		})
+	}
+}
+
 func TestParseSandboxAllowOverrides_Env(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

Expand the supported sandbox variables (`${CWD}`, `${HOME}`, `${TMPDIR}`) in the runtime `--sandbox-allow` path overrides for `read`/`write`/`exec` types, so they resolve the same way profile-loaded sandbox paths already do.

The expansion happens in `resolveToAbsolute`, the single chokepoint shared by `resolveFilesystemPath` and `resolveExecPath`, before resolving to an absolute path. It reuses the existing `sandbox/util.ExpandVariables` helper, keeping flag-based and profile-based overrides consistent. Glob characters (`*`, `?`, `[`) are preserved through expansion and `filepath.Clean`, and tilde and glob validation keep their current ordering.

## Why this matters

As reported in #257, `pmg --sandbox --sandbox-allow=write='${CWD}/**'` did not work, while the relative form `write=./**` did. The `${CWD}`, `${HOME}` and `${TMPDIR}` variables were only expanded for sandbox profiles loaded from config/profile files; the runtime `--sandbox-allow` CLI override path never expanded them. As a result `${CWD}` was treated as a literal path segment, the resolved absolute path was wrong, and the write allow rule never matched. This change makes the documented variables behave identically whether they come from a profile or a CLI flag.

## Testing

- `go test ./config/ -count=1` (passes)
- Added `TestParseSingleOverride_ExpandsSandboxVariables` covering `${CWD}/**` (glob preserved), `${HOME}/x`, `${TMPDIR}/...` for read/write, and `${CWD}/bin/tool` for exec, plus a regression guard that a plain absolute path is unchanged.
- `gofmt`, `go vet ./config/...`, `go build ./config/...` clean.

Fixes #257
