### PR TITLE
ci: add E2E for pmg action server-mode

### DIFF
--- a/.github/actions/proxy-e2e-assertions/action.yml
+++ b/.github/actions/proxy-e2e-assertions/action.yml
@@ -1,0 +1,50 @@
+name: Proxy E2E Assertions
+description: >
+  Shared assertions for a running PMG persistent proxy. Assumes the proxy is
+  already started and HTTP_PROXY + CA env vars are exported into the job env.
+  Runs benign + malicious installs. The caller owns stopping the proxy (e.g.
+  pmg proxy stop --fail-on-violation) since teardown differs per setup.
+
+runs:
+  using: composite
+  steps:
+    - name: Verify proxy env is set
+      shell: bash
+      run: |
+        echo "HTTP_PROXY=$HTTP_PROXY"
+        test -n "$HTTP_PROXY"
+
+    - name: Benign npm install succeeds
+      shell: bash
+      run: |
+        mkdir benign-test && cd benign-test
+        npm init -y
+        npm install lodash@4.17.21
+        test -d node_modules/lodash
+        cd .. && rm -rf benign-test
+
+    - name: Malicious npm install is blocked
+      shell: bash
+      run: |
+        mkdir mal-npm && cd mal-npm
+        npm init -y
+        # The install MUST fail (proxy blocks it). Assert that, instead of
+        # continue-on-error which would hide a regression where it succeeds.
+        if npm --no-cache --prefer-online install safedep-test-pkg@0.1.3; then
+          echo "ERROR: malicious npm install succeeded but should have been blocked"
+          exit 1
+        fi
+        echo "OK: malicious npm install was blocked"
+        cd .. && rm -rf mal-npm
+
+    - name: Malicious pip install is blocked (python3 -m pip)
+      shell: bash
+      run: |
+        python3 -m venv venv && source venv/bin/activate
+        if python3 -m pip install safedep-test-pkg; then
+          echo "ERROR: malicious pip install succeeded but should have been blocked"
+          deactivate
+          exit 1
+        fi
+        echo "OK: malicious pip install was blocked"
+        deactivate && rm -rf venv

--- a/.github/workflows/persistent-proxy-e2e.yml
+++ b/.github/workflows/persistent-proxy-e2e.yml
@@ -24,7 +24,6 @@ jobs:
       SAFEDEP_API_KEY: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
       SAFEDEP_TENANT_ID: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN}}
       PMG_CLOUD_ENABLED: "true"
-      PMG_CLOUD_ENDPOINT_ID: github-actions/${{ github.repository }}
     defaults:
       run:
         shell: bash
@@ -60,49 +59,13 @@ jobs:
       - name: Inject proxy env
         run: pmg proxy env >> "$GITHUB_ENV"
 
-      - name: Verify proxy env is set
-        run: |
-          echo "HTTP_PROXY=$HTTP_PROXY"
-          test -n "$HTTP_PROXY"
-
-      - name: Benign npm install succeeds
-        run: |
-          mkdir benign-test && cd benign-test
-          npm init -y
-          npm install lodash@4.17.21
-          test -d node_modules/lodash
-          cd .. && rm -rf benign-test
-
-      - name: Malicious npm install is blocked
-        run: |
-          mkdir mal-npm && cd mal-npm
-          npm init -y
-          # The install MUST fail (proxy blocks it). Assert that, instead of
-          # continue-on-error which would hide a regression where it succeeds.
-          if npm --no-cache --prefer-online install safedep-test-pkg@0.1.3; then
-            echo "ERROR: malicious npm install succeeded but should have been blocked"
-            exit 1
-          fi
-          echo "OK: malicious npm install was blocked"
-          cd .. && rm -rf mal-npm
-
-      - name: Malicious pip install is blocked (python3 -m pip)
-        run: |
-          python3 -m venv venv && source venv/bin/activate
-          if python3 -m pip install safedep-test-pkg; then
-            echo "ERROR: malicious pip install succeeded but should have been blocked"
-            deactivate
-            exit 1
-          fi
-          echo "OK: malicious pip install was blocked"
-          deactivate && rm -rf venv
+      - name: Run proxy E2E assertions
+        uses: ./.github/actions/proxy-e2e-assertions
 
       - name: Stop proxy and verify it fails on the blocks
         if: always()
+        shell: bash
         run: |
-          # We blocked packages above, so --fail-on-violation must exit non-zero.
-          # Assert that (a green test means the gate works), and always run so the
-          # daemon is stopped even if an earlier step failed.
           if pmg proxy stop --fail-on-violation; then
             echo "ERROR: stop should have exited non-zero (packages were blocked)"
             exit 1

--- a/.github/workflows/pmg-action-e2e.yml
+++ b/.github/workflows/pmg-action-e2e.yml
@@ -44,43 +44,12 @@ jobs:
           api-key: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
           tenant-id: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN }}
 
