### PR TITLE
fix(doctor): stop npm protection passing when the real package manager is absent

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/safedep/dry/log"
+	"github.com/safedep/pmg/internal/shim"
+	"github.com/safedep/pmg/internal/ui"
 )
 
 type ProtectionTestCase struct {
@@ -34,7 +36,10 @@ func ProtectionTestCases() []ProtectionTestCase {
 }
 
 func RunProtectionCheck(tc ProtectionTestCase, pmgBinary string) CheckResult {
-	if _, err := exec.LookPath(tc.PackageManager); err != nil {
+	// Resolve the real package manager the same way the runner does — PATH with
+	// PMG shim dirs stripped. A plain exec.LookPath would find the PMG shim on
+	// PATH and report the manager as available even when the real binary is absent
+	if _, err := shim.ResolveRealBinary(tc.PackageManager); err != nil {
 		return CheckResult{
 			Status:  StatusWarn,
 			Message: fmt.Sprintf("%s not available — skipping protection test for %s", tc.PackageManager, tc.Package),
@@ -72,8 +77,8 @@ func RunProtectionCheck(tc ProtectionTestCase, pmgBinary string) CheckResult {
 	cmd.Dir = tmpDir
 	cmd.Env = env
 
-	_, runErr := cmd.CombinedOutput()
-	return evaluateProtectionResult(tc.PackageManager, tc.Package, runErr)
+	output, runErr := cmd.CombinedOutput()
+	return evaluateProtectionResult(tc.PackageManager, tc.Package, string(output), runErr)
 }
 
 func setupVenv(baseDir string) (string, error) {
@@ -96,22 +101,35 @@ func prependPath(env []string, dir string) []string {
 	return result
 }
 
-func evaluateProtectionResult(pm string, pkg string, err error) CheckResult {
-	if err != nil {
-		if isExecutableNotFound(err) {
-			return CheckResult{
-				Status:  StatusWarn,
-				Message: fmt.Sprintf("%s not available — skipping protection test for %s", pm, pkg),
-			}
+func evaluateProtectionResult(pm string, pkg string, output string, err error) CheckResult {
+	if err == nil {
+		return CheckResult{
+			Status:  StatusFail,
+			Message: fmt.Sprintf("Failed to block %s/%s — package was installed instead of blocked", pm, pkg),
 		}
+	}
+
+	if isExecutableNotFound(err) {
+		return CheckResult{
+			Status:  StatusWarn,
+			Message: fmt.Sprintf("%s not available — skipping protection test for %s", pm, pkg),
+		}
+	}
+
+	// A non-zero exit alone is not proof of a block: PackageManagerNotFound,
+	// proxy/CA setup failures, and config errors all exit non-zero too. Require
+	// PMG's block headline in the output before declaring protection working.
+	// The headline is emitted only for malware blocks, not cooldown-only blocks.
+	if strings.Contains(output, ui.MalwareBlockedHeadline) {
 		return CheckResult{
 			Status:  StatusPass,
 			Message: fmt.Sprintf("Malicious package blocked (%s/%s)", pm, pkg),
 		}
 	}
+
 	return CheckResult{
-		Status:  StatusFail,
-		Message: fmt.Sprintf("Failed to block %s/%s — package was installed instead of blocked", pm, pkg),
+		Status:  StatusWarn,
+		Message: fmt.Sprintf("Install failed without a malware block (%v)", err),
 	}
 }
 

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/safedep/pmg/internal/ui"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,13 +18,15 @@ func TestEvaluateProtectionResult(t *testing.T) {
 		name       string
 		pm         string
 		pkg        string
+		output     string
 		err        error
 		wantStatus CheckStatus
 	}{
 		{
-			name:       "blocked",
+			name:       "blocked with headline in output",
 			pm:         "npm",
 			pkg:        "safedep-test-pkg@0.1.3",
+			output:     "✗ " + ui.MalwareBlockedHeadline + "\n  safedep-test-pkg@0.1.3\n",
 			err:        fmt.Errorf("exit status 1"),
 			wantStatus: StatusPass,
 		},
@@ -31,23 +34,53 @@ func TestEvaluateProtectionResult(t *testing.T) {
 			name:       "not blocked",
 			pm:         "npm",
 			pkg:        "safedep-test-pkg@0.1.3",
+			output:     "",
 			err:        nil,
 			wantStatus: StatusFail,
 		},
 		{
-			name:       "pm not found",
+			name:       "pmg binary not found",
 			pm:         "npm",
 			pkg:        "safedep-test-pkg@0.1.3",
-			err:        &exec.Error{Name: "npm", Err: exec.ErrNotFound},
+			err:        &exec.Error{Name: "pmg", Err: exec.ErrNotFound},
+			wantStatus: StatusWarn,
+		},
+		{
+			name:       "non-zero exit without block headline is inconclusive",
+			pm:         "npm",
+			pkg:        "safedep-test-pkg@0.1.3",
+			output:     "npm is not installed\n",
+			err:        fmt.Errorf("exit status 127"),
 			wantStatus: StatusWarn,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := evaluateProtectionResult(tt.pm, tt.pkg, tt.err)
+			result := evaluateProtectionResult(tt.pm, tt.pkg, tt.output, tt.err)
 			assert.Equal(t, tt.wantStatus, result.Status)
 		})
 	}
+}
+
+func TestRunProtectionCheckSkipsWhenOnlyShimOnPath(t *testing.T) {
+	tmp := t.TempDir()
+	// ~/.pmg/bin suffix is stripped by FilterPMGFromPath, so a shim here must
+	// not be mistaken for a real npm binary.
+	shimDir := filepath.Join(tmp, ".pmg", "bin")
+	require.NoError(t, os.MkdirAll(shimDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(shimDir, "npm"), []byte("#!/bin/sh\n"), 0o755))
+
+	t.Setenv("PATH", shimDir)
+
+	tc := ProtectionTestCase{
+		PackageManager: "npm",
+		Package:        "safedep-test-pkg@0.1.3",
+		InstallArgs:    []string{"npm", "install", "safedep-test-pkg@0.1.3"},
+	}
+
+	result := RunProtectionCheck(tc, filepath.Join(tmp, "nonexistent-pmg"))
+	assert.Equal(t, StatusWarn, result.Status)
+	assert.Contains(t, result.Message, "not available")
 }
 
 func TestProtectionTestCases(t *testing.T) {

--- a/internal/ui/proxy_presenter.go
+++ b/internal/ui/proxy_presenter.go
@@ -36,7 +36,7 @@ func (p ProxyPresenter) BlockMessage(reason proxy.BlockReason, blockCtx *proxy.B
 	var message string
 	switch reason {
 	case proxy.BlockReasonMalware, proxy.BlockReasonUserDeclined:
-		prefix := "Malicious package blocked"
+		prefix := MalwareBlockedHeadline
 		if reason == proxy.BlockReasonUserDeclined {
 			prefix = "Installation blocked by user"
 		}

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -139,13 +139,19 @@ func Report(data *ReportData) {
 	}
 }
 
+// MalwareBlockedHeadline is the headline printed when a malicious package is
+// blocked. Exported so out-of-process consumers (e.g. `pmg setup doctor`) can
+// detect a genuine block from captured output instead of inferring it from a
+// non-zero exit code, which any failure would also produce.
+const MalwareBlockedHeadline = "Malicious package blocked"
+
 func printMalwareBlockSection(data *ReportData) {
 	if len(data.BlockedPackages) == 0 {
 		return
 	}
 
 	fmt.Println()
-	fmt.Printf("%s %s\n", Colors.Red("✗"), Colors.Red("Malicious package blocked"))
+	fmt.Printf("%s %s\n", Colors.Red("✗"), Colors.Red(MalwareBlockedHeadline))
 	printMaliciousPackagesList(data.BlockedPackages)
 	fmt.Println()
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -70,7 +70,7 @@ func blockWithExit(config *BlockConfig, exit bool) error {
 	// already shown to the user in verbose mode as part of the reporting.
 	if verbosityLevel != VerbosityLevelVerbose {
 		fmt.Println()
-		fmt.Printf("%s %s\n", Colors.Red("✗"), Colors.Red("Malicious package blocked"))
+		fmt.Printf("%s %s\n", Colors.Red("✗"), Colors.Red(MalwareBlockedHeadline))
 
 		if config.ShowReference {
 			printMaliciousPackagesList(config.MalwarePackages)


### PR DESCRIPTION
## Problem

`pmg setup doctor` reported **npm protection: OK** on a machine where npm was not installed:

```
OK    npm protection   Malicious package blocked (npm/safedep-test-pkg@0.1.3)   —
```

In proxy mode the flow runs the real npm CLI and blocks at the network layer. With npm absent, `runner.ExecuteWithOptions` → `shim.ResolveRealBinary("npm")` fails with `BinaryNotFoundError` (exit 127) *before* any package is intercepted — nothing was blocked, yet the doctor showed a pass.

## Root cause — two compounding defects

1. **Availability gate resolved the shim, not the real binary.** The gate used `exec.LookPath(tc.PackageManager)`, which finds the PMG shim on PATH (`/usr/local/lib/pmg/bin/npm`), so the "skip when unavailable" branch never fired.

2. **"Non-zero exit == blocked" was too broad.** The result was inferred purely from exit status, so `PackageManagerNotFound` (127) — and any other failure (CA/proxy/config) — was misclassified as a successful malware block.

## Fix

1. Gate on `shim.ResolveRealBinary(...)` (PATH with PMG shim dirs stripped), matching the runner. A missing real binary now correctly yields `WARN — not available, skipping`.

2. Require PMG's block headline in the captured output before reporting `PASS`. Other non-zero exits report `WARN` with the underlying error surfaced, so real failures are visible instead of masquerading as protection working.

The headline is extracted into `ui.MalwareBlockedHeadline` and referenced by all block-output sites so the doctor's marker cannot drift from what PMG prints.