### PR TITLE
feat(sandbox): add network_via_proxy_only and allow_direct_dns policy fields

### DIFF
--- a/sandbox/lint.go
+++ b/sandbox/lint.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/safedep/dry/utils"
 	"github.com/safedep/pmg/sandbox/util"
 )
 
@@ -117,6 +118,15 @@ func LintProfile(policy *SandboxPolicy) []LintIssue {
 				Rule:    rule,
 			})
 		}
+	}
+
+	if utils.SafelyGetValue(policy.AllowDirectDNS) && !utils.SafelyGetValue(policy.NetworkViaProxyOnly) {
+		warns = append(warns, LintIssue{
+			Level:   LintLevelWarn,
+			Code:    "allow-direct-dns-without-lockdown",
+			Message: "allow_direct_dns has no effect unless network_via_proxy_only is true",
+			Field:   "allow_direct_dns",
+		})
 	}
 
 	conflictPairs := []struct {

--- a/sandbox/lint_test.go
+++ b/sandbox/lint_test.go
@@ -262,7 +262,8 @@ func TestLintProfile_AllowDirectDNSWithoutLockdown(t *testing.T) {
 			var found *LintIssue
 			for _, i := range LintProfile(policy) {
 				if i.Code == "allow-direct-dns-without-lockdown" {
-					found = &i
+					issue := i
+					found = &issue
 					break
 				}
 			}

--- a/sandbox/lint_test.go
+++ b/sandbox/lint_test.go
@@ -3,7 +3,9 @@ package sandbox
 import (
 	"testing"
 
+	"github.com/safedep/dry/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // cleanPolicy returns a minimally-valid policy with no lint issues.
@@ -228,5 +230,52 @@ func TestLintProfile_OrderingErrorsBeforeWarnsBeforeInfo(t *testing.T) {
 		case LintLevelInfo:
 			phase = 2
 		}
+	}
+}
+
+func TestLintProfile_AllowDirectDNSWithoutLockdown(t *testing.T) {
+	tests := []struct {
+		name                string
+		allowDirectDNS      *bool
+		networkViaProxyOnly *bool
+		wantWarn            bool
+	}{
+		{
+			name:           "allow_direct_dns without lockdown warns",
+			allowDirectDNS: utils.PtrTo(true),
+			wantWarn:       true,
+		},
+		{
+			name:                "allow_direct_dns with lockdown is clean",
+			allowDirectDNS:      utils.PtrTo(true),
+			networkViaProxyOnly: utils.PtrTo(true),
+			wantWarn:            false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := cleanPolicy()
+			policy.AllowDirectDNS = tc.allowDirectDNS
+			policy.NetworkViaProxyOnly = tc.networkViaProxyOnly
+
+			var found *LintIssue
+			for _, i := range LintProfile(policy) {
+				if i.Code == "allow-direct-dns-without-lockdown" {
+					found = &i
+					break
+				}
+			}
+
+			if !tc.wantWarn {
+				assert.Nil(t, found)
+				return
+			}
+
+			require.NotNil(t, found)
+			assert.Equal(t, LintLevelWarn, found.Level)
+			assert.Equal(t, "allow_direct_dns", found.Field)
+			assert.Equal(t, "allow_direct_dns has no effect unless network_via_proxy_only is true", found.Message)
+		})
 	}
 }

--- a/sandbox/policy.go
+++ b/sandbox/policy.go
@@ -38,6 +38,16 @@ type SandboxPolicy struct {
 
 	// AllowNetworkBind allows binding to localhost (127.0.0.1 / ::1) for listening.
 	AllowNetworkBind *bool `yaml:"allow_network_bind" json:"allow_network_bind"`
+
+	// NetworkViaProxyOnly confines all outbound network access to the PMG
+	// proxy. Requires the proxy flow; drivers fail closed without a running
+	// proxy.
+	NetworkViaProxyOnly *bool `yaml:"network_via_proxy_only" json:"network_via_proxy_only"`
+
+	// AllowDirectDNS re-opens direct DNS (mDNSResponder) under
+	// NetworkViaProxyOnly. No effect otherwise. Default false: the proxy
+	// resolves names and direct DNS is an exfiltration channel.
+	AllowDirectDNS *bool `yaml:"allow_direct_dns" json:"allow_direct_dns"`
 }
 
 // FilesystemPolicy defines allowed and denied filesystem access patterns.
