### PR TITLE
fix(container): cross-compile per target platform so linux/arm64 ships an arm64 binary

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -67,4 +67,10 @@ jobs:
             .
         fi
 
+    - name: Verify Image Platform Variants
+      run: |
+        for platform in linux/amd64 linux/arm64; do
+          docker run --rm --platform $platform $REGISTRY/$IMAGE_NAME:latest version
+        done
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN go mod download
 
 COPY . .
 
-RUN make
+ARG TARGETOS TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} make
 
 FROM debian:11-slim@sha256:e4b93db6aad977a95aa103917f3de8a2b16ead91cf255c3ccdb300c5d20f3015
 # Original: debian:11-slim


### PR DESCRIPTION
## Summary

Fixes #379 — the published `linux/arm64` image variant contained an x86-64 binary and failed with exit 133 on any arm64 host.

The Dockerfile's build stage runs on `$BUILDPLATFORM` (amd64 on the CI runner) and `make` never received a target architecture, so a single amd64 binary was copied into every manifest variant.

## Changes

- **Dockerfile**: declare `ARG TARGETOS TARGETARCH` in the build stage and run `CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} make`, so each platform variant gets a natively cross-compiled binary.
- **.github/workflows/container.yml**: add a `Verify Image Platform Variants` step that runs `pmg version` from the pushed `:latest` image under both `linux/amd64` and `linux/arm64` (QEMU is already set up in the job). A mispackaged variant would fail to execute, guarding against regression per the issue's acceptance criteria.

## Verification

- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 make` → `bin/pmg: ELF 64-bit LSB executable, ARM aarch64, statically linked` — confirms pmg needs no cgo on Linux, resolving the issue's open question (`CGO_ENABLED=0` is the simpler path vs. a cross C toolchain).
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make` → x86-64 static binary; `./bin/pmg version` runs successfully (the command the new CI check invokes).
- Workflow YAML validated. Full multi-arch `docker buildx` build could not be run in this environment (no Docker daemon); the new CI verify step covers that end-to-end on the next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8yrxjqVw7454zByb8kxvD

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8yrxjqVw7454zByb8kxvD)_