### PR TITLE
feat(proxy): persistent proxy server (POC)

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -8,6 +8,6 @@ runs:
       run: npm install -g yarn
       shell: bash
 
-    - name: install packages if cache miss
-      run: yarn install safedep-test-pkg
+    - name: install packages
+      run: npm install safedep-test-pkg
       shell: bash

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,13 @@
+name: install npm packages
+description: Installs npm packages
+
+runs:
+  using: composite
+  steps:
+    - name: Install Yarn
+      run: npm install -g yarn
+      shell: bash
+
+    - name: install packages if cache miss
+      run: yarn install safedep-test-pkg
+      shell: bash

--- a/.github/workflows/persistent-proxy-e2e.yml
+++ b/.github/workflows/persistent-proxy-e2e.yml
@@ -84,6 +84,7 @@ jobs:
           cd .. && rm -rf malicious-test
 
       - name: pip installs through proxy
+        continue-on-error: true
         run: |
           python -m venv venv && source venv/bin/activate
           python -m pip install safedep-test-pkg

--- a/.github/workflows/persistent-proxy-e2e.yml
+++ b/.github/workflows/persistent-proxy-e2e.yml
@@ -89,6 +89,9 @@ jobs:
           python -m pip install safedep-test-pkg
           deactivate && rm -rf venv
 
+      - name: Install Dependencies from composite
+        uses: ./.github/actions/install
+
       - name: Stop proxy
         if: always()
         run: pmg proxy stop

--- a/.github/workflows/persistent-proxy-e2e.yml
+++ b/.github/workflows/persistent-proxy-e2e.yml
@@ -86,8 +86,7 @@ jobs:
       - name: pip installs through proxy
         run: |
           python -m venv venv && source venv/bin/activate
-          pip install requests==2.32.4
-          python -c "import requests; print('pip ok:', requests.__version__)"
+          pip install safedep-test-pkg
           deactivate && rm -rf venv
 
       - name: Stop proxy

--- a/.github/workflows/persistent-proxy-e2e.yml
+++ b/.github/workflows/persistent-proxy-e2e.yml
@@ -6,9 +6,9 @@ on:
     branches:
       - main
     paths:
-      - 'cmd/proxy/**'
-      - 'internal/proxystate/**'
-      - 'internal/flows/cert.go'
+      - "cmd/proxy/**"
+      - "internal/proxystate/**"
+      - "internal/flows/cert.go"
 
 permissions:
   contents: read
@@ -66,7 +66,7 @@ jobs:
           test -n "$NODE_EXTRA_CA_CERTS"
           test -f "$NODE_EXTRA_CA_CERTS"
 
-      - name: Test: benign package installs successfully
+      - name: Benign package installs successfully
         run: |
           mkdir benign-test && cd benign-test
           npm init -y
@@ -75,7 +75,7 @@ jobs:
           echo "SUCCESS: lodash installed through proxy"
           cd .. && rm -rf benign-test
 
-      - name: Test: malicious package is blocked
+      - name: Malicious package is blocked
         run: |
           mkdir malicious-test && cd malicious-test
           npm init -y
@@ -90,7 +90,7 @@ jobs:
           echo "SUCCESS: safedep-test-pkg blocked by persistent proxy"
           cd .. && rm -rf malicious-test
 
-      - name: Test: pip installs through proxy
+      - name: pip installs through proxy
         run: |
           python -m venv venv && source venv/bin/activate
           pip install requests==2.32.4

--- a/.github/workflows/persistent-proxy-e2e.yml
+++ b/.github/workflows/persistent-proxy-e2e.yml
@@ -76,12 +76,11 @@ jobs:
           cd .. && rm -rf benign-test
 
       - name: Malicious package is blocked (npm exits non-zero)
+        continue-on-error: true
         run: |
           mkdir malicious-test && cd malicious-test
           npm init -y
-          npm --no-cache --prefer-online install safedep-test-pkg@0.1.3 && exit 1 || true
-          test ! -d node_modules/safedep-test-pkg
-          echo "SUCCESS: npm correctly failed to install safedep-test-pkg"
+          npm --no-cache --prefer-online install safedep-test-pkg@0.1.3
           cd .. && rm -rf malicious-test
 
       - name: pip installs through proxy
@@ -91,10 +90,6 @@ jobs:
           python -c "import requests; print('pip ok:', requests.__version__)"
           deactivate && rm -rf venv
 
-      - name: Stop proxy (exits 1 when packages were blocked)
-        run: |
-          if pmg proxy stop; then
-            echo "ERROR: pmg proxy stop should have exited non-zero (packages were blocked)"
-            exit 1
-          fi
-          echo "SUCCESS: pmg proxy stop correctly reported blocked packages"
+      - name: Stop proxy
+        if: always()
+        run: pmg proxy stop

