### PR TITLE
feat(sandbox): enable network_via_proxy_only for the Go ecosystem profile

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -438,7 +438,26 @@ does not have this limitation; its `file-read*` and `file-write*` rules are inde
 <details>
 <summary>macOS (Seatbelt)</summary>
 
-**Network filtering is limited**: Seatbelt supports network rules in policies, but fine-grained `host:port` filtering is not enforced.
+**Network lockdown (`network_via_proxy_only`)**: Fine-grained `host:port` filtering is not
+expressible in Seatbelt, so per-host control happens at the PMG proxy instead. With
+`network_via_proxy_only: true`, the sandbox denies all outbound network except the loopback port
+of the running PMG proxy — raw sockets, QUIC, and arbitrary ports are blocked at the kernel.
+Direct DNS is disabled by default (the proxy resolves names); `allow_direct_dns: true` re-opens
+it. The Go profile ships with lockdown enabled.
+
+Lockdown is fail-closed: it requires the proxy flow, and pmg errors out rather than running
+without confinement when no proxy is available — including on Linux, where
+`network_via_proxy_only` is not yet supported (the drivers reject it with a clear error, never a
+silent fallback).
+
+For local development: plain commands like `npm run dev` are not sandboxed unless
+`enforce_always` is set; loopback↔loopback traffic keeps working via `allow_network_bind`; and
+proxy-honoring clients reach any destination through the proxy CONNECT path. What breaks under
+lockdown is direct non-loopback sockets — tools that ignore `HTTP_PROXY`/`HTTPS_PROXY` and
+non-HTTP wire protocols (e.g. Postgres or Redis clients pointed at non-loopback hosts). Such
+denials render as:
+
+> direct network access blocked by network_via_proxy_only — traffic must flow through the PMG proxy (a tool may have ignored HTTP_PROXY/HTTPS_PROXY)
 
 </details>
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -440,8 +440,10 @@ does not have this limitation; its `file-read*` and `file-write*` rules are inde
 
 **Network lockdown (`network_via_proxy_only`)**: Fine-grained `host:port` filtering is not
 expressible in Seatbelt, so per-host control happens at the PMG proxy instead. With
-`network_via_proxy_only: true`, the sandbox denies all outbound network except the loopback port
-of the running PMG proxy — raw sockets, QUIC, and arbitrary ports are blocked at the kernel.
+`network_via_proxy_only: true`, the sandbox denies all non-loopback outbound network; only the
+running PMG proxy's port is reachable, and profiles with `allow_network_bind` additionally keep
+loopback↔loopback connects open. Raw sockets, QUIC, and arbitrary non-loopback ports are blocked
+at the kernel.
 Direct DNS is disabled by default (the proxy resolves names); `allow_direct_dns: true` re-opens
 it. The Go profile ships with lockdown enabled.
 
@@ -451,7 +453,8 @@ without confinement when no proxy is available — including on Linux, where
 silent fallback).
 
 For local development: plain commands like `npm run dev` are not sandboxed unless
-`enforce_always` is set; loopback↔loopback traffic keeps working via `allow_network_bind`; and
+`enforce_always` is set; loopback↔loopback traffic keeps working via `allow_network_bind` (as
+noted above); and
 proxy-honoring clients reach any destination through the proxy CONNECT path. What breaks under
 lockdown is direct non-loopback sockets — tools that ignore `HTTP_PROXY`/`HTTPS_PROXY` and
 non-HTTP wire protocols (e.g. Postgres or Redis clients pointed at non-loopback hosts). Such

--- a/sandbox/profiles/go.yml
+++ b/sandbox/profiles/go.yml
@@ -11,6 +11,11 @@ allow_pty: true
 # binds and outbound traffic are unaffected.
 allow_network_bind: true
 
+# All outbound traffic is confined to the PMG proxy (loopback). Per-host
+# control happens at the proxy; direct DNS is disabled (the proxy resolves).
+# Requires the proxy flow; pmg fails closed if the proxy is not running.
+network_via_proxy_only: true
+
 # .git/config stays blocked (default). go build embeds VCS info by default
 # (-buildvcs=auto) which invokes git; if git fails on the blocked config, build
 # with -buildvcs=false or set allow_git_config: true in a custom profile.
