### PR TITLE
feat(sandbox): actionable violation message for lockdown network denials

### DIFF
--- a/sandbox/platform/seatbelt_diagnostics_darwin.go
+++ b/sandbox/platform/seatbelt_diagnostics_darwin.go
@@ -324,6 +324,9 @@ func summarizeSeatbeltViolation(kind, target string) string {
 		}
 		return fmt.Sprintf("network bind denied: %s", target)
 	case "network-outbound":
+		if target == "direct" {
+			return "direct network access blocked by network_via_proxy_only — traffic must flow through the PMG proxy (a tool may have ignored HTTP_PROXY/HTTPS_PROXY)"
+		}
 		if target == "" {
 			return "network connect denied"
 		}

--- a/sandbox/platform/seatbelt_diagnostics_darwin.go
+++ b/sandbox/platform/seatbelt_diagnostics_darwin.go
@@ -143,6 +143,14 @@ func extractSeatbeltViolations(entries []seatbeltLogEntry, runID string) []sandb
 			target = extractSeatbeltDeniedToken(entry.EventMessage, payload)
 		}
 
+		// The lockdown deny marker (target=direct) is authoritative for the
+		// human message even when the raw operand is path-shaped (e.g. the
+		// mDNSResponder unix socket); Target keeps the denied operand.
+		labelTarget := target
+		if labelKind == "network-outbound" && payload.Target == "direct" {
+			labelTarget = payload.Target
+		}
+
 		violations = append(violations, sandbox.Violation{
 			Kind:       kind,
 			RawKind:    payload.Kind,
@@ -150,7 +158,7 @@ func extractSeatbeltViolations(entries []seatbeltLogEntry, runID string) []sandb
 			RuleTarget: payload.Target,
 			Process:    process,
 			RawLog:     strings.TrimSpace(entry.EventMessage),
-			RuleLabel:  summarizeSeatbeltViolation(labelKind, target),
+			RuleLabel:  summarizeSeatbeltViolation(labelKind, labelTarget),
 		})
 	}
 

--- a/sandbox/platform/seatbelt_diagnostics_darwin.go
+++ b/sandbox/platform/seatbelt_diagnostics_darwin.go
@@ -147,7 +147,7 @@ func extractSeatbeltViolations(entries []seatbeltLogEntry, runID string) []sandb
 		// human message even when the raw operand is path-shaped (e.g. the
 		// mDNSResponder unix socket); Target keeps the denied operand.
 		labelTarget := target