--- a/.github/workflows/persistent-proxy-e2e.yml
+++ b/.github/workflows/persistent-proxy-e2e.yml
@@ -75,19 +75,13 @@ jobs:
           echo "SUCCESS: lodash installed through proxy"
           cd .. && rm -rf benign-test
 
-      - name: Malicious package is blocked
+      - name: Malicious package is blocked (npm exits non-zero)
         run: |
           mkdir malicious-test && cd malicious-test
           npm init -y
-          if npm --no-cache --prefer-online install safedep-test-pkg@0.1.3; then
-            echo "ERROR: safedep-test-pkg was not blocked!"
-            exit 1
-          fi
-          if [ -d "node_modules/safedep-test-pkg" ]; then
-            echo "ERROR: safedep-test-pkg found in node_modules!"
-            exit 1
-          fi
-          echo "SUCCESS: safedep-test-pkg blocked by persistent proxy"
+          npm --no-cache --prefer-online install safedep-test-pkg@0.1.3 && exit 1 || true
+          test ! -d node_modules/safedep-test-pkg
+          echo "SUCCESS: npm correctly failed to install safedep-test-pkg"
           cd .. && rm -rf malicious-test
 
       - name: pip installs through proxy
@@ -97,6 +91,10 @@ jobs:
           python -c "import requests; print('pip ok:', requests.__version__)"
           deactivate && rm -rf venv
 
-      - name: Stop proxy
-        if: always()
-        run: pmg proxy stop || true
+      - name: Stop proxy (exits 1 when packages were blocked)
+        run: |
+          if pmg proxy stop; then
+            echo "ERROR: pmg proxy stop should have exited non-zero (packages were blocked)"
+            exit 1
+          fi
+          echo "SUCCESS: pmg proxy stop correctly reported blocked packages"

--- a/.github/workflows/persistent-proxy-e2e.yml
+++ b/.github/workflows/persistent-proxy-e2e.yml
@@ -86,7 +86,7 @@ jobs:
       - name: pip installs through proxy
         run: |
           python -m venv venv && source venv/bin/activate
-          pip install safedep-test-pkg
+          python -m pip install safedep-test-pkg
           deactivate && rm -rf venv
 
       - name: Stop proxy

--- a/.github/workflows/persistent-proxy-e2e.yml
+++ b/.github/workflows/persistent-proxy-e2e.yml
@@ -1,0 +1,102 @@
+name: Persistent Proxy E2E
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'cmd/proxy/**'
+      - 'internal/proxystate/**'
+      - 'internal/flows/cert.go'
+
+permissions:
+  contents: read
+
+jobs:
+  persistent-proxy-e2e:
+    name: Persistent Proxy E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Build PMG
+        run: make
+
+      - name: Add pmg to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - name: Setup PMG
+        run: pmg setup install
+
+      - name: Start persistent proxy
+        run: |
+          pmg proxy start &
+          # Poll until proxy writes its state file (up to 10s)
+          for i in $(seq 1 10); do
+            pmg proxy status && break
+            sleep 1
+          done
+
+      - name: Inject proxy env vars into workflow environment
+        run: pmg proxy env --gha
+
+      - name: Verify proxy env vars are set
+        run: |
+          echo "HTTP_PROXY=$HTTP_PROXY"
+          echo "NODE_EXTRA_CA_CERTS=$NODE_EXTRA_CA_CERTS"
+          test -n "$HTTP_PROXY"
+          test -n "$NODE_EXTRA_CA_CERTS"
+          test -f "$NODE_EXTRA_CA_CERTS"
+
+      - name: Test: benign package installs successfully
+        run: |
+          mkdir benign-test && cd benign-test
+          npm init -y
+          npm install lodash@4.17.21
+          test -d node_modules/lodash
+          echo "SUCCESS: lodash installed through proxy"
+          cd .. && rm -rf benign-test
+
+      - name: Test: malicious package is blocked
+        run: |
+          mkdir malicious-test && cd malicious-test
+          npm init -y
+          if npm --no-cache --prefer-online install safedep-test-pkg@0.1.3; then
+            echo "ERROR: safedep-test-pkg was not blocked!"
+            exit 1
+          fi
+          if [ -d "node_modules/safedep-test-pkg" ]; then
+            echo "ERROR: safedep-test-pkg found in node_modules!"
+            exit 1
+          fi
+          echo "SUCCESS: safedep-test-pkg blocked by persistent proxy"
+          cd .. && rm -rf malicious-test
+
+      - name: Test: pip installs through proxy
+        run: |
+          python -m venv venv && source venv/bin/activate
+          pip install requests==2.32.4
+          python -c "import requests; print('pip ok:', requests.__version__)"
+          deactivate && rm -rf venv
+
+      - name: Stop proxy
+        if: always()
+        run: pmg proxy stop || true