@@ -59,12 +64,11 @@ filesystem:
     - /usr/**
 
 network:
-  # Per-host rules are NOT enforced on any platform. macOS Seatbelt and Linux
-  # Bubblewrap only make a binary decision: any allow_outbound entry enables
-  # ALL outbound traffic, and "*:*" in deny_outbound disables the network
-  # entirely only when allow_outbound is empty. The hosts below document the
-  # default Go module endpoints and keep the network enabled; actual module
-  # traffic control comes from the PMG proxy's fail-closed GOPROXY rewrite.
+  # These hosts are documentation of the default Go module endpoints and the
+  # future input to proxy-level per-host policy. They are NOT kernel-enforced:
+  # with network_via_proxy_only, the sandbox only permits loopback traffic to
+  # the PMG proxy, and the proxy (with fail-closed GOPROXY rewrite) controls
+  # module traffic.
   allow_outbound:
     - proxy.golang.org:443
     - sum.golang.org:443

--- a/sandbox/profiles/go.yml
+++ b/sandbox/profiles/go.yml
@@ -11,9 +11,11 @@ allow_pty: true
 # binds and outbound traffic are unaffected.
 allow_network_bind: true
 
-# All outbound traffic is confined to the PMG proxy (loopback). Per-host
-# control happens at the proxy; direct DNS is disabled (the proxy resolves).
-# Requires the proxy flow; pmg fails closed if the proxy is not running.
+# All non-loopback outbound traffic is denied: only the PMG proxy's port is
+# reachable, plus loopback-to-loopback connects since this profile sets
+# allow_network_bind. Per-host control happens at the proxy; direct DNS is
+# disabled (the proxy resolves). Requires the proxy flow; pmg fails closed
+# if the proxy is not running.
 network_via_proxy_only: true
 
 # .git/config stays blocked (default). go build embeds VCS info by default
@@ -66,9 +68,9 @@ filesystem:
 network:
   # These hosts are documentation of the default Go module endpoints and the
   # future input to proxy-level per-host policy. They are NOT kernel-enforced:
-  # with network_via_proxy_only, the sandbox only permits loopback traffic to
-  # the PMG proxy, and the proxy (with fail-closed GOPROXY rewrite) controls
-  # module traffic.
+  # with network_via_proxy_only, the sandbox denies all non-loopback outbound
+  # traffic, and the proxy (with fail-closed GOPROXY rewrite) controls module
+  # traffic.
   allow_outbound:
     - proxy.golang.org:443
     - sum.golang.org:443


### PR DESCRIPTION
## Summary

Flips the M0 feature on for its first adopter. Lockdown ships enabled only for the Go ecosystem: Go support is proxy-flow-only with a fail-closed GOPROXY rewrite, so module and sumdb traffic already flow through the proxy — lockdown mostly ratifies reality and starts real-world soak with the ecosystem best positioned for it. All other profiles are untouched (opt-in later via profile template override).

- `sandbox/profiles/go.yml`: `network_via_proxy_only: true` below `allow_network_bind`; the `network:` comment essay replaced — the host lists stay as documentation of the default Go endpoints and the future input to proxy-level per-host policy (M2), no longer claiming kernel enforcement semantics.
- `docs/sandbox.md`: the macOS "Network filtering is limited" bullet becomes a lockdown subsection covering what `network_via_proxy_only`/`allow_direct_dns` do, the fail-closed contract (proxy required; Linux unsupported with a clear error, never silent), the local-dev story (non-sandboxed commands, loopback↔loopback via `allow_network_bind`, proxy-honoring clients unaffected; what breaks is direct non-loopback sockets), and the exact violation message from #373.

## Validation

- `go test ./sandbox/... -count=1` green (profile registry parses the embedded profile).
- `pmg sandbox profile lint go` → `OK no issues found`.
- ⚠️ **Manual validation before merge** (needs a real Mac, per the issue): `pmg go get <module>` in a scratch module succeeds through the proxy; a `go run` program attempting a direct non-loopback `net.Dial` is blocked with the `network_via_proxy_only` violation message.

Tracking: [FOU-204](https://linear.app/safedep/issue/FOU-204/m06-enable-network-via-proxy-only-in-goyml-and-document)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqMU5GNBbQvQct9nxek1VS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqMU5GNBbQvQct9nxek1VS)_