@@ -161,6 +171,14 @@ func (child *SandboxPolicy) MergeWithParent(parent *SandboxPolicy) {
 
 	if child.AllowNetworkBind == nil {
 		child.AllowNetworkBind = utils.PtrTo(utils.SafelyGetValue(parent.AllowNetworkBind))
+	}
+
+	if child.NetworkViaProxyOnly == nil {
+		child.NetworkViaProxyOnly = utils.PtrTo(utils.SafelyGetValue(parent.NetworkViaProxyOnly))
+	}
+
+	if child.AllowDirectDNS == nil {
+		child.AllowDirectDNS = utils.PtrTo(utils.SafelyGetValue(parent.AllowDirectDNS))
 	}
 }
 

--- a/sandbox/policy_test.go
+++ b/sandbox/policy_test.go
@@ -286,3 +286,83 @@ func TestValidateResolved(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeWithParentNetworkViaProxyOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		parent   *bool
+		child    *bool
+		expected bool
+	}{
+		{
+			name:     "child overrides parent false with true",
+			parent:   utils.PtrTo(false),
+			child:    utils.PtrTo(true),
+			expected: true,
+		},
+		{
+			name:     "child nil inherits parent true",
+			parent:   utils.PtrTo(true),
+			child:    nil,
+			expected: true,
+		},
+		{
+			name:     "both nil defaults to false",
+			parent:   nil,
+			child:    nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := &SandboxPolicy{NetworkViaProxyOnly: tt.parent}
+			child := &SandboxPolicy{NetworkViaProxyOnly: tt.child}
+
+			child.MergeWithParent(parent)
+
+			assert.NotNil(t, child.NetworkViaProxyOnly)
+			assert.Equal(t, tt.expected, *child.NetworkViaProxyOnly)
+		})
+	}
+}
+
+func TestMergeWithParentAllowDirectDNS(t *testing.T) {
+	tests := []struct {
+		name     string
+		parent   *bool
+		child    *bool
+		expected bool
+	}{
+		{
+			name:     "child overrides parent false with true",
+			parent:   utils.PtrTo(false),
+			child:    utils.PtrTo(true),
+			expected: true,
+		},
+		{
+			name:     "child nil inherits parent true",
+			parent:   utils.PtrTo(true),
+			child:    nil,
+			expected: true,
+		},
+		{
+			name:     "both nil defaults to false",
+			parent:   nil,
+			child:    nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := &SandboxPolicy{AllowDirectDNS: tt.parent}
+			child := &SandboxPolicy{AllowDirectDNS: tt.child}
+
+			child.MergeWithParent(parent)
+
+			assert.NotNil(t, child.AllowDirectDNS)
+			assert.Equal(t, tt.expected, *child.AllowDirectDNS)
+		})
+	}
+}