--- a/cmd/proxy/env.go
+++ b/cmd/proxy/env.go
@@ -1,0 +1,100 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/internal/proxystate"
+	"github.com/spf13/cobra"
+)
+
+func newEnvCommand() *cobra.Command {
+	var gha bool
+
+	cmd := &cobra.Command{
+		Use:   "env",
+		Short: "Print proxy environment variables (use with eval or --gha for GitHub Actions)",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runEnv(gha)
+		},
+	}
+
+	cmd.Flags().BoolVar(&gha, "gha", false, "Write env vars to $GITHUB_ENV instead of stdout")
+	return cmd
+}
+
+func runEnv(gha bool) error {
+	cfg := config.Get()
+	statePath := proxystate.StatePath(cfg.ConfigDir())
+
+	state, err := proxystate.Read(statePath)
+	if err != nil {
+		return fmt.Errorf("proxy not running — start with 'pmg proxy start' first: %w", err)
+	}
+
+	proxyURL := fmt.Sprintf("http://%s", state.Addr)
+	noProxy := "localhost,127.0.0.1,::1"
+
+	vars := []string{
+		fmt.Sprintf("HTTP_PROXY=%s", proxyURL),
+		fmt.Sprintf("HTTPS_PROXY=%s", proxyURL),
+		fmt.Sprintf("http_proxy=%s", proxyURL),
+		fmt.Sprintf("https_proxy=%s", proxyURL),
+		fmt.Sprintf("NO_PROXY=%s", noProxy),
+		fmt.Sprintf("no_proxy=%s", noProxy),
+		"NODE_USE_ENV_PROXY=1",
+		fmt.Sprintf("NODE_EXTRA_CA_CERTS=%s", state.CACertPath),
+		fmt.Sprintf("SSL_CERT_FILE=%s", state.CACertPath),
+		fmt.Sprintf("REQUESTS_CA_BUNDLE=%s", state.CACertPath),
+		fmt.Sprintf("PIP_CERT=%s", state.CACertPath),
+		fmt.Sprintf("PIP_PROXY=%s", proxyURL),
+		"PIP_RETRIES=0",
+		fmt.Sprintf("YARN_HTTP_PROXY=%s", proxyURL),
+		fmt.Sprintf("YARN_HTTPS_PROXY=%s", proxyURL),
+		fmt.Sprintf("YARN_HTTPS_CA_FILE_PATH=%s", state.CACertPath),
+	}
+
+	if gha {
+		return writeGitHubEnv(vars)
+	}
+
+	return writeShellExports(vars)
+}
+
+func writeShellExports(vars []string) error {
+	w := bufio.NewWriter(os.Stdout)
+	for _, kv := range vars {
+		// Split on first '=' so we can quote only the value, handling paths with spaces.
+		k, v, _ := strings.Cut(kv, "=")
+		if _, err := fmt.Fprintf(w, "export %s=%q\n", k, v); err != nil {
+			return fmt.Errorf("write env var: %w", err)
+		}
+	}
+	return w.Flush()
+}
+
+func writeGitHubEnv(vars []string) error {
+	ghEnvFile := os.Getenv("GITHUB_ENV")
+	if ghEnvFile == "" {
+		return fmt.Errorf("$GITHUB_ENV is not set — are you running in GitHub Actions?")
+	}
+
+	f, err := os.OpenFile(ghEnvFile, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open $GITHUB_ENV file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	w := bufio.NewWriter(f)
+	for _, v := range vars {
+		if _, err := fmt.Fprintf(w, "%s\n", v); err != nil {
+			return fmt.Errorf("write to $GITHUB_ENV: %w", err)
+		}
+	}
+	return w.Flush()
+}

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -1,0 +1,15 @@
+package proxy
+
+import "github.com/spf13/cobra"
+
+func NewProxyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proxy",
+		Short: "Manage the persistent PMG proxy server",
+	}
+	cmd.AddCommand(newStartCommand())
+	cmd.AddCommand(newStopCommand())
+	cmd.AddCommand(newEnvCommand())
+	cmd.AddCommand(newStatusCommand())
+	return cmd
+}

