### PR TITLE
test(sandbox): darwin end-to-end lockdown enforcement test

### DIFF
--- a/sandbox/platform/lockdown_integration_darwin_test.go
+++ b/sandbox/platform/lockdown_integration_darwin_test.go
@@ -214,7 +214,7 @@ func TestLockdownEnforcementDarwin(t *testing.T) {
 		assert.NoError(t, err, "DNS must pass with allow_direct_dns")
 	})
 
-	t.Run("allow_direct_dns with network bind (diagnostic)", func(t *testing.T) {
+	t.Run("allow_direct_dns with network bind", func(t *testing.T) {
 		policy := lockdownTestPolicy(t)
 		policy.AllowDirectDNS = utils.PtrTo(true)
 		policy.AllowNetworkBind = utils.PtrTo(true)

--- a/sandbox/platform/lockdown_integration_darwin_test.go
+++ b/sandbox/platform/lockdown_integration_darwin_test.go
@@ -1,0 +1,219 @@
+//go:build darwin
+
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/safedep/dry/utils"
+	"github.com/safedep/pmg/sandbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const lockdownHelperEnv = "PMG_LOCKDOWN_HELPER"
+
+// TestLockdownHelperProcess is not a test: it is the child process re-executed
+// under sandbox-exec by the lockdown integration test below. It performs the
+// network checks described by its environment and exits 0 only when every
+// check agrees with its expectation.
+func TestLockdownHelperProcess(t *testing.T) {
+	if os.Getenv(lockdownHelperEnv) != "1" {
+		t.Skip("helper process only")
+	}
+
+	failed := false
+	report := func(name string, ok bool) {
+		fmt.Printf("check %s: ok=%v\n", name, ok)
+		if !ok {
+			failed = true
+		}
+	}
+
+	if addr := os.Getenv("PMG_DIAL_MUST_PASS"); addr != "" {
+		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+		report("dial-must-pass "+addr, err == nil)
+		if conn != nil {
+			_ = conn.Close()
+		}
+	}
+
+	if addr := os.Getenv("PMG_DIAL_MUST_FAIL"); addr != "" {
+		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+		report("dial-must-fail "+addr, err != nil)
+		if conn != nil {
+			_ = conn.Close()
+		}
+	}
+
+	if host := os.Getenv("PMG_RESOLVE"); host != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_, err := net.DefaultResolver.LookupHost(ctx, host)
+		wantPass := os.Getenv("PMG_RESOLVE_MUST_PASS") == "1"
+		report(fmt.Sprintf("resolve %s (wantPass=%v)", host, wantPass), (err == nil) == wantPass)
+	}
+
+	if os.Getenv("PMG_SELF_DIAL") == "1" {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			report("self-dial listen", false)
+		} else {
+			go func() {
+				conn, aerr := ln.Accept()
+				if aerr == nil {
+					_ = conn.Close()
+				}
+			}()
+			conn, derr := net.DialTimeout("tcp", ln.Addr().String(), 2*time.Second)
+			report("self-dial "+ln.Addr().String(), derr == nil)
+			if conn != nil {
+				_ = conn.Close()
+			}
+			_ = ln.Close()
+		}
+	}
+
+	if failed {
+		os.Exit(1)
+	}
+}
+
+func requireSandboxExec(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("sandbox-exec"); err != nil {
+		// Skips must not hide security tests in CI (see ci.yml).
+		if os.Getenv("CI") != "" {
+			t.Fatal("sandbox-exec required in CI")
+		}
+		t.Skip("sandbox-exec not available")
+	}
+}
+
+func mustListenLoopback(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	return ln
+}
+
+func lockdownTestPolicy(t *testing.T) *sandbox.SandboxPolicy {
+	t.Helper()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	return &sandbox.SandboxPolicy{
+		Name:            "lockdown-e2e",
+		PackageManagers: []string{"npm"},
+		Filesystem: sandbox.FilesystemPolicy{
+			AllowRead: []string{
+				cwd + "/**",
+				filepath.Dir(exe) + "/**",
+				os.TempDir() + "/**",
+				"/private/tmp/**",
+				"/usr/lib/**",
+				"/System/**",
+			},
+			AllowWrite: []string{
+				os.TempDir() + "/**",
+				"/private/tmp/**",
+				"/dev/null",
+			},
+		},
+		NetworkViaProxyOnly: utils.PtrTo(true),
+	}
+}
+
+func writeTempProfile(t *testing.T, policy *sandbox.SandboxPolicy, proxyAddr string) string {
+	t.Helper()
+	profile, err := newSeatbeltPolicyTranslator().translate(policy,
+		&sandbox.ExecutionContext{ProxyAddr: proxyAddr})
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp("", "pmg-lockdown-e2e-*.sb")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
+	_, err = f.WriteString(profile)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func runSandboxedHelper(t *testing.T, profilePath string, env map[string]string) error {
+	t.Helper()
+	cmd := exec.Command("/usr/bin/sandbox-exec", "-f", profilePath,
+		os.Args[0], "-test.run", "^TestLockdownHelperProcess$", "-test.v")
+	cmd.Env = append(os.Environ(), lockdownHelperEnv+"=1")
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	out, err := cmd.CombinedOutput()
+	t.Logf("sandboxed helper output:\n%s", out)
+	return err
+}
+
+func TestLockdownEnforcementDarwin(t *testing.T) {
+	requireSandboxExec(t)
+
+	proxyLn := mustListenLoopback(t)
+	otherLn := mustListenLoopback(t)
+
+	t.Run("base lockdown", func(t *testing.T) {
+		profile := writeTempProfile(t, lockdownTestPolicy(t), proxyLn.Addr().String())
+		err := runSandboxedHelper(t, profile, map[string]string{
+			"PMG_DIAL_MUST_PASS": proxyLn.Addr().String(),
+			"PMG_DIAL_MUST_FAIL": otherLn.Addr().String(),
+			"PMG_RESOLVE":        "example.com",
+		})
+		assert.NoError(t, err, "proxy dial must pass, direct dial and DNS must fail")
+	})
+
+	t.Run("allow_direct_dns re-opens DNS", func(t *testing.T) {
+		policy := lockdownTestPolicy(t)
+		policy.AllowDirectDNS = utils.PtrTo(true)
+		profile := writeTempProfile(t, policy, proxyLn.Addr().String())
+		err := runSandboxedHelper(t, profile, map[string]string{
+			"PMG_DIAL_MUST_PASS":    proxyLn.Addr().String(),
+			"PMG_RESOLVE":           "example.com",
+			"PMG_RESOLVE_MUST_PASS": "1",
+		})
+		assert.NoError(t, err, "DNS must pass with allow_direct_dns")
+	})
+
+	// Gating check for the milestone: allow_network_bind's
+	// (allow network* (local ip "localhost:*")) rules are emitted after the
+	// lockdown deny and are expected to keep loopback->loopback connects
+	// working. If this sub-test fails, the committed fallback is to emit
+	// (allow network-outbound (remote ip "localhost:*")) under lockdown when
+	// AllowNetworkBind is set.
+	t.Run("allow_network_bind keeps loopback self-dial working", func(t *testing.T) {
+		policy := lockdownTestPolicy(t)
+		policy.AllowNetworkBind = utils.PtrTo(true)
+		profile := writeTempProfile(t, policy, proxyLn.Addr().String())
+		err := runSandboxedHelper(t, profile, map[string]string{
+			"PMG_DIAL_MUST_PASS": proxyLn.Addr().String(),
+			"PMG_SELF_DIAL":      "1",
+		})
+		assert.NoError(t, err, "loopback self-dial must pass under lockdown with allow_network_bind")
+	})
+}

--- a/sandbox/platform/lockdown_integration_darwin_test.go
+++ b/sandbox/platform/lockdown_integration_darwin_test.go
@@ -61,6 +61,25 @@ func TestLockdownHelperProcess(t *testing.T) {
 		_, err := net.DefaultResolver.LookupHost(ctx, host)
 		wantPass := os.Getenv("PMG_RESOLVE_MUST_PASS") == "1"
 		report(fmt.Sprintf("resolve %s (wantPass=%v)", host, wantPass), (err == nil) == wantPass, err)
+
+		// Informational probes to localize where resolution is blocked; they
+		// do not affect the pass/fail outcome.
+		goResolver := &net.Resolver{PreferGo: true}
+		_, goErr := goResolver.LookupHost(ctx, host)
+		fmt.Printf("probe prefergo-resolve %s: err=%v\n", host, goErr)
+
+		conn, dialErr := net.DialTimeout("udp", "1.1.1.1:53", 2*time.Second)
+		if dialErr != nil {
+			fmt.Printf("probe udp53-dial: err=%v\n", dialErr)
+		} else {
+			_, writeErr := conn.Write([]byte{0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 0x03, 'c', 'o', 'm', 0x00, 0x00, 0x01, 0x00, 0x01})
+			_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+			buf := make([]byte, 512)
+			_, readErr := conn.Read(buf)
+			fmt.Printf("probe udp53 write err=%v read err=%v\n", writeErr, readErr)
+			_ = conn.Close()
+		}
 	}
 
 	if os.Getenv("PMG_SELF_DIAL") == "1" {
@@ -193,6 +212,18 @@ func TestLockdownEnforcementDarwin(t *testing.T) {
 			"PMG_RESOLVE_MUST_PASS": "1",
 		})
 		assert.NoError(t, err, "DNS must pass with allow_direct_dns")
+	})
+
+	t.Run("allow_direct_dns with network bind (diagnostic)", func(t *testing.T) {
+		policy := lockdownTestPolicy(t)
+		policy.AllowDirectDNS = utils.PtrTo(true)
+		policy.AllowNetworkBind = utils.PtrTo(true)
+		profile := writeTempProfile(t, policy, proxyLn.Addr().String())
+		err := runSandboxedHelper(t, profile, map[string]string{
+			"PMG_RESOLVE":           "example.com",
+			"PMG_RESOLVE_MUST_PASS": "1",
+		})
+		assert.NoError(t, err, "DNS with allow_direct_dns and allow_network_bind")
 	})
 
 	// Gating check for the milestone: allow_network_bind's

--- a/sandbox/platform/lockdown_integration_darwin_test.go
+++ b/sandbox/platform/lockdown_integration_darwin_test.go
@@ -17,7 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const lockdownHelperEnv = "PMG_LOCKDOWN_HELPER"
+const (
+	lockdownHelperEnv       = "PMG_LOCKDOWN_HELPER"
+	lockdownSandboxExecPath = "/usr/bin/sandbox-exec"
+)
 
 // TestLockdownHelperProcess is not a test: it is the child process re-executed
 // under sandbox-exec by the lockdown integration test below. It performs the
@@ -81,13 +84,13 @@ func TestLockdownHelperProcess(t *testing.T) {
 	}
 
 	if failed {
-		os.Exit(1)
+		t.Fatal("one or more sandboxed checks disagreed with expectations")
 	}
 }
 
 func requireSandboxExec(t *testing.T) {
 	t.Helper()
-	if _, err := exec.LookPath("sandbox-exec"); err != nil {
+	if _, err := os.Stat(lockdownSandboxExecPath); err != nil {
 		// Skips must not hide security tests in CI (see ci.yml).
 		if os.Getenv("CI") != "" {
 			t.Fatal("sandbox-exec required in CI")
@@ -152,7 +155,7 @@ func writeTempProfile(t *testing.T, policy *sandbox.SandboxPolicy, proxyAddr str
 
 func runSandboxedHelper(t *testing.T, profilePath string, env map[string]string) error {
 	t.Helper()
-	cmd := exec.Command("/usr/bin/sandbox-exec", "-f", profilePath,
+	cmd := exec.Command(lockdownSandboxExecPath, "-f", profilePath,
 		os.Args[0], "-test.run", "^TestLockdownHelperProcess$", "-test.v")
 	cmd.Env = append(os.Environ(), lockdownHelperEnv+"=1")
 	for k, v := range env {

--- a/sandbox/platform/lockdown_integration_darwin_test.go
+++ b/sandbox/platform/lockdown_integration_darwin_test.go
@@ -32,8 +32,8 @@ func TestLockdownHelperProcess(t *testing.T) {
 	}
 
 	failed := false
-	report := func(name string, ok bool) {
-		fmt.Printf("check %s: ok=%v\n", name, ok)
+	report := func(name string, ok bool, err error) {
+		fmt.Printf("check %s: ok=%v err=%v\n", name, ok, err)
 		if !ok {
 			failed = true
 		}
@@ -41,7 +41,7 @@ func TestLockdownHelperProcess(t *testing.T) {
 
 	if addr := os.Getenv("PMG_DIAL_MUST_PASS"); addr != "" {
 		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
-		report("dial-must-pass "+addr, err == nil)
+		report("dial-must-pass "+addr, err == nil, err)
 		if conn != nil {
 			_ = conn.Close()
 		}
@@ -49,7 +49,7 @@ func TestLockdownHelperProcess(t *testing.T) {
 
 	if addr := os.Getenv("PMG_DIAL_MUST_FAIL"); addr != "" {
 		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
-		report("dial-must-fail "+addr, err != nil)
+		report("dial-must-fail "+addr, err != nil, err)
 		if conn != nil {
 			_ = conn.Close()
 		}
@@ -60,13 +60,13 @@ func TestLockdownHelperProcess(t *testing.T) {
 		defer cancel()
 		_, err := net.DefaultResolver.LookupHost(ctx, host)
 		wantPass := os.Getenv("PMG_RESOLVE_MUST_PASS") == "1"
-		report(fmt.Sprintf("resolve %s (wantPass=%v)", host, wantPass), (err == nil) == wantPass)
+		report(fmt.Sprintf("resolve %s (wantPass=%v)", host, wantPass), (err == nil) == wantPass, err)
 	}
 
 	if os.Getenv("PMG_SELF_DIAL") == "1" {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
-			report("self-dial listen", false)
+			report("self-dial listen", false, err)
 		} else {
 			go func() {
 				conn, aerr := ln.Accept()
@@ -75,7 +75,7 @@ func TestLockdownHelperProcess(t *testing.T) {
 				}
 			}()
 			conn, derr := net.DialTimeout("tcp", ln.Addr().String(), 2*time.Second)
-			report("self-dial "+ln.Addr().String(), derr == nil)
+			report("self-dial "+ln.Addr().String(), derr == nil, derr)
 			if conn != nil {
 				_ = conn.Close()
 			}

--- a/sandbox/platform/lockdown_integration_darwin_test.go
+++ b/sandbox/platform/lockdown_integration_darwin_test.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -114,27 +113,20 @@ func mustListenLoopback(t *testing.T) net.Listener {
 	return ln
 }
 
+// lockdownTestPolicy mirrors the shipped profiles' filesystem posture
+// (broad read like go.yml, temp-only writes): filesystem breadth is not
+// under test here, network confinement is.
 func lockdownTestPolicy(t *testing.T) *sandbox.SandboxPolicy {
 	t.Helper()
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	exe, err := os.Executable()
-	require.NoError(t, err)
 
 	return &sandbox.SandboxPolicy{
 		Name:            "lockdown-e2e",
 		PackageManagers: []string{"npm"},
 		Filesystem: sandbox.FilesystemPolicy{
-			AllowRead: []string{
-				cwd + "/**",
-				filepath.Dir(exe) + "/**",
-				os.TempDir() + "/**",
-				"/private/tmp/**",
-				"/usr/lib/**",
-				"/System/**",
-			},
+			AllowRead: []string{"/"},
 			AllowWrite: []string{
 				os.TempDir() + "/**",
+				"/tmp/**",
 				"/private/tmp/**",
 				"/dev/null",
 			},

--- a/sandbox/platform/seatbelt_translator_darwin.go
+++ b/sandbox/platform/seatbelt_translator_darwin.go
@@ -660,7 +660,10 @@ func (t *seatbeltPolicyTranslator) translateNetwork(policy *sandbox.SandboxPolic
 		// explicitly re-opens it.
 		if utils.SafelyGetValue(policy.AllowDirectDNS) {
 			sb.WriteString("(allow mach-lookup (global-name \"com.apple.dnssd.service\"))\n")
+			// /var is a symlink to /private/var and Seatbelt matches resolved
+			// paths; emit both literals (same duality as the TMPDIR handling).
 			sb.WriteString("(allow network-outbound (remote unix-socket (path-literal \"/var/run/mDNSResponder\")))\n")
+			sb.WriteString("(allow network-outbound (remote unix-socket (path-literal \"/private/var/run/mDNSResponder\")))\n")
 			sb.WriteString("(allow network-outbound (remote ip \"*:53\"))\n")
 		}
 

--- a/sandbox/platform/seatbelt_translator_darwin.go
+++ b/sandbox/platform/seatbelt_translator_darwin.go
@@ -652,11 +652,14 @@ func (t *seatbeltPolicyTranslator) translateNetwork(policy *sandbox.SandboxPolic
 			sb.WriteString("(allow network-outbound (remote ip \"localhost:*\"))\n")
 		}
 
-		// macOS getaddrinfo resolves via the /var/run/mDNSResponder unix
-		// socket, but res_search-style resolvers (Go net, libresolv) send
-		// UDP directly to the nameserver — direct DNS needs both. The proxy
-		// resolves names, so DNS stays closed unless explicitly re-opened.
+		// Empirical (M0.5): modern macOS getaddrinfo reaches mDNSResponder
+		// via the com.apple.dnssd.service XPC endpoint, not only the legacy
+		// /var/run/mDNSResponder unix socket; resolvers that speak DNS
+		// themselves need direct port 53. Direct DNS re-opens all three.
+		// The proxy resolves names, so DNS stays closed unless the profile
+		// explicitly re-opens it.
 		if utils.SafelyGetValue(policy.AllowDirectDNS) {
+			sb.WriteString("(allow mach-lookup (global-name \"com.apple.dnssd.service\"))\n")
 			sb.WriteString("(allow network-outbound (remote unix-socket (path-literal \"/var/run/mDNSResponder\")))\n")
 			sb.WriteString("(allow network-outbound (remote ip \"*:53\"))\n")
 		}

--- a/sandbox/platform/seatbelt_translator_darwin.go
+++ b/sandbox/platform/seatbelt_translator_darwin.go
@@ -644,11 +644,21 @@ func (t *seatbeltPolicyTranslator) translateNetwork(policy *sandbox.SandboxPolic
 			sb.WriteString("\"))\n")
 		}
 
-		// macOS resolves names via the /var/run/mDNSResponder unix socket,
-		// which the deny above covers; the proxy resolves names, so direct
-		// DNS stays closed unless explicitly re-opened.
+		// Empirical (M0.5): the bind rules below do not cover outbound
+		// connects — at connect() time the socket's local address is still
+		// unbound, so (local ip "localhost:*") cannot match. Re-open
+		// loopback outbound explicitly for bind-enabled profiles.
+		if utils.SafelyGetValue(policy.AllowNetworkBind) {
+			sb.WriteString("(allow network-outbound (remote ip \"localhost:*\"))\n")
+		}
+
+		// macOS getaddrinfo resolves via the /var/run/mDNSResponder unix
+		// socket, but res_search-style resolvers (Go net, libresolv) send
+		// UDP directly to the nameserver — direct DNS needs both. The proxy
+		// resolves names, so DNS stays closed unless explicitly re-opened.
 		if utils.SafelyGetValue(policy.AllowDirectDNS) {
 			sb.WriteString("(allow network-outbound (remote unix-socket (path-literal \"/var/run/mDNSResponder\")))\n")
+			sb.WriteString("(allow network-outbound (remote ip \"*:53\"))\n")
 		}
 
 		sb.WriteString("\n")

--- a/sandbox/platform/seatbelt_translator_darwin.go
+++ b/sandbox/platform/seatbelt_translator_darwin.go
@@ -644,24 +644,19 @@ func (t *seatbeltPolicyTranslator) translateNetwork(policy *sandbox.SandboxPolic
 			sb.WriteString("\"))\n")
 		}
 
-		// Empirical (M0.5): the bind rules below do not cover outbound
-		// connects — at connect() time the socket's local address is still
-		// unbound, so (local ip "localhost:*") cannot match. Re-open
-		// loopback outbound explicitly for bind-enabled profiles.
+		// Bind rules cannot cover outbound connects (the local address is
+		// unbound at connect() time), so loopback outbound is re-opened
+		// explicitly for bind-enabled profiles.
 		if utils.SafelyGetValue(policy.AllowNetworkBind) {
 			sb.WriteString("(allow network-outbound (remote ip \"localhost:*\"))\n")
 		}
 
-		// Empirical (M0.5): modern macOS getaddrinfo reaches mDNSResponder
-		// via the com.apple.dnssd.service XPC endpoint, not only the legacy
-		// /var/run/mDNSResponder unix socket; resolvers that speak DNS
-		// themselves need direct port 53. Direct DNS re-opens all three.
-		// The proxy resolves names, so DNS stays closed unless the profile
-		// explicitly re-opens it.
+		// getaddrinfo resolves via the com.apple.dnssd.service XPC endpoint,
+		// legacy clients use the mDNSResponder socket (both /var and resolved
+		// /private/var paths — Seatbelt matches resolved paths), and
+		// self-resolving clients need direct port 53.
 		if utils.SafelyGetValue(policy.AllowDirectDNS) {
 			sb.WriteString("(allow mach-lookup (global-name \"com.apple.dnssd.service\"))\n")
-			// /var is a symlink to /private/var and Seatbelt matches resolved
-			// paths; emit both literals (same duality as the TMPDIR handling).
 			sb.WriteString("(allow network-outbound (remote unix-socket (path-literal \"/var/run/mDNSResponder\")))\n")
 			sb.WriteString("(allow network-outbound (remote unix-socket (path-literal \"/private/var/run/mDNSResponder\")))\n")
 			sb.WriteString("(allow network-outbound (remote ip \"*:53\"))\n")

--- a/sandbox/platform/seatbelt_translator_darwin_test.go
+++ b/sandbox/platform/seatbelt_translator_darwin_test.go
@@ -765,6 +765,7 @@ func TestTranslateNetworkLockdown(t *testing.T) {
 	proxyAllow := `(allow network-outbound (remote ip "localhost:54321"))`
 	blanketAllow := "(allow network-outbound)\n"
 	dnsAllow := `(allow network-outbound (remote unix-socket (path-literal "/var/run/mDNSResponder")))`
+	dnsMachAllow := `(allow mach-lookup (global-name "com.apple.dnssd.service"))`
 	dnsPortAllow := `(allow network-outbound (remote ip "*:53"))`
 	bindRule := `(allow network* (local ip "localhost:*"))`
 	loopbackOutboundAllow := `(allow network-outbound (remote ip "localhost:*"))`
@@ -792,6 +793,7 @@ func TestTranslateNetworkLockdown(t *testing.T) {
 			mutate: func(p *sandbox.SandboxPolicy) { p.AllowDirectDNS = utils.PtrTo(true) },
 			assert: func(t *testing.T, out string) {
 				assert.Contains(t, out, dnsAllow)
+				assert.Contains(t, out, dnsMachAllow)
 				assert.Contains(t, out, dnsPortAllow)
 			},
 		},

--- a/sandbox/platform/seatbelt_translator_darwin_test.go
+++ b/sandbox/platform/seatbelt_translator_darwin_test.go
@@ -765,6 +765,7 @@ func TestTranslateNetworkLockdown(t *testing.T) {
 	proxyAllow := `(allow network-outbound (remote ip "localhost:54321"))`
 	blanketAllow := "(allow network-outbound)\n"
 	dnsAllow := `(allow network-outbound (remote unix-socket (path-literal "/var/run/mDNSResponder")))`
+	dnsAllowPrivate := `(allow network-outbound (remote unix-socket (path-literal "/private/var/run/mDNSResponder")))`
 	dnsMachAllow := `(allow mach-lookup (global-name "com.apple.dnssd.service"))`
 	dnsPortAllow := `(allow network-outbound (remote ip "*:53"))`
 	bindRule := `(allow network* (local ip "localhost:*"))`
@@ -793,6 +794,7 @@ func TestTranslateNetworkLockdown(t *testing.T) {
 			mutate: func(p *sandbox.SandboxPolicy) { p.AllowDirectDNS = utils.PtrTo(true) },
 			assert: func(t *testing.T, out string) {
 				assert.Contains(t, out, dnsAllow)
+				assert.Contains(t, out, dnsAllowPrivate)
 				assert.Contains(t, out, dnsMachAllow)
 				assert.Contains(t, out, dnsPortAllow)
 			},

--- a/sandbox/platform/seatbelt_translator_darwin_test.go
+++ b/sandbox/platform/seatbelt_translator_darwin_test.go
@@ -765,7 +765,9 @@ func TestTranslateNetworkLockdown(t *testing.T) {
 	proxyAllow := `(allow network-outbound (remote ip "localhost:54321"))`
 	blanketAllow := "(allow network-outbound)\n"
 	dnsAllow := `(allow network-outbound (remote unix-socket (path-literal "/var/run/mDNSResponder")))`
+	dnsPortAllow := `(allow network-outbound (remote ip "*:53"))`
 	bindRule := `(allow network* (local ip "localhost:*"))`
+	loopbackOutboundAllow := `(allow network-outbound (remote ip "localhost:*"))`
 
 	tests := []struct {
 		name   string
@@ -785,11 +787,12 @@ func TestTranslateNetworkLockdown(t *testing.T) {
 			},
 		},
 		{
-			name:   "allow_direct_dns reopens mDNSResponder",
+			name:   "allow_direct_dns reopens mDNSResponder and port 53",
 			rt:     rt,
 			mutate: func(p *sandbox.SandboxPolicy) { p.AllowDirectDNS = utils.PtrTo(true) },
 			assert: func(t *testing.T, out string) {
 				assert.Contains(t, out, dnsAllow)
+				assert.Contains(t, out, dnsPortAllow)
 			},
 		},
 		{
@@ -799,10 +802,11 @@ func TestTranslateNetworkLockdown(t *testing.T) {
 			assert: func(t *testing.T, out string) {
 				assert.Contains(t, out, denyMarker)
 				assert.Contains(t, out, bindRule)
+				assert.Contains(t, out, loopbackOutboundAllow)
 				denyIdx := strings.Index(out, denyMarker)
-				bindIdx := strings.Index(out, bindRule)
 				require.GreaterOrEqual(t, denyIdx, 0)
-				assert.Greater(t, bindIdx, denyIdx, "bind rules must come after the lockdown deny (SBPL last-match-wins)")
+				assert.Greater(t, strings.Index(out, bindRule), denyIdx, "bind rules must come after the lockdown deny (SBPL last-match-wins)")
+				assert.Greater(t, strings.Index(out, loopbackOutboundAllow), denyIdx, "loopback outbound allow must come after the lockdown deny")
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Hermetic end-to-end proof that the lockdown profile actually enforces under real `sandbox-exec`, resolving the two empirical questions the design deferred to implementation. Re-exec helper-process pattern (`TestLockdownHelperProcess` driven by env vars), parent builds a lockdown policy, translates it against a live fake-proxy listener's address, and runs the test binary under `sandbox-exec -f`. Applies the CI convention from #366: **fails instead of skipping** when `sandbox-exec` is missing in CI.

## Empirical outcomes (macos-26-arm64 runner, 2026-07-10)

**Base lockdown: PROVEN.** Proxy-port dial passes; direct dial to another loopback port fails (`connect: operation not permitted`); DNS fails.

**Loopback gating check: FAILED → committed fallback implemented.** `allow_network_bind`'s `(allow network* (local ip "localhost:*"))` does **not** cover outbound connects — at `connect()` time the socket's local address is still unbound, so the local-ip filter never matches. Bind-enabled lockdown profiles now explicitly emit `(allow network-outbound (remote ip "localhost:*"))` after the lockdown deny (per the issue's committed fallback), keeping httptest/dev-server workflows alive. Golden assertion added.

**DNS check: PROVEN, with three findings beyond the spec's assumption** (each fixed in the translator, all golden-asserted):
1. `/var/run/mDNSResponder` never matched — Seatbelt matches resolved paths, `/var` → `/private/var`; both literals now emitted.
2. Modern macOS `getaddrinfo` reaches mDNSResponder via the `com.apple.dnssd.service` mach XPC endpoint — without that allow, resolution fails instantly regardless of socket/port allows.
3. Self-resolving clients (pure-Go resolver, libresolv-style) send UDP directly to the nameserver — `allow_direct_dns` also allows `*:53` so the escape hatch covers every resolver style.

Under base lockdown all three DNS channels stay closed (verified via system resolver, pure-Go resolver, and raw UDP:53 probes — all denied).

## Sub-tests (all green)

1. base lockdown — proxy dial passes, other-loopback dial fails, DNS fails
2. `allow_direct_dns` — system-resolver DNS passes
3. `allow_direct_dns` + `allow_network_bind` — DNS passes
4. `allow_network_bind` self-dial — loopback connect passes via the fallback rule

The helper also emits informational probes (pure-Go resolve, raw UDP:53) on every DNS check — kept as permanent forensics for future regressions.

Outcome also recorded on the Linear issue per its acceptance criteria.

Tracking: [FOU-203](https://linear.app/safedep/issue/FOU-203/m05-darwin-end-to-end-enforcement-test-spec-validation-items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqMU5GNBbQvQct9nxek1VS