-      - name: Verify proxy env is set by the action
-        run: |
-          echo "HTTP_PROXY=$HTTP_PROXY"
-          test -n "$HTTP_PROXY"
-
-      - name: Benign npm install succeeds
-        run: |
-          mkdir benign-test && cd benign-test
-          npm init -y
-          npm install lodash@4.17.21
-          test -d node_modules/lodash
-          cd .. && rm -rf benign-test
-
-      - name: Malicious npm install is blocked
-        run: |
-          mkdir mal-npm && cd mal-npm
-          npm init -y
-          if npm --no-cache --prefer-online install safedep-test-pkg@0.1.3; then
-            echo "ERROR: malicious npm install succeeded but should have been blocked"
-            exit 1
-          fi
-          echo "OK: malicious npm install was blocked"
-          cd .. && rm -rf mal-npm
-
-      - name: Malicious pip install is blocked (python3 -m pip)
-        run: |
-          python3 -m venv venv && source venv/bin/activate
-          if python3 -m pip install safedep-test-pkg; then
-            echo "ERROR: malicious pip install succeeded but should have been blocked"
-            deactivate
-            exit 1
-          fi
-          echo "OK: malicious pip install was blocked"
-          deactivate && rm -rf venv
+      - name: Run proxy E2E assertions
+        uses: ./.github/actions/proxy-e2e-assertions
 
       - name: Stop proxy and verify it fails on the blocks
         if: always()
+        shell: bash
         run: |
           if pmg proxy stop --fail-on-violation; then
             echo "ERROR: stop should have exited non-zero (packages were blocked)"

--- a/.github/workflows/pmg-action-e2e.yml
+++ b/.github/workflows/pmg-action-e2e.yml
@@ -1,0 +1,89 @@
+# .github/workflows/pmg-action-e2e.yml
+name: PMG Server Action E2E
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "action.yml"
+      - "cmd/proxy/**"
+      - "internal/proxyserver/**"
+      - "internal/flows/cert.go"
+
+permissions:
+  contents: read
+
+jobs:
+  pmg-action-server-e2e:
+    name: PMG Server Action E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Run PMG action in server mode
+        uses: ./ # action.yml
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN }}
+
+      - name: Verify proxy env is set by the action
+        run: |
+          echo "HTTP_PROXY=$HTTP_PROXY"
+          test -n "$HTTP_PROXY"
+
+      - name: Benign npm install succeeds
+        run: |
+          mkdir benign-test && cd benign-test
+          npm init -y
+          npm install lodash@4.17.21
+          test -d node_modules/lodash
+          cd .. && rm -rf benign-test
+
+      - name: Malicious npm install is blocked
+        run: |
+          mkdir mal-npm && cd mal-npm
+          npm init -y
+          if npm --no-cache --prefer-online install safedep-test-pkg@0.1.3; then
+            echo "ERROR: malicious npm install succeeded but should have been blocked"
+            exit 1
+          fi
+          echo "OK: malicious npm install was blocked"
+          cd .. && rm -rf mal-npm
+
+      - name: Malicious pip install is blocked (python3 -m pip)
+        run: |
+          python3 -m venv venv && source venv/bin/activate
+          if python3 -m pip install safedep-test-pkg; then
+            echo "ERROR: malicious pip install succeeded but should have been blocked"
+            deactivate
+            exit 1
+          fi
+          echo "OK: malicious pip install was blocked"
+          deactivate && rm -rf venv
+
+      - name: Stop proxy and verify it fails on the blocks
+        if: always()
+        run: |
+          if pmg proxy stop --fail-on-violation; then
+            echo "ERROR: stop should have exited non-zero (packages were blocked)"
+            exit 1
+          fi
+          echo "OK: stop correctly failed on the policy violation"


### PR DESCRIPTION
## What

Adds `.github/workflows/pmg-action-e2e.yml` — an E2E that exercises the `safedep/pmg` action with `server-mode: true`, the path documented in [docs/persistent-proxy.md](../blob/main/docs/persistent-proxy.md).

The action starts the proxy daemon and injects `HTTP_PROXY` + CA env vars, then bare package managers are intercepted:

- benign `npm install lodash` succeeds (proxy + CA trust wired correctly)
- malicious `npm install safedep-test-pkg` is blocked (403 → non-zero exit)
- malicious `pip install safedep-test-pkg` is blocked
- `pmg proxy stop --fail-on-violation` exits non-zero on the blocks (the CI gate)

## Why a separate file

Mirrors the existing `persistent-proxy-e2e.yml`, which tests the raw `pmg proxy start/env/stop` commands. This is its sibling: same flow, but driven through `action.yml`. Keeping it separate keeps the one-workflow-per-concern pattern, lets it carry its own targeted `paths:` filter, and isolates the cloud-secret dependency from the secret-free `pmg-e2e.yml`.

## Scope note

`uses: ./` installs a **released** `pmg` binary (the action only downloads from releases), so this validates the **action's server-mode orchestration** against a real release. The branch's proxy internals remain covered by `persistent-proxy-e2e.yml`.

Triggered on `action.yml` / `cmd/proxy/**` / `internal/proxyserver/**` / `internal/flows/cert.go` changes, plus manual `workflow_dispatch`.