--- a/cmd/proxy/start.go
+++ b/cmd/proxy/start.go
@@ -106,7 +106,13 @@ func runStart(_ *cobra.Command, _ []string) error {
 	<-sigCh
 
 	close(confirmationChan)
-	_ = proxystate.Remove(statePath)
+
+	// Write final blocked count before exiting so `pmg proxy stop` can read it.
+	// stop is responsible for removing the state file.
+	state.BlockedCount = stats.GetStats().BlockedCount
+	if werr := proxystate.Write(statePath, state); werr != nil {
+		log.Warnf("failed to write final proxy state: %v", werr)
+	}
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/cmd/proxy/start.go
+++ b/cmd/proxy/start.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/safedep/dry/log"
+	"github.com/safedep/pmg/analyzer"
+	"github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/internal/flows"
+	"github.com/safedep/pmg/internal/proxystate"
+	pmgproxy "github.com/safedep/pmg/proxy"
+	"github.com/safedep/pmg/proxy/certmanager"
+	"github.com/safedep/pmg/proxy/interceptors"
+	"github.com/spf13/cobra"
+)
+
+func newStartCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start the persistent PMG proxy server (runs in foreground)",
+		RunE:  runStart,
+	}
+}
+
+func runStart(_ *cobra.Command, _ []string) error {
+	cfg := config.Get()
+	statePath := proxystate.StatePath(cfg.ConfigDir())
+
+	if existing, err := proxystate.Read(statePath); err == nil && existing.IsRunning() {
+		return fmt.Errorf("proxy already running (pid %d, addr %s) — run 'pmg proxy stop' first", existing.PID, existing.Addr)
+	}
+
+	caCertPath := filepath.Join(cfg.ConfigDir(), "proxy-ca.pem")
+	caCert, _, err := flows.SetupCACertificate(cfg.ConfigDir(), caCertPath)
+	if err != nil {
+		return fmt.Errorf("setup CA certificate: %w", err)
+	}
+
+	certMgr, err := certmanager.NewCertificateManagerWithCA(caCert, certmanager.DefaultCertManagerConfig())
+	if err != nil {
+		return fmt.Errorf("create certificate manager: %w", err)
+	}
+
+	malysisAnalyzer, err := analyzer.NewMalysisAnalyzer(analyzer.MalysisQueryAnalyzerConfig{})
+	if err != nil {
+		return fmt.Errorf("create analyzer: %w", err)
+	}
+
+	cache := interceptors.NewInMemoryAnalysisCache()
+	stats := interceptors.NewAnalysisStatsCollector()
+	confirmationChan := make(chan *interceptors.ConfirmationRequest, 100)
+	go autoBlockConfirmations(confirmationChan)
+
+	factory := interceptors.NewInterceptorFactory(
+		malysisAnalyzer, cache, stats, confirmationChan, interceptors.InterceptorContext{},
+	)
+
+	var interceptorList []pmgproxy.Interceptor
+	for _, eco := range interceptors.SupportedEcosystems() {
+		i, ferr := factory.CreateInterceptor(eco)
+		if ferr != nil {
+			return fmt.Errorf("create interceptor for %s: %w", eco.String(), ferr)
+		}
+		interceptorList = append(interceptorList, i)
+	}
+	interceptorList = append(interceptorList, interceptors.NewAuditLoggerInterceptor())
+
+	proxyConfig := pmgproxy.DefaultProxyConfig()
+	proxyConfig.CertManager = certMgr
+	proxyConfig.Interceptors = interceptorList
+
+	server, err := pmgproxy.NewProxyServer(proxyConfig)
+	if err != nil {
+		return fmt.Errorf("create proxy server: %w", err)
+	}
+
+	if err := server.Start(); err != nil {
+		return fmt.Errorf("start proxy server: %w", err)
+	}
+
+	state := proxystate.State{
+		PID:        os.Getpid(),
+		Addr:       server.Address(),
+		CACertPath: caCertPath,
+	}
+	if err := proxystate.Write(statePath, state); err != nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Stop(stopCtx)
+		return fmt.Errorf("write proxy state: %w", err)
+	}
+
+	log.Infof("PMG persistent proxy running on %s (pid %d)", state.Addr, state.PID)
+	if _, err := fmt.Fprintf(os.Stderr, "PMG proxy running on %s\nRun: eval $(pmg proxy env)  # or: pmg proxy env --gha\n", state.Addr); err != nil {
+		log.Warnf("failed to write startup message: %v", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	<-sigCh
+
+	close(confirmationChan)
+	_ = proxystate.Remove(statePath)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return server.Stop(stopCtx)
+}
+
+// autoBlockConfirmations drains the confirmation channel and always denies,
+// appropriate for non-interactive CI/CD environments.
+func autoBlockConfirmations(ch chan *interceptors.ConfirmationRequest) {
+	for req := range ch {
+		log.Warnf("Persistent proxy: auto-blocking suspicious package %s", req.PackageVersion.GetPackage().GetName())
+		req.ResponseChan <- false
+		close(req.ResponseChan)
+	}
+}

--- a/cmd/proxy/status.go
+++ b/cmd/proxy/status.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/internal/proxystate"
+	"github.com/spf13/cobra"
+)
+
+func newStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show the status of the persistent PMG proxy server",
+		RunE:  runStatus,
+	}
+}
+
+func runStatus(_ *cobra.Command, _ []string) error {
+	cfg := config.Get()
+	statePath := proxystate.StatePath(cfg.ConfigDir())
+
+	state, err := proxystate.Read(statePath)
+	if err != nil {
+		if _, werr := fmt.Fprintln(os.Stdout, "PMG proxy: not running (no state file)"); werr != nil {
+			return werr
+		}
+		return nil
+	}
+
+	if state.IsRunning() {
+		_, err = fmt.Fprintf(os.Stdout, "PMG proxy: running (pid %d, addr %s, ca %s)\n",
+			state.PID, state.Addr, state.CACertPath)
+	} else {
+		_, err = fmt.Fprintf(os.Stdout, "PMG proxy: stopped (stale state for pid %d — run 'pmg proxy stop' to clean up)\n", state.PID)
+	}
+
+	return err
+}