-		if labelKind == "network-outbound" && payload.Target == "direct" {
+		if labelKind == seatbeltKindNetworkOutbound && payload.Target == seatbeltLockdownTargetDirect {
 			labelTarget = payload.Target
 		}
 
@@ -204,8 +204,8 @@ func inferSeatbeltKindFromRawLog(raw string) (sandbox.ViolationKind, string, boo
 		return sandbox.ViolationKindExec, "process-exec", true
 	case verb == "network-bind":
 		return sandbox.ViolationKindNetworkBind, "network-bind", true
-	case verb == "network-outbound":
-		return sandbox.ViolationKindNetworkConnect, "network-outbound", true
+	case verb == seatbeltKindNetworkOutbound:
+		return sandbox.ViolationKindNetworkConnect, seatbeltKindNetworkOutbound, true
 	}
 
 	return sandbox.ViolationKindGenericDeny, "", false
@@ -331,8 +331,8 @@ func summarizeSeatbeltViolation(kind, target string) string {
 			return "network bind denied"
 		}
 		return fmt.Sprintf("network bind denied: %s", target)
-	case "network-outbound":
-		if target == "direct" {
+	case seatbeltKindNetworkOutbound:
+		if target == seatbeltLockdownTargetDirect {
 			return "direct network access blocked by network_via_proxy_only — traffic must flow through the PMG proxy (a tool may have ignored HTTP_PROXY/HTTPS_PROXY)"
 		}
 		if target == "" {

--- a/sandbox/platform/seatbelt_diagnostics_darwin_test.go
+++ b/sandbox/platform/seatbelt_diagnostics_darwin_test.go
@@ -218,6 +218,9 @@ func TestInferSeatbeltKindFromRawLog(t *testing.T) {
 	}
 }
 
+// Normative copy, quoted by docs (M0.6); changes here are breaking.
+const lockdownDirectDenialMessage = "direct network access blocked by network_via_proxy_only — traffic must flow through the PMG proxy (a tool may have ignored HTTP_PROXY/HTTPS_PROXY)"
+
 func TestExtractSeatbeltViolationsLockdownDirectDenial(t *testing.T) {
 	entries := []seatbeltLogEntry{
 		{
@@ -236,8 +239,25 @@ func TestExtractSeatbeltViolationsLockdownDirectDenial(t *testing.T) {
 	require.Len(t, violations, 2)
 
 	assert.Equal(t, sandbox.ViolationKindNetworkConnect, violations[0].Kind)
-	assert.Contains(t, violations[0].RuleLabel, "direct network access blocked by network_via_proxy_only")
+	assert.Equal(t, lockdownDirectDenialMessage, violations[0].RuleLabel)
 
 	assert.Equal(t, sandbox.ViolationKindNetworkConnect, violations[1].Kind)
 	assert.Equal(t, "network connect denied: 1.2.3.4:443", violations[1].RuleLabel)
+}
+
+func TestExtractSeatbeltViolationsLockdownDenialWithPathOperand(t *testing.T) {
+	entries := []seatbeltLogEntry{
+		{
+			EventMessage: `Sandbox: node(125) deny(1) network-outbound /private/var/run/mDNSResponder ` +
+				seatbeltLogMessage("run-1", "network-outbound", "direct"),
+			Process: "node",
+		},
+	}
+
+	violations := extractSeatbeltViolations(entries, "run-1")
+	require.Len(t, violations, 1)
+
+	assert.Equal(t, sandbox.ViolationKindNetworkConnect, violations[0].Kind)
+	assert.Equal(t, "/private/var/run/mDNSResponder", violations[0].Target)
+	assert.Equal(t, lockdownDirectDenialMessage, violations[0].RuleLabel)
 }

--- a/sandbox/platform/seatbelt_diagnostics_darwin_test.go
+++ b/sandbox/platform/seatbelt_diagnostics_darwin_test.go
@@ -217,3 +217,27 @@ func TestInferSeatbeltKindFromRawLog(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractSeatbeltViolationsLockdownDirectDenial(t *testing.T) {
+	entries := []seatbeltLogEntry{
+		{
+			EventMessage: `Sandbox: curl(123) deny(1) network-outbound ` +
+				seatbeltLogMessage("run-1", "network-outbound", "direct"),
+			Process: "curl",
+		},
+		{
+			EventMessage: `Sandbox: curl(124) deny(1) network-outbound ` +
+				seatbeltLogMessage("run-1", "network-outbound", "1.2.3.4:443"),
+			Process: "curl",
+		},
+	}
+
+	violations := extractSeatbeltViolations(entries, "run-1")
+	require.Len(t, violations, 2)
+
+	assert.Equal(t, sandbox.ViolationKindNetworkConnect, violations[0].Kind)
+	assert.Contains(t, violations[0].RuleLabel, "direct network access blocked by network_via_proxy_only")
+
+	assert.Equal(t, sandbox.ViolationKindNetworkConnect, violations[1].Kind)
+	assert.Equal(t, "network connect denied: 1.2.3.4:443", violations[1].RuleLabel)
+}

--- a/sandbox/platform/seatbelt_translator_darwin.go
+++ b/sandbox/platform/seatbelt_translator_darwin.go
@@ -29,6 +29,13 @@ func generateLogTag() string {
 	return fmt.Sprintf("PMG_SBX_%s", randomStr[:12])
 }
 
+// Shared vocabulary between rule emission (translator) and violation
+// parsing (diagnostics); a drift between the two breaks message rendering.
+const (
+	seatbeltKindNetworkOutbound  = "network-outbound"
+	seatbeltLockdownTargetDirect = "direct"
+)
+
 func seatbeltLogMessage(runID, kind, target string) string {
 	return fmt.Sprintf("PMG_SBX|run=%s|kind=%s|target=%s", runID, kind, url.QueryEscape(target))
 }
@@ -615,7 +622,7 @@ func (t *seatbeltPolicyTranslator) translateNetwork(policy *sandbox.SandboxPolic
 	if utils.SafelyGetValue(policy.NetworkViaProxyOnly) {
 		sb.WriteString(";; network_via_proxy_only: all outbound confined to the PMG proxy\n")
 		sb.WriteString("(deny network-outbound (with message \"")
-		sb.WriteString(seatbeltLogMessage(t.logTag, "network-outbound", "direct"))
+		sb.WriteString(seatbeltLogMessage(t.logTag, seatbeltKindNetworkOutbound, seatbeltLockdownTargetDirect))
 		sb.WriteString("\"))\n")
 
 		// Without a running proxy (render/inspection, e.g. `pmg sandbox


### PR DESCRIPTION
## Summary

Under `network_via_proxy_only`, "a tool ignored HTTP_PROXY and connected directly" will be the single most common violation users hit. The lockdown deny rule (from #372) emits `target=direct`; the Seatbelt diagnostics message renderer now special-cases it:

> direct network access blocked by network_via_proxy_only — traffic must flow through the PMG proxy (a tool may have ignored HTTP_PROXY/HTTPS_PROXY)

This message copy is normative — the M0.6 docs quote it. Non-direct targets keep rendering `network connect denied: <target>` (regression-asserted), empty targets keep the generic message.

## Tests

`TestExtractSeatbeltViolationsLockdownDirectDenial` feeds raw violation log lines through the existing parsing helpers: the `target=direct` marker classifies as `ViolationKindNetworkConnect` and renders the lockdown message; a `target=1.2.3.4:443` marker still renders the plain denial. `go test ./sandbox/... -count=1` green; darwin vet clean.

Tracking: [FOU-202](https://linear.app/safedep/issue/FOU-202/m04-actionable-violation-message-for-lockdown-network-denials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqMU5GNBbQvQct9nxek1VS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqMU5GNBbQvQct9nxek1VS)_