--- a/sandbox/resolve.go
+++ b/sandbox/resolve.go
@@ -39,6 +39,12 @@ func expandPolicyPaths(p *SandboxPolicy, opts ResolveOptions) (*SandboxPolicy, e
 	if p.AllowNetworkBind != nil {
 		out.AllowNetworkBind = utils.PtrTo(*p.AllowNetworkBind)
 	}
+	if p.NetworkViaProxyOnly != nil {
+		out.NetworkViaProxyOnly = utils.PtrTo(*p.NetworkViaProxyOnly)
+	}
+	if p.AllowDirectDNS != nil {
+		out.AllowDirectDNS = utils.PtrTo(*p.AllowDirectDNS)
+	}
 
 	allowRead, err := expandSlice(p.Filesystem.AllowRead, opts)
 	if err != nil {

--- a/sandbox/resolve_test.go
+++ b/sandbox/resolve_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/safedep/dry/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -119,4 +120,35 @@ func TestResolveProfileDoesNotMutateRegistry(t *testing.T) {
 	after, err := registry.GetProfile("npm-restrictive")
 	require.NoError(t, err)
 	assert.Equal(t, originalAllowRead, after.Filesystem.AllowRead, "registry profile must not be mutated")
+}
+
+func TestExpandPolicyPathsIsolatesBoolPointers(t *testing.T) {
+	source := &SandboxPolicy{
+		Name:                "ptr-isolation",
+		PackageManagers:     []string{"npm"},
+		Filesystem:          FilesystemPolicy{AllowRead: []string{"/tmp"}},
+		AllowGitConfig:      utils.PtrTo(true),
+		AllowPTY:            utils.PtrTo(true),
+		AllowNetworkBind:    utils.PtrTo(true),
+		NetworkViaProxyOnly: utils.PtrTo(true),
+		AllowDirectDNS:      utils.PtrTo(true),
+	}
+
+	resolved, err := expandPolicyPaths(source, ResolveOptions{CWD: "/x", Home: "/y"})
+	require.NoError(t, err)
+
+	fields := []struct {
+		name             string
+		source, resolved *bool
+	}{
+		{"AllowGitConfig", source.AllowGitConfig, resolved.AllowGitConfig},
+		{"AllowPTY", source.AllowPTY, resolved.AllowPTY},
+		{"AllowNetworkBind", source.AllowNetworkBind, resolved.AllowNetworkBind},
+		{"NetworkViaProxyOnly", source.NetworkViaProxyOnly, resolved.NetworkViaProxyOnly},
+		{"AllowDirectDNS", source.AllowDirectDNS, resolved.AllowDirectDNS},
+	}
+	for _, f := range fields {
+		assert.NotSame(t, f.source, f.resolved, f.name)
+		assert.Equal(t, *f.source, *f.resolved, f.name)
+	}
 }


### PR DESCRIPTION
## Summary

Config surface for the network-lockdown capability (M0). Two new pointer-bool fields on `SandboxPolicy`, following the exact `AllowPTY`/`AllowGitConfig`/`AllowNetworkBind` pattern:

- `network_via_proxy_only` — confines a sandboxed package manager's outbound network to the PMG proxy (enforcement lands in M0.2/M0.3).
- `allow_direct_dns` — its escape hatch re-opening direct DNS (mDNSResponder) under lockdown; no effect otherwise, default false since the proxy resolves names and direct DNS is an exfiltration channel.

Both get nil-aware inheritance in `MergeWithParent` (child overrides parent when non-nil). `LintProfile` warns (`allow-direct-dns-without-lockdown`) on the meaningless combination of `allow_direct_dns` without `network_via_proxy_only`.

No behavior change anywhere: the fields are declared and inherited but unread — readers land in M0.2/M0.3 (`policy.NetworkViaProxyOnly`, `policy.AllowDirectDNS`).

## Tests

- `TestMergeWithParentNetworkViaProxyOnly` / `TestMergeWithParentAllowDirectDNS` — child overrides parent false→true; child nil inherits parent true; both nil defaults false with non-nil pointer after merge.
- `TestLintProfile_AllowDirectDNSWithoutLockdown` — warning present with exact code/level/field when only `allow_direct_dns` set; absent when `network_via_proxy_only` is also true.
- `go test ./sandbox/... -count=1` green; `GOOS=darwin` and `GOOS=windows` builds clean.

Tracking: [FOU-199](https://linear.app/safedep/issue/FOU-199/m01-policy-schema-network-via-proxy-only-and-allow-direct-dns-fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqMU5GNBbQvQct9nxek1VS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqMU5GNBbQvQct9nxek1VS)_