--- a/cmd/proxy/stop.go
+++ b/cmd/proxy/stop.go
@@ -1,0 +1,49 @@
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/internal/proxystate"
+	"github.com/spf13/cobra"
+)
+
+func newStopCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the running persistent PMG proxy server",
+		RunE:  runStop,
+	}
+}
+
+func runStop(_ *cobra.Command, _ []string) error {
+	cfg := config.Get()
+	statePath := proxystate.StatePath(cfg.ConfigDir())
+
+	state, err := proxystate.Read(statePath)
+	if err != nil {
+		return fmt.Errorf("no proxy state found — is the proxy running? (%w)", err)
+	}
+
+	if !state.IsRunning() {
+		_ = proxystate.Remove(statePath)
+		return fmt.Errorf("proxy process (pid %d) is not running; state file cleaned up", state.PID)
+	}
+
+	proc, err := os.FindProcess(state.PID)
+	if err != nil {
+		return fmt.Errorf("find proxy process (pid %d): %w", state.PID, err)
+	}
+
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("send SIGTERM to proxy (pid %d): %w", state.PID, err)
+	}
+
+	if _, err := fmt.Fprintf(os.Stdout, "Sent SIGTERM to PMG proxy (pid %d, addr %s)\n", state.PID, state.Addr); err != nil {
+		return fmt.Errorf("write stop message: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/proxy/stop.go
+++ b/cmd/proxy/stop.go
@@ -4,10 +4,18 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+	"time"
 
+	"github.com/safedep/dry/usefulerror"
 	"github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/errcodes"
 	"github.com/safedep/pmg/internal/proxystate"
 	"github.com/spf13/cobra"
+)
+
+const (
+	stopPollInterval = 200 * time.Millisecond
+	stopPollTimeout  = 10 * time.Second
 )
 
 func newStopCommand() *cobra.Command {
@@ -41,8 +49,36 @@ func runStop(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("send SIGTERM to proxy (pid %d): %w", state.PID, err)
 	}
 
-	if _, err := fmt.Fprintf(os.Stdout, "Sent SIGTERM to PMG proxy (pid %d, addr %s)\n", state.PID, state.Addr); err != nil {
-		return fmt.Errorf("write stop message: %w", err)
+	// Wait for the process to exit so we can read the final blocked count it writes.
+	deadline := time.Now().Add(stopPollTimeout)
+	for time.Now().Before(deadline) {
+		if !state.IsRunning() {
+			break
+		}
+		time.Sleep(stopPollInterval)
+	}
+
+	// Read the final state the proxy wrote on shutdown (has BlockedCount).
+	final, rerr := proxystate.Read(statePath)
+	_ = proxystate.Remove(statePath)
+
+	if rerr != nil {
+		// Proxy exited but didn't write final state (e.g. crash). Treat as clean.
+		if _, werr := fmt.Fprintf(os.Stdout, "PMG proxy (pid %d) stopped\n", state.PID); werr != nil {
+			return werr
+		}
+		return nil
+	}
+
+	if _, werr := fmt.Fprintf(os.Stdout, "PMG proxy stopped — analyzed packages, %d blocked\n", final.BlockedCount); werr != nil {
+		return werr
+	}
+
+	if final.BlockedCount > 0 {
+		return usefulerror.NewUsefulError().
+			WithCode(errcodes.ProxyPackagesBlocked).
+			WithMsg(fmt.Sprintf("%d package(s) were blocked by the proxy", final.BlockedCount)).
+			WithHelp("Review the proxy logs for details on blocked packages")
 	}
 
 	return nil

--- a/errcodes/codes.go
+++ b/errcodes/codes.go
@@ -24,6 +24,9 @@ const (
 	CertTrustStore      = "CertTrustStore"
 	UnsupportedPlatform = "UnsupportedPlatform"
 
+	// Proxy error codes.
+	ProxyPackagesBlocked = "ProxyPackagesBlocked"
+
 	// Unknown mirrors the default code that dry/usefulerror returns for errors
 	// created without an explicit code, so unset and explicitly-unknown errors
 	// classify identically (e.g. the bug-report hint in ui.ErrorExit).

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,8 +1,5 @@
-buf.build/gen/go/bufbuild/protovalidate/connectrpc/go v1.20.0-20240508200655-46a4cf4ba109.1/go.mod h1:hR/w+cb6VNC4j0Rf91uvB2CMAcwIJ1cYxnGFwsP/w4k=
 buf.build/gen/go/bufbuild/protovalidate/grpc/go v1.6.1-20240508200655-46a4cf4ba109.1/go.mod h1:12iIaR0LjReZQXXxBXMzWTMUIN6n4Y3HuSTwPpUQYSg=
 buf.build/gen/go/bufbuild/protovalidate/grpc/go v1.6.2-20240508200655-46a4cf4ba109.1/go.mod h1:cz5A7G0AEk7z2kciJ1jK72u/8kRVlcfAhi2B9jYoMZw=
-buf.build/gen/go/safedep/api/connectrpc/go v1.20.0-20260620084912-77c7bb923ddb.1/go.mod h1:7HRi2R20XR03np5l5oGKAa/RRFVeuFtyiE/loG1/P+4=
-buf.build/go/protovalidate v1.2.0/go.mod h1:7rYiQEhqvAipoazpVNBBH2S2f8bjG4huMVy1V2Yofn4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.121.2/go.mod h1:nRFlrHq39MNVWu+zESP2PosMWA0ryJw8KUBZ2iZpxbw=
 cloud.google.com/go/auth v0.16.1/go.mod h1:1howDHJ5IETh/LwYs3ZxvlkXF48aSqqJUM+5o02dNOI=
@@ -12,7 +9,6 @@ cloud.google.com/go/iam v1.5.2/go.mod h1:SE1vg0N81zQqLzQEwxL2WI6yhetBdbNQuTvIKCS
 cloud.google.com/go/monitoring v1.24.2/go.mod h1:x7yzPWcgDRnPEv3sI+jJGBkwl5qINf+6qY4eq0I9B4U=
 cloud.google.com/go/profiler v0.4.3/go.mod h1:3xFodugWfPIQZWFcXdUmfa+yTiiyQ8fWrdT+d2Sg4J0=
 cloud.google.com/go/storage v1.55.0/go.mod h1:ztSmTTwzsdXe5syLVS0YsbFxXuvEmEyZj7v7zChEmuY=
-connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 deps.dev/api/v3 v3.0.0-20250307021655-d811e36f9cad/go.mod h1:o6PwfRErnKxbT8Sdij64ZMiTqMNxPsYwfymiyjXPh7A=
 deps.dev/api/v3alpha v0.0.0-20250429014815-ac0aa6a085fa/go.mod h1:qL3BV/n9j5WptUB9hWZrWM6yISapPTUYIQmHMWrGEmk=
@@ -39,7 +35,6 @@ github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOL
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
@@ -126,7 +121,6 @@ github.com/goark/go-cvss v1.6.7/go.mod h1:qsmYCGTQnQqW/Lq1Z3lRCEarKD++nx7C+KgsG0
 github.com/gohugoio/hashstructure v0.5.0/go.mod h1:Ser0TniXuu/eauYmrwM4o64EBvySxNzITEOLlm4igec=
 github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
-github.com/google/cel-go v0.28.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/go-containerregistry v0.19.1/go.mod h1:YCMFNQeeXeLF+dnhhWkqDItx/JSkH01j1Kis4PsjzFI=
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932/go.mod h1:cC6EdPbj/17GFCPDK39NRarlMI+kt+O60S12cNB5J9Y=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=

--- a/internal/flows/cert.go
+++ b/internal/flows/cert.go
@@ -1,0 +1,69 @@
+package flows
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/safedep/dry/log"
+	"github.com/safedep/pmg/proxy/certmanager"
+	"github.com/safedep/pmg/truststore"
+)
+
+// SetupCACertificate loads the persisted CA from configDir or generates an
+// ephemeral one, merges it with the system CA bundle, and writes the result
+// to outputPath. Returns the certificate, whether it was ephemeral, and any
+// error. The caller is responsible for cleaning up outputPath when ephemeral.
+func SetupCACertificate(configDir, outputPath string) (*certmanager.Certificate, bool, error) {
+	caCert, persisted := loadPersistedCA(configDir)
+	ephemeral := !persisted
+
+	if persisted {
+		log.Debugf("Using persisted CA certificate from %s", configDir)
+		warnIfCANotTrusted()
+	} else {
+		log.Debugf("Generating ephemeral CA certificate for proxy MITM")
+		generated, err := certmanager.GenerateCA(certmanager.DefaultCertManagerConfig())
+		if err != nil {
+			return nil, false, fmt.Errorf("generate CA certificate: %w", err)
+		}
+		caCert = generated
+	}
+
+	merged := certmanager.MergeWithSystemCA(caCert.Certificate)
+	if err := os.WriteFile(outputPath, merged, 0o600); err != nil {
+		return nil, false, fmt.Errorf("write CA certificate to %s: %w", outputPath, err)
+	}
+
+	log.Debugf("CA certificate written to %s", outputPath)
+	return caCert, ephemeral, nil
+}
+
+func loadPersistedCA(dir string) (*certmanager.Certificate, bool) {
+	caCert, err := certmanager.LoadCA(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warnf("Failed to load persisted CA, using ephemeral: %v", err)
+		}
+		return nil, false
+	}
+
+	if caCert.IsExpired(time.Hour) {
+		log.Warnf("Persisted CA is expired; using ephemeral. Re-run `pmg setup cert install`")
+		return nil, false
+	}
+
+	return caCert, true
+}
+
+func warnIfCANotTrusted() {
+	user, system, err := truststore.Status(certmanager.CACommonName)
+	if err != nil {
+		log.Debugf("Could not determine CA trust status: %v", err)
+		return
+	}
+
+	if !user && !system {
+		log.Warnf("Persisted CA is not trusted in the OS store; native tools may reject TLS. Run `pmg setup cert install`.")
+	}
+}

--- a/internal/flows/proxy_flow.go
+++ b/internal/flows/proxy_flow.go
@@ -2,7 +2,6 @@ package flows
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,7 +20,6 @@ import (
 	"github.com/safedep/pmg/proxy"
 	"github.com/safedep/pmg/proxy/certmanager"
 	"github.com/safedep/pmg/proxy/interceptors"
-	"github.com/safedep/pmg/truststore"
 )
 
 type proxyFlow struct {
@@ -329,69 +327,11 @@ func handleExecutionResultError(err error) error {
 	return fmt.Errorf("failed to execute command: %w", err)
 }
 
-// setupCACertificate prefers the persisted CA (created by `pmg setup cert install`)
-// so the proxy signs leaves with the same CA that is in the OS trust store. When no
-// persisted CA exists it falls back to an ephemeral per-run CA, preserving original
-// behavior. The temp file always carries the pure CA merged with the system bundle so
-// env-var trust injection works on every platform.
 func (f *proxyFlow) setupCACertificate() (*certmanager.Certificate, string, error) {
 	dir := config.Get().ConfigDir()
-
-	caCert, persisted := loadPersistedCA(dir)
-	if persisted {
-		log.Debugf("Using persisted CA certificate from %s", dir)
-		warnIfCANotTrusted()
-	} else {
-		log.Debugf("Generating ephemeral CA certificate for proxy MITM")
-		generated, err := certmanager.GenerateCA(certmanager.DefaultCertManagerConfig())
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to generate CA certificate: %w", err)
-		}
-		caCert = generated
-	}
-
-	mergedPEM := certmanager.MergeWithSystemCA(caCert.Certificate)
-
-	tempDir := os.TempDir()
-	caCertPath := filepath.Join(tempDir, fmt.Sprintf("pmg-ca-cert-%d.pem", os.Getpid()))
-	if err := os.WriteFile(caCertPath, mergedPEM, 0o600); err != nil {
-		return nil, "", fmt.Errorf("failed to write CA certificate to %s: %w", caCertPath, err)
-	}
-
-	log.Debugf("CA certificate written to %s", caCertPath)
-	return caCert, caCertPath, nil
-}
-
-// loadPersistedCA returns the on-disk CA when present and not expired.
-func loadPersistedCA(dir string) (*certmanager.Certificate, bool) {
-	caCert, err := certmanager.LoadCA(dir)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			log.Warnf("Failed to load persisted CA, using ephemeral: %v", err)
-		}
-		return nil, false
-	}
-
-	if caCert.IsExpired(time.Hour) {
-		log.Warnf("Persisted CA is expired; using ephemeral. Re-run `pmg setup cert install`")
-		return nil, false
-	}
-
-	return caCert, true
-}
-
-// warnIfCANotTrusted logs a hint when the persisted CA is not in any OS store,
-// which matters for native tools (e.g. Go on macOS/Windows) that ignore the
-// injected env vars. Best-effort; never blocks the run.
-func warnIfCANotTrusted() {
-	user, system, err := truststore.Status(certmanager.CACommonName)
-	if err != nil {
-		log.Debugf("Could not determine CA trust status: %v", err)
-		return
-	}
-	if !user && !system {
-		log.Warnf("Persisted CA is not trusted in the OS store; native tools may reject TLS. Run `pmg setup cert install`.")
-	}
+	outputPath := filepath.Join(os.TempDir(), fmt.Sprintf("pmg-ca-cert-%d.pem", os.Getpid()))
+	cert, _, err := SetupCACertificate(dir, outputPath)
+	return cert, outputPath, err
 }
 
 // createCertificateManager creates a certificate manager with the given CA certificate

--- a/internal/proxystate/state.go
+++ b/internal/proxystate/state.go
@@ -1,0 +1,56 @@
+package proxystate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const stateFileName = "proxy-state.json"
+
+type State struct {
+	PID        int    `json:"pid"`
+	Addr       string `json:"addr"`
+	CACertPath string `json:"ca_cert_path"`
+}
+
+func StatePath(configDir string) string {
+	return filepath.Join(configDir, stateFileName)
+}
+
+func Write(path string, s State) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("marshal proxy state: %w", err)
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func Read(path string) (State, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return State{}, fmt.Errorf("read proxy state: %w", err)
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return State{}, fmt.Errorf("unmarshal proxy state: %w", err)
+	}
+	return s, nil
+}
+
+func Remove(path string) error {
+	return os.Remove(path)
+}
+
+func (s State) IsRunning() bool {
+	if s.PID <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(s.PID)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/proxystate/state.go
+++ b/internal/proxystate/state.go
@@ -11,9 +11,10 @@ import (
 const stateFileName = "proxy-state.json"
 
 type State struct {
-	PID        int    `json:"pid"`
-	Addr       string `json:"addr"`
-	CACertPath string `json:"ca_cert_path"`
+	PID          int    `json:"pid"`
+	Addr         string `json:"addr"`
+	CACertPath   string `json:"ca_cert_path"`
+	BlockedCount int    `json:"blocked_count"`
 }
 
 func StatePath(configDir string) string {

--- a/internal/proxystate/state_test.go
+++ b/internal/proxystate/state_test.go
@@ -1,0 +1,56 @@
+package proxystate_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/safedep/pmg/internal/proxystate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteAndRead(t *testing.T) {
+	dir := t.TempDir()
+	path := proxystate.StatePath(dir)
+
+	s := proxystate.State{PID: 12345, Addr: "127.0.0.1:9999", CACertPath: "/tmp/ca.pem"}
+	require.NoError(t, proxystate.Write(path, s))
+
+	got, err := proxystate.Read(path)
+	require.NoError(t, err)
+	assert.Equal(t, s.PID, got.PID)
+	assert.Equal(t, s.Addr, got.Addr)
+	assert.Equal(t, s.CACertPath, got.CACertPath)
+}
+
+func TestReadMissingFile(t *testing.T) {
+	_, err := proxystate.Read(filepath.Join(t.TempDir(), "nonexistent.json"))
+	assert.Error(t, err)
+}
+
+func TestRemove(t *testing.T) {
+	dir := t.TempDir()
+	path := proxystate.StatePath(dir)
+
+	require.NoError(t, proxystate.Write(path, proxystate.State{PID: 1, Addr: "127.0.0.1:1"}))
+	require.NoError(t, proxystate.Remove(path))
+
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestIsRunningCurrentProcess(t *testing.T) {
+	s := proxystate.State{PID: os.Getpid(), Addr: "127.0.0.1:1"}
+	assert.True(t, s.IsRunning())
+}
+
+func TestIsRunningDeadPID(t *testing.T) {
+	s := proxystate.State{PID: 999999999}
+	assert.False(t, s.IsRunning())
+}
+
+func TestStatePath(t *testing.T) {
+	path := proxystate.StatePath("/some/config/dir")
+	assert.Equal(t, "/some/config/dir/proxy-state.json", path)
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/safedep/pmg/cmd/executors"
 	landlockCmd "github.com/safedep/pmg/cmd/landlock"
 	"github.com/safedep/pmg/cmd/npm"
+	proxyCmd "github.com/safedep/pmg/cmd/proxy"
 	"github.com/safedep/pmg/cmd/pypi"
 	sandboxCmd "github.com/safedep/pmg/cmd/sandbox"
 	"github.com/safedep/pmg/cmd/setup"
@@ -148,6 +149,7 @@ func main() {
 	cmd.AddCommand(pypi.NewUvCommand())
 	cmd.AddCommand(pypi.NewPoetryCommand())
 	cmd.AddCommand(executors.NewPipxCommand())
+	cmd.AddCommand(proxyCmd.NewProxyCommand())
 	cmd.AddCommand(version.NewVersionCommand())
 	cmd.AddCommand(setup.NewSetupCommand())
 	cmd.AddCommand(setup.NewRemoveCommand())


### PR DESCRIPTION
## Summary

- Adds `pmg proxy` command group with `start`, `stop`, `env`, and `status` subcommands
- The proxy runs persistently in the foreground, intercepting all npm/pip traffic without requiring PMG shim wrappers or aliases
- Designed for CI/CD pipelines (GitHub Actions) where env vars can be set globally for all steps

## How it works

```bash
# Start once (background in CI)
pmg proxy start &

# Inject env vars into the environment
eval $(pmg proxy env)       # local shell
pmg proxy env --gha         # GitHub Actions ($GITHUB_ENV)

# All subsequent package manager calls are intercepted automatically
npm install                 # no `pmg npm` wrapper needed
pip install requests
```

## GHA example

```yaml
- run: pmg proxy start &
- run: |
    sleep 1
    pmg proxy env --gha
- run: npm install          # intercepted, no pmg wrapper
- run: pip install -r requirements.txt
```

## Changes

- `internal/proxystate` — state file (pid/addr/ca-cert-path) with liveness check
- `internal/flows/cert.go` — extracted shared `SetupCACertificate` (removes duplication from `proxy_flow.go`)
- `cmd/proxy/{start,stop,env,status}.go` — command implementations
- `.github/workflows/persistent-proxy-e2e.yml` — E2E test for persistent proxy mode (trigger via `workflow_dispatch` on this branch)