### PR TITLE
feat(sandbox): surface bubblewrap denials as sandbox violations

### DIFF
--- a/cmd/sandbox/allow.go
+++ b/cmd/sandbox/allow.go
@@ -233,6 +233,17 @@ func suggestionsFromCache(cache *pmgsandbox.ViolationCache, all bool) ([]pmgsand
 		)
 	}
 
+	// Refused here rather than by returning nothing: the caller's generic
+	// "no eligible allowances to save" tells the user to run a sandboxed
+	// command, which they just did and can see in `violations list`.
+	if entry.Record.Report.OutputDerived {
+		return nil, invalidArgumentError(
+			"the latest violation report cannot be promoted to an allowance",
+			"It was parsed from the sandboxed command's own output, which a package can forge to name any target. "+
+				"Review it with `pmg sandbox explain --last`, then add the allowance explicitly with `pmg sandbox allow <type>=<value>`.",
+		)
+	}
+
 	if all {
 		return pmgsandbox.BuildAllOverrides(entry.Record.Report), nil
 	}

--- a/cmd/sandbox/allow_test.go
+++ b/cmd/sandbox/allow_test.go
@@ -212,3 +212,29 @@ func TestAllow_LastNormalizesRelativeTargets(t *testing.T) {
 	require.Len(t, overlay.Allow, 1)
 	assert.Equal(t, wantAbs, overlay.Allow[0].Value, "cache-derived target should be normalized to absolute")
 }
+
+// A forged denial must not reach the overlay, however the user invokes --last.
+// See ViolationReport.OutputDerived.
+func TestAllow_LastRefusesOutputDerivedReport(t *testing.T) {
+	deps := newAllowDeps(t)
+	forged := &pmgsandbox.ViolationReport{
+		SandboxName:   pmgsandbox.DriverBubblewrap,
+		OutputDerived: true,
+		Violations: []pmgsandbox.Violation{
+			{Kind: pmgsandbox.ViolationKindFSRead, Target: filepath.Join(deps.repoRoot, "innocent.txt")},
+			{Kind: pmgsandbox.ViolationKindExec, Target: "/usr/bin/curl"},
+		},
+	}
+	_, err := deps.cache.Write(forged)
+	require.NoError(t, err)
+
+	for _, args := range [][]string{{"--last"}, {"--last", "--all"}} {
+		_, _, err := runAllowCmd(t, deps, args...)
+		require.Error(t, err, "args: %v", args)
+		assert.Contains(t, err.Error(), "cannot be promoted")
+	}
+
+	overlay, _, err := pmgsandbox.LoadOverlayForRepo(deps.overlayDir, deps.repoRoot)
+	require.NoError(t, err)
+	assert.Nil(t, overlay, "nothing may be persisted from a forgeable report")
+}

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -512,6 +512,15 @@ Not reported:
   Node and Python.
 - A bare name carrying neither a separator nor an extension, such as `Makefile`. The trailing
   token of an error line is often prose, so a target must look like a path to be accepted.
+- A denial on a host that sets `LC_ALL`. libc translates `strerror(3)`, so PMG pins
+  `LC_MESSAGES=C` for the sandboxed command to keep those phrases in English. `LC_ALL` outranks
+  `LC_MESSAGES`, and overriding it would change number formatting and collation for every build
+  script in the install, which is too broad a side effect for a diagnostics feature.
+
+Reports from this driver are marked as derived from the command's output. Because a malicious
+package can print a denial that never happened and name any target it likes, these violations are
+shown by `violations list` and `explain` but never become an override suggestion, and
+`pmg sandbox allow --last` will not persist them.
 
 Landlock and Seatbelt do not share these limits; both read a dedicated kernel or platform channel
 rather than the command's output.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -213,7 +213,8 @@ pmg sandbox profile show npm-restrictive --resolved
 
 `pmg sandbox doctor` runs platform-specific checks for the current host. Cached violation reports
 used by `violations list` and `explain --last` are produced by macOS Seatbelt diagnostics and, on
-Linux, by the Landlock driver's seccomp supervisor.
+Linux, by the Landlock driver's seccomp supervisor or the Bubblewrap driver's reader of the
+sandboxed command's output.
 
 Coverage differs by platform. Seatbelt logs every denial, including the default-deny allow-list
 boundary. The Landlock driver only reports denials made by its seccomp deny-list layer (reads and
@@ -222,7 +223,8 @@ writes of `deny_*` paths, blocked `deny_exec` binaries): denials made by the Lan
 produce no report. `deny_write` entries outside writable areas are enforced by Landlock rather than
 seccomp, so they are likewise not reported. Operational degradation events on the audit socket
 (`namespace_isolation_unavailable`, `memfd_open_failed`) are not included in violation reports
-today; they may be added later. Bubblewrap denials only appear as command errors such as `EACCES`.
+today; they may be added later. The Bubblewrap driver reports denials it can recognise in the
+sandboxed command's own error output; see its platform section below for what that covers.
 
 ### Runtime Allow Overrides
 
@@ -491,6 +493,28 @@ while denying reads for the same path. `--bind` exposes both directions; `--tmpf
 in `allow_write` but not `allow_read`), the bind mount also exposes reads, and PMG cannot enforce
 the read-side mandatory deny. PMG warns via `log.Warnf` when it detects this case. macOS Seatbelt
 does not have this limitation; its `file-read*` and `file-write*` rules are independent.
+
+**Violation reporting is best effort**: Bubblewrap isolates with namespaces and mounts rather than
+a security module, so it never observes a denial. The kernel fails the syscall and the sandboxed
+program reports the error itself. PMG reads the command's output and matches the trailing
+`strerror(3)` phrase, which is identical across programs even though the message prefix is not.
+
+Recognised: `Permission denied`, `Operation not permitted`, `Read-only file system`, and exec
+failures bwrap reports itself. Denials from shell install scripts and the coreutils they call are
+covered, including paths that are quoted, contain spaces, or contain a colon.
+
+Not reported:
+
+- A path absent from the sandbox fails with `No such file or directory`, which is
+  indistinguishable from a file that never existed. Reporting it would flag every genuinely
+  missing file, so it is skipped unless bwrap itself reports it for a failed exec.
+- Language runtimes that print the path after the errno phrase rather than before it, such as
+  Node and Python.
+- A bare name carrying neither a separator nor an extension, such as `Makefile`. The trailing
+  token of an error line is often prose, so a target must look like a path to be accepted.
+
+Landlock and Seatbelt do not share these limits; both read a dedicated kernel or platform channel
+rather than the command's output.
 
 </details>
 

--- a/internal/runner/execute.go
+++ b/internal/runner/execute.go
@@ -175,7 +175,10 @@ func runPTY(
 		}
 	}()
 
-	outputRouter, err := pty.NewOutputRouter(os.Stdout)
+	// A PTY session routes the child's output itself and never writes to
+	// cmd.Stderr, so sandbox drivers whose only denial signal is that output
+	// need it teed here to observe anything.
+	outputRouter, err := pty.NewOutputRouter(ptyOutput(result))
 	if err != nil {
 		return fmt.Errorf("failed to create output router: %w", err)
 	}
@@ -255,6 +258,15 @@ func runPTY(
 	}
 
 	return nil
+}
+
+func ptyOutput(result *sandbox.ExecutionResult) io.Writer {
+	tap := result.DiagnosticsWriter()
+	if tap == nil {
+		return os.Stdout
+	}
+
+	return io.MultiWriter(os.Stdout, tap)
 }
 
 func executionMode(opts ExecuteOptions) ExecutionMode {

--- a/internal/runner/execute_test.go
+++ b/internal/runner/execute_test.go
@@ -1,7 +1,9 @@
 package runner
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +11,7 @@ import (
 	"github.com/safedep/pmg/config"
 	"github.com/safedep/pmg/internal/shim"
 	"github.com/safedep/pmg/packagemanager"
+	"github.com/safedep/pmg/sandbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -117,4 +120,27 @@ func TestExecuteWithOptionsMissingPackageManager(t *testing.T) {
 	require.ErrorAs(t, err, &notFound)
 	assert.Equal(t, "bun", notFound.Name)
 	assert.Equal(t, 127, notFound.ExitCode())
+}
+
+type stubDiagnosticsSandbox struct {
+	sandbox.Sandbox
+	writer io.Writer
+}
+
+func (s stubDiagnosticsSandbox) DiagnosticsWriter() io.Writer { return s.writer }
+
+func TestPTYOutputTeesToSandboxDiagnostics(t *testing.T) {
+	var tap bytes.Buffer
+
+	result := sandbox.NewExecutionResult(
+		sandbox.WithExecutionResultSandbox(stubDiagnosticsSandbox{writer: &tap}))
+
+	_, err := ptyOutput(result).Write([]byte("cat: /work/.env: Permission denied\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "cat: /work/.env: Permission denied\n", tap.String())
+}
+
+func TestPTYOutputIsStdoutWithoutDiagnostics(t *testing.T) {
+	assert.Equal(t, os.Stdout, ptyOutput(sandbox.NewExecutionResult()))
 }

--- a/sandbox/all_overrides.go
+++ b/sandbox/all_overrides.go
@@ -3,10 +3,11 @@ package sandbox
 // BuildAllOverrides maps every safe FS/exec violation in report to an
 // OverrideSuggestion. Network violations are intentionally skipped because
 // drivers do not classify network denials yet. Returns nil when the report is
-// empty. Duplicates (same Kind+Target) are collapsed so callers do not have to
-// de-dup against the existing overlay before passing the result through.
+// empty or OutputDerived, since forgeable evidence must not become a persisted
+// allowance. Duplicates (same Kind+Target) are collapsed so callers do not have
+// to de-dup against the existing overlay before passing the result through.
 func BuildAllOverrides(report *ViolationReport) []OverrideSuggestion {
-	if report == nil || len(report.Violations) == 0 {
+	if report == nil || len(report.Violations) == 0 || report.OutputDerived {
 		return nil
 	}
 

--- a/sandbox/platform/bubblewrap_diagnostics_linux.go
+++ b/sandbox/platform/bubblewrap_diagnostics_linux.go
@@ -1,0 +1,215 @@
+//go:build linux
+
+package platform
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/safedep/pmg/sandbox"
+)
+
+// Bubblewrap enforces with namespaces and mounts rather than an LSM, so it
+// never observes a denial: the kernel fails the syscall and the sandboxed
+// program reports it. The prefix varies by program ("cat:", "npm ERR!",
+// "/bin/sh: 1: cannot create"); the strerror(3) phrase it ends with does not,
+// so matching is anchored on the suffix.
+const (
+	bubblewrapErrnoEACCES = "Permission denied"
+	bubblewrapErrnoEPERM  = "Operation not permitted"
+	bubblewrapErrnoEROFS  = "Read-only file system"
+	bubblewrapErrnoENOENT = "No such file or directory"
+)
+
+var bubblewrapErrnoPhrases = []string{
+	bubblewrapErrnoEACCES,
+	bubblewrapErrnoEPERM,
+	bubblewrapErrnoEROFS,
+	bubblewrapErrnoENOENT,
+}
+
+// bubblewrapMaxTargetLen bounds a parsed target. The sandboxed process controls
+// what reaches stderr, and no path the kernel rejected can exceed PATH_MAX.
+const bubblewrapMaxTargetLen = 4096
+
+// bubblewrapVerbs maps the verb a program prefixes to a path onto a violation
+// kind. It only classifies: bubblewrapExtractTarget does not consult it, so an
+// unlisted verb costs precision on the kind rather than losing the target.
+//
+// Longer prefixes precede the prefixes they contain so the longest match wins.
+var bubblewrapVerbs = []struct {
+	prefix string
+	kind   sandbox.ViolationKind
+}{
+	{"cannot remove directory ", sandbox.ViolationKindFSDeleteOrRename},
+	{"cannot remove ", sandbox.ViolationKindFSDeleteOrRename},
+	{"cannot unlink ", sandbox.ViolationKindFSDeleteOrRename},
+	{"cannot rename ", sandbox.ViolationKindFSDeleteOrRename},
+	{"cannot move ", sandbox.ViolationKindFSDeleteOrRename},
+	{"cannot create ", sandbox.ViolationKindFSWrite},
+	{"cannot make directory ", sandbox.ViolationKindFSWrite},
+	{"cannot touch ", sandbox.ViolationKindFSWrite},
+	{"cannot write ", sandbox.ViolationKindFSWrite},
+	{"changing ownership of ", sandbox.ViolationKindFSWrite},
+	{"changing permissions of ", sandbox.ViolationKindFSWrite},
+	{"cannot open ", sandbox.ViolationKindFSRead},
+	{"cannot access ", sandbox.ViolationKindFSRead},
+	{"cannot stat ", sandbox.ViolationKindFSRead},
+	{"execvp ", sandbox.ViolationKindExec},
+}
+
+// bubblewrapDenial is one stderr line reduced to the facts a sandbox.Violation
+// carries.
+type bubblewrapDenial struct {
+	kind    sandbox.ViolationKind
+	target  string
+	process string
+	rawKind string
+	raw     string
+}
+
+// parseBubblewrapDenial extracts a denial from a single stderr line, reporting
+// false for anything it cannot parse confidently. Most package manager output
+// is not a denial, and for an advisory report a false positive costs more than
+// a miss.
+//
+// ENOENT is accepted only for an exec failure, which bwrap itself reports. A
+// missing path reported by the sandboxed program cannot be told apart from a
+// file that genuinely does not exist.
+func parseBubblewrapDenial(line string) (bubblewrapDenial, bool) {
+	trimmed := strings.TrimRight(strings.TrimSpace(line), ".")
+
+	errno, ok := bubblewrapErrnoSuffix(trimmed)
+	if !ok {
+		return bubblewrapDenial{}, false
+	}
+
+	head := strings.TrimRight(strings.TrimSuffix(trimmed, errno), ": ")
+	if head == "" {
+		return bubblewrapDenial{}, false
+	}
+
+	// Split on colon-space rather than colon: a path may legally contain a
+	// colon ("a:b.txt") but effectively never a colon followed by a space.
+	fields := strings.Split(head, ": ")
+	message := strings.TrimSpace(fields[len(fields)-1])
+
+	kind := bubblewrapViolationKind(message, errno)
+	if errno == bubblewrapErrnoENOENT && kind != sandbox.ViolationKindExec {
+		return bubblewrapDenial{}, false
+	}
+
+	target := bubblewrapExtractTarget(message)
+	if !bubblewrapPlausibleTarget(target) {
+		return bubblewrapDenial{}, false
+	}
+
+	return bubblewrapDenial{
+		kind:    kind,
+		target:  target,
+		process: bubblewrapProcess(fields),
+		rawKind: errno,
+		raw:     trimmed,
+	}, true
+}
+
+// bubblewrapErrnoSuffix reports the errno phrase a line ends with; lines
+// without one are not denials.
+func bubblewrapErrnoSuffix(line string) (string, bool) {
+	for _, phrase := range bubblewrapErrnoPhrases {
+		if strings.HasSuffix(line, phrase) {
+			return phrase, true
+		}
+	}
+
+	return "", false
+}
+
+// bubblewrapViolationKind classifies from the verb the program used. Without a
+// recognised verb the operation is inferred: EROFS can only come from a write,
+// and a bare "<path>: Permission denied" is a failed open for read.
+func bubblewrapViolationKind(message, errno string) sandbox.ViolationKind {
+	for _, v := range bubblewrapVerbs {
+		if strings.HasPrefix(message, v.prefix) {
+			return v.kind
+		}
+	}
+
+	if errno == bubblewrapErrnoEROFS {
+		return sandbox.ViolationKindFSWrite
+	}
+
+	return sandbox.ViolationKindFSRead
+}
+
+// bubblewrapExtractTarget recovers the path from a message that may carry
+// arbitrary prose in front of it. Quoting is the only delimiter a program gives
+// for a path containing spaces, so a quoted tail wins; otherwise the path is the
+// final whitespace-separated token.
+func bubblewrapExtractTarget(message string) string {
+	if inner, ok := bubblewrapQuotedTail(message); ok {
+		return inner
+	}
+
+	if idx := strings.LastIndexByte(message, ' '); idx >= 0 {
+		return message[idx+1:]
+	}
+
+	return message
+}
+
+// bubblewrapQuotedTail returns the contents of a quoted region closing the
+// message. GNU tools historically render names as `name' rather than 'name'.
+func bubblewrapQuotedTail(message string) (string, bool) {
+	if len(message) < 2 {
+		return "", false
+	}
+
+	body := message[:len(message)-1]
+
+	var open int
+	switch message[len(message)-1] {
+	case '\'':
+		open = max(strings.LastIndexByte(body, '\''), strings.LastIndexByte(body, '`'))
+	case '"':
+		open = strings.LastIndexByte(body, '"')
+	default:
+		return "", false
+	}
+
+	if open < 0 {
+		return "", false
+	}
+
+	return body[open+1:], true
+}
+
+// bubblewrapPlausibleTarget rejects anything that does not look like a path.
+// Programs narrate around errno phrases, so without this every "npm ERR! ...
+// Permission denied" line would become a violation.
+func bubblewrapPlausibleTarget(target string) bool {
+	if target == "" || len(target) > bubblewrapMaxTargetLen {
+		return false
+	}
+
+	if strings.ContainsAny(target, "\x00\n\r") {
+		return false
+	}
+
+	return strings.Contains(target, "/") || strings.HasPrefix(target, ".")
+}
+
+// bubblewrapProcess recovers the failing program from the leading field. It is
+// advisory: programs that do not prefix their name yield "".
+func bubblewrapProcess(fields []string) string {
+	if len(fields) < 2 {
+		return ""
+	}
+
+	head := strings.TrimSpace(fields[0])
+	if head == "" || strings.ContainsAny(head, " \t") {
+		return ""
+	}
+
+	return filepath.Base(head)
+}

--- a/sandbox/platform/bubblewrap_diagnostics_linux.go
+++ b/sandbox/platform/bubblewrap_diagnostics_linux.go
@@ -4,6 +4,8 @@ package platform
 
 import (
 	"bytes"
+	"io"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -125,9 +127,9 @@ func parseBubblewrapDenial(line string) (bubblewrapDenial, bool) {
 	return bubblewrapDenial{
 		kind:    kind,
 		target:  target,
-		process: bubblewrapProcess(fields),
+		process: bubblewrapStripControl(bubblewrapProcess(fields)),
 		rawKind: errno,
-		raw:     raw,
+		raw:     bubblewrapStripControl(raw),
 	}, true
 }
 
@@ -201,9 +203,9 @@ func bubblewrapQuotedTarget(message string) (string, bool) {
 }
 
 // bubblewrapPlausibleTarget rejects anything that does not look like a path.
-// The trailing token of a line is often prose, so "npm ERR! ... Permission
-// denied" would otherwise report "..." as a denied path. A path carries a
-// separator or an extension, and at least one letter or digit.
+// The trailing token of a line is often prose: without this check the line
+// "npm ERR! ... Permission denied" would report "..." as a denied path. A path
+// carries a separator or an extension, and at least one letter or digit.
 //
 // Extensionless bare names in the working directory (Makefile) are consequently
 // missed. That is the deliberate side of the trade: a wrong target produces a
@@ -213,7 +215,7 @@ func bubblewrapPlausibleTarget(target string) bool {
 		return false
 	}
 
-	if strings.ContainsAny(target, "\x00\n\r") {
+	if strings.ContainsFunc(target, unicode.IsControl) {
 		return false
 	}
 
@@ -239,6 +241,23 @@ func bubblewrapProcess(fields []string) string {
 	}
 
 	return filepath.Base(head)
+}
+
+// bubblewrapStripControl removes control characters from a field bound for a
+// terminal. Unlike the other drivers' evidence, these fields are written by the
+// sandboxed process. Dropping the escape character leaves the rest of any
+// sequence as inert text, so it cannot act on the terminal when
+// `pmg sandbox explain` renders it.
+//
+// A target carrying control characters is rejected outright instead, since it
+// also feeds an override suggestion the user may copy.
+func bubblewrapStripControl(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 // bubblewrapDenialCap bounds the per-run denial buffer. Denials are deduplicated
@@ -269,6 +288,12 @@ type bubblewrapStderrTap struct {
 
 func newBubblewrapStderrTap() *bubblewrapStderrTap {
 	return &bubblewrapStderrTap{seen: make(map[string]bool)}
+}
+
+// bubblewrapDenialKey identifies a denial for deduplication: the same kind of
+// block on the same target is one denial, however many times a process retries.
+func bubblewrapDenialKey(d bubblewrapDenial) string {
+	return string(d.kind) + "\x00" + d.target
 }
 
 func (t *bubblewrapStderrTap) Write(p []byte) (int, error) {
@@ -365,8 +390,68 @@ func (t *bubblewrapStderrTap) collect() []bubblewrapDenial {
 	return out
 }
 
-// bubblewrapDenialKey identifies a denial for deduplication: the same kind of
-// block on the same target is one denial, however many times a process retries.
-func bubblewrapDenialKey(d bubblewrapDenial) string {
-	return string(d.kind) + "\x00" + d.target
+// attachDiagnostics splices a stderr tap into cmd for this run. State is
+// replaced on every Execute so a reused driver never reports a previous run's
+// denials.
+//
+// The existing writer is wrapped rather than replaced: the caller has already
+// pointed stderr at the user's terminal, and the command's own output must
+// reach it unchanged.
+func (b *bubblewrapSandbox) attachDiagnostics(cmd *exec.Cmd, policy *sandbox.SandboxPolicy) {
+	tap := newBubblewrapStderrTap()
+
+	b.tap = tap
+	b.policyName = policy.Name
+
+	if cmd.Stderr == nil {
+		cmd.Stderr = tap
+		return
+	}
+
+	cmd.Stderr = io.MultiWriter(cmd.Stderr, tap)
+}
+
+// DiagnosticsWriter exposes this run's tap for execution paths that route the
+// command's output themselves instead of through cmd.Stderr. A PTY session
+// merges stdout and stderr onto the pty master, so the tap sees both; denial
+// lines are still selected by their errno suffix.
+func (b *bubblewrapSandbox) DiagnosticsWriter() io.Writer {
+	if b.tap == nil {
+		return nil
+	}
+
+	return b.tap
+}
+
+// BestEffortViolation reports denials parsed from the sandboxed command's own
+// output during the last Execute. Coverage is bounded by what that command
+// chose to print, since bubblewrap observes nothing itself; see
+// parseBubblewrapDenial for what is and is not recognised.
+func (b *bubblewrapSandbox) BestEffortViolation(err error) (*sandbox.ViolationReport, error) {
+	if err == nil || b.tap == nil {
+		return nil, nil
+	}
+
+	denials := b.tap.collect()
+	if len(denials) == 0 {
+		return nil, nil
+	}
+
+	violations := make([]sandbox.Violation, 0, len(denials))
+	for _, d := range denials {
+		violations = append(violations, sandbox.Violation{
+			Kind:      d.kind,
+			RawKind:   d.rawKind,
+			Target:    d.target,
+			Process:   d.process,
+			RawLog:    d.raw,
+			RuleLabel: summarizeViolation(d.kind, d.target),
+		})
+	}
+
+	return &sandbox.ViolationReport{
+		SandboxName: b.Name(),
+		PolicyName:  b.policyName,
+		Violations:  violations,
+	}, nil
 }

--- a/sandbox/platform/bubblewrap_diagnostics_linux.go
+++ b/sandbox/platform/bubblewrap_diagnostics_linux.go
@@ -3,9 +3,13 @@
 package platform
 
 import (
+	"bytes"
 	"path/filepath"
 	"strings"
+	"sync"
+	"unicode"
 
+	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/sandbox"
 )
 
@@ -33,29 +37,39 @@ var bubblewrapErrnoPhrases = []string{
 const bubblewrapMaxTargetLen = 4096
 
 // bubblewrapVerbs maps the verb a program prefixes to a path onto a violation
-// kind. It only classifies: bubblewrapExtractTarget does not consult it, so an
-// unlisted verb costs precision on the kind rather than losing the target.
+// kind. Only verbs that contradict the fallback in bubblewrapViolationKind are
+// listed; a read verb would restate it.
 //
-// Longer prefixes precede the prefixes they contain so the longest match wins.
+// When adding an entry, place it ahead of any prefix it extends so the longer
+// match wins.
 var bubblewrapVerbs = []struct {
 	prefix string
 	kind   sandbox.ViolationKind
 }{
-	{"cannot remove directory ", sandbox.ViolationKindFSDeleteOrRename},
 	{"cannot remove ", sandbox.ViolationKindFSDeleteOrRename},
+	{"failed to remove ", sandbox.ViolationKindFSDeleteOrRename},
 	{"cannot unlink ", sandbox.ViolationKindFSDeleteOrRename},
-	{"cannot rename ", sandbox.ViolationKindFSDeleteOrRename},
 	{"cannot move ", sandbox.ViolationKindFSDeleteOrRename},
 	{"cannot create ", sandbox.ViolationKindFSWrite},
-	{"cannot make directory ", sandbox.ViolationKindFSWrite},
 	{"cannot touch ", sandbox.ViolationKindFSWrite},
-	{"cannot write ", sandbox.ViolationKindFSWrite},
+	{"failed to create symbolic link ", sandbox.ViolationKindFSWrite},
 	{"changing ownership of ", sandbox.ViolationKindFSWrite},
 	{"changing permissions of ", sandbox.ViolationKindFSWrite},
-	{"cannot open ", sandbox.ViolationKindFSRead},
-	{"cannot access ", sandbox.ViolationKindFSRead},
-	{"cannot stat ", sandbox.ViolationKindFSRead},
 	{"execvp ", sandbox.ViolationKindExec},
+}
+
+// bubblewrapQuotePairs are the quoting styles a program may use to delimit a
+// path. Coreutils selects between the ASCII and Unicode forms by locale, so
+// both occur in practice; the backtick form is older GNU output.
+var bubblewrapQuotePairs = []struct {
+	open  string
+	close string
+}{
+	{"‘", "’"},
+	{"“", "”"},
+	{"`", "'"},
+	{"'", "'"},
+	{`"`, `"`},
 }
 
 // bubblewrapDenial is one stderr line reduced to the facts a sandbox.Violation
@@ -77,7 +91,11 @@ type bubblewrapDenial struct {
 // missing path reported by the sandboxed program cannot be told apart from a
 // file that genuinely does not exist.
 func parseBubblewrapDenial(line string) (bubblewrapDenial, bool) {
-	trimmed := strings.TrimRight(strings.TrimSpace(line), ".")
+	raw := strings.TrimSpace(line)
+
+	// Some programs terminate the message with a period. Match without it, but
+	// keep raw as printed.
+	trimmed := strings.TrimRight(raw, ".")
 
 	errno, ok := bubblewrapErrnoSuffix(trimmed)
 	if !ok {
@@ -109,7 +127,7 @@ func parseBubblewrapDenial(line string) (bubblewrapDenial, bool) {
 		target:  target,
 		process: bubblewrapProcess(fields),
 		rawKind: errno,
-		raw:     trimmed,
+		raw:     raw,
 	}, true
 }
 
@@ -143,12 +161,10 @@ func bubblewrapViolationKind(message, errno string) sandbox.ViolationKind {
 }
 
 // bubblewrapExtractTarget recovers the path from a message that may carry
-// arbitrary prose in front of it. Quoting is the only delimiter a program gives
-// for a path containing spaces, so a quoted tail wins; otherwise the path is the
-// final whitespace-separated token.
+// arbitrary prose around it.
 func bubblewrapExtractTarget(message string) string {
-	if inner, ok := bubblewrapQuotedTail(message); ok {
-		return inner
+	if quoted, ok := bubblewrapQuotedTarget(message); ok {
+		return quoted
 	}
 
 	if idx := strings.LastIndexByte(message, ' '); idx >= 0 {
@@ -158,35 +174,40 @@ func bubblewrapExtractTarget(message string) string {
 	return message
 }
 
-// bubblewrapQuotedTail returns the contents of a quoted region closing the
-// message. GNU tools historically render names as `name' rather than 'name'.
-func bubblewrapQuotedTail(message string) (string, bool) {
-	if len(message) < 2 {
+// bubblewrapQuotedTarget returns the innermost quoted region of the message.
+// Quoting is the only delimiter a program gives for a path containing spaces,
+// and some tools follow the path with prose ("cannot open '/x' for reading"),
+// so the search is not anchored to the end. Selecting the latest opening quote
+// keeps an unrelated earlier quote from swallowing the path.
+func bubblewrapQuotedTarget(message string) (string, bool) {
+	bestStart, bestEnd, openLen := -1, -1, 0
+
+	for _, q := range bubblewrapQuotePairs {
+		end := strings.LastIndex(message, q.close)
+		if end <= 0 {
+			continue
+		}
+
+		if start := strings.LastIndex(message[:end], q.open); start > bestStart {
+			bestStart, bestEnd, openLen = start, end, len(q.open)
+		}
+	}
+
+	if bestStart < 0 {
 		return "", false
 	}
 
-	body := message[:len(message)-1]
-
-	var open int
-	switch message[len(message)-1] {
-	case '\'':
-		open = max(strings.LastIndexByte(body, '\''), strings.LastIndexByte(body, '`'))
-	case '"':
-		open = strings.LastIndexByte(body, '"')
-	default:
-		return "", false
-	}
-
-	if open < 0 {
-		return "", false
-	}
-
-	return body[open+1:], true
+	return message[bestStart+openLen : bestEnd], true
 }
 
 // bubblewrapPlausibleTarget rejects anything that does not look like a path.
-// Programs narrate around errno phrases, so without this every "npm ERR! ...
-// Permission denied" line would become a violation.
+// The trailing token of a line is often prose, so "npm ERR! ... Permission
+// denied" would otherwise report "..." as a denied path. A path carries a
+// separator or an extension, and at least one letter or digit.
+//
+// Extensionless bare names in the working directory (Makefile) are consequently
+// missed. That is the deliberate side of the trade: a wrong target produces a
+// misleading override suggestion, while a missed one only costs a report.
 func bubblewrapPlausibleTarget(target string) bool {
 	if target == "" || len(target) > bubblewrapMaxTargetLen {
 		return false
@@ -196,7 +217,13 @@ func bubblewrapPlausibleTarget(target string) bool {
 		return false
 	}
 
-	return strings.Contains(target, "/") || strings.HasPrefix(target, ".")
+	if !strings.Contains(target, "/") && !strings.Contains(target, ".") {
+		return false
+	}
+
+	return strings.ContainsFunc(target, func(r rune) bool {
+		return unicode.IsLetter(r) || unicode.IsDigit(r)
+	})
 }
 
 // bubblewrapProcess recovers the failing program from the leading field. It is
@@ -212,4 +239,134 @@ func bubblewrapProcess(fields []string) string {
 	}
 
 	return filepath.Base(head)
+}
+
+// bubblewrapDenialCap bounds the per-run denial buffer. Denials are deduplicated
+// before the cap applies, so this caps distinct denials: a process retrying one
+// denied path cannot evict a later, different one.
+const bubblewrapDenialCap = 512
+
+// bubblewrapMaxLineLen bounds an unterminated line. The sandboxed process
+// decides when to emit a newline, so a stream without one must not grow the tap
+// indefinitely.
+const bubblewrapMaxLineLen = 16 * 1024
+
+// bubblewrapStderrTap is an io.Writer spliced into the sandboxed command's
+// stderr. It reassembles lines across writes, since a write carries an arbitrary
+// byte range rather than whole lines, and buffers the denials it finds.
+//
+// Write never reports an error. The tap shares cmd.Stderr with the user's
+// terminal through io.MultiWriter, which stops at the first failing writer, so
+// failing here would silence the command's own output.
+type bubblewrapStderrTap struct {
+	mu       sync.Mutex
+	partial  []byte
+	skipping bool
+	denials  []bubblewrapDenial
+	seen     map[string]bool
+	dropped  bool
+}
+
+func newBubblewrapStderrTap() *bubblewrapStderrTap {
+	return &bubblewrapStderrTap{seen: make(map[string]bool)}
+}
+
+func (t *bubblewrapStderrTap) Write(p []byte) (int, error) {
+	n := len(p)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for len(p) > 0 {
+		idx := bytes.IndexByte(p, '\n')
+		if idx < 0 {
+			t.buffer(p)
+			break
+		}
+
+		t.buffer(p[:idx])
+		t.flushLine()
+		p = p[idx+1:]
+	}
+
+	return n, nil
+}
+
+// buffer accumulates a line fragment. An over-long line is abandoned rather than
+// truncated: a truncated head still ends in the errno phrase and would parse
+// into a plausible but wrong target.
+//
+// Caller must hold t.mu.
+func (t *bubblewrapStderrTap) buffer(chunk []byte) {
+	if t.skipping {
+		return
+	}
+
+	if len(t.partial)+len(chunk) > bubblewrapMaxLineLen {
+		t.skipping = true
+		t.partial = nil
+		return
+	}
+
+	t.partial = append(t.partial, chunk...)
+}
+
+// flushLine records a denial if the accumulated line holds one.
+//
+// Caller must hold t.mu.
+func (t *bubblewrapStderrTap) flushLine() {
+	line := string(t.partial)
+	t.partial = nil
+
+	if t.skipping {
+		t.skipping = false
+		return
+	}
+
+	denial, ok := parseBubblewrapDenial(line)
+	if !ok {
+		return
+	}
+
+	key := bubblewrapDenialKey(denial)
+	if t.seen[key] {
+		return
+	}
+
+	if len(t.denials) >= bubblewrapDenialCap {
+		if !t.dropped {
+			t.dropped = true
+			log.Warnf("bubblewrap diagnostics: denial buffer full (%d), dropping further denials", bubblewrapDenialCap)
+		}
+		return
+	}
+
+	// seen is marked only on append so it stays bounded by the cap. Its keys
+	// carry paths the sandboxed process chose, so growing it unconditionally
+	// would reintroduce the memory growth the cap exists to prevent.
+	t.seen[key] = true
+	t.denials = append(t.denials, denial)
+}
+
+// collect flushes any unterminated trailing line and returns the buffered
+// denials. Callers invoke it after cmd.Run() has returned, when no further
+// writes can race with the flush.
+func (t *bubblewrapStderrTap) collect() []bubblewrapDenial {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if len(t.partial) > 0 {
+		t.flushLine()
+	}
+
+	out := make([]bubblewrapDenial, len(t.denials))
+	copy(out, t.denials)
+
+	return out
+}
+
+// bubblewrapDenialKey identifies a denial for deduplication: the same kind of
+// block on the same target is one denial, however many times a process retries.
+func bubblewrapDenialKey(d bubblewrapDenial) string {
+	return string(d.kind) + "\x00" + d.target
 }

--- a/sandbox/platform/bubblewrap_diagnostics_linux.go
+++ b/sandbox/platform/bubblewrap_diagnostics_linux.go
@@ -5,6 +5,7 @@ package platform
 import (
 	"bytes"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -402,6 +403,7 @@ func (b *bubblewrapSandbox) attachDiagnostics(cmd *exec.Cmd, policy *sandbox.San
 
 	b.tap = tap
 	b.policyName = policy.Name
+	b.pinMessageLocale(cmd)
 
 	if cmd.Stderr == nil {
 		cmd.Stderr = tap
@@ -409,6 +411,19 @@ func (b *bubblewrapSandbox) attachDiagnostics(cmd *exec.Cmd, policy *sandbox.San
 	}
 
 	cmd.Stderr = io.MultiWriter(cmd.Stderr, tap)
+}
+
+// pinMessageLocale asks the child for C-locale diagnostics: denials are
+// recognised by their strerror(3) phrase, which libc translates.
+//
+// LC_ALL outranks this and is deliberately left alone, since overriding it
+// would change number formatting and collation for every build script.
+func (b *bubblewrapSandbox) pinMessageLocale(cmd *exec.Cmd) {
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+
+	cmd.Env = append(cmd.Env, "LC_MESSAGES=C")
 }
 
 // DiagnosticsWriter exposes this run's tap for execution paths that route the
@@ -450,8 +465,9 @@ func (b *bubblewrapSandbox) BestEffortViolation(err error) (*sandbox.ViolationRe
 	}
 
 	return &sandbox.ViolationReport{
-		SandboxName: b.Name(),
-		PolicyName:  b.policyName,
-		Violations:  violations,
+		SandboxName:   b.Name(),
+		PolicyName:    b.policyName,
+		Violations:    violations,
+		OutputDerived: true,
 	}, nil
 }

--- a/sandbox/platform/bubblewrap_diagnostics_linux_test.go
+++ b/sandbox/platform/bubblewrap_diagnostics_linux_test.go
@@ -3,7 +3,10 @@
 package platform
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -271,6 +274,23 @@ func TestParseBubblewrapDenialKeepsRawLineAsPrinted(t *testing.T) {
 	assert.Equal(t, line, got.raw)
 }
 
+// The evidence fields are written by the sandboxed process and are rendered
+// later by `pmg sandbox explain`. Removing the escape character leaves the
+// remaining bytes as inert text, which is what stops the sequence firing.
+func TestParseBubblewrapDenialNeutralisesTerminalEscapes(t *testing.T) {
+	got, ok := parseBubblewrapDenial("\x1b[31mcat\x1b[0m: /work/.env: Permission denied")
+	require.True(t, ok)
+
+	assert.Equal(t, "/work/.env", got.target)
+	assert.NotContains(t, got.raw, "\x1b")
+	assert.NotContains(t, got.process, "\x1b")
+}
+
+func TestParseBubblewrapDenialRejectsControlCharsInTarget(t *testing.T) {
+	_, ok := parseBubblewrapDenial("cat: /work/\x1b[2J.env: Permission denied")
+	assert.False(t, ok)
+}
+
 func TestParseBubblewrapDenialRejectsOversizedTarget(t *testing.T) {
 	long := "/" + strings.Repeat("a", bubblewrapMaxTargetLen)
 	require.Greater(t, len(long), bubblewrapMaxTargetLen)
@@ -335,6 +355,151 @@ func TestBubblewrapStderrTapBoundsDistinctDenials(t *testing.T) {
 
 	assert.Len(t, tap.collect(), bubblewrapDenialCap)
 	assert.Len(t, tap.seen, bubblewrapDenialCap)
+}
+
+func TestAttachDiagnosticsPreservesExistingStderr(t *testing.T) {
+	b, err := newBubblewrapSandbox()
+	require.NoError(t, err)
+
+	var userVisible bytes.Buffer
+	cmd := &exec.Cmd{Stderr: &userVisible}
+
+	b.attachDiagnostics(cmd, &sandbox.SandboxPolicy{Name: "npm-restrictive"})
+
+	line := "cat: /work/.env: Permission denied\n"
+	_, err = cmd.Stderr.Write([]byte(line))
+	require.NoError(t, err)
+
+	assert.Equal(t, line, userVisible.String())
+	assert.Len(t, b.tap.collect(), 1)
+}
+
+func TestAttachDiagnosticsHandlesNilStderr(t *testing.T) {
+	b, err := newBubblewrapSandbox()
+	require.NoError(t, err)
+
+	cmd := &exec.Cmd{}
+	b.attachDiagnostics(cmd, &sandbox.SandboxPolicy{Name: "npm-restrictive"})
+
+	require.NotNil(t, cmd.Stderr)
+	_, err = cmd.Stderr.Write([]byte("cat: /work/.env: Permission denied\n"))
+	require.NoError(t, err)
+
+	assert.Len(t, b.tap.collect(), 1)
+}
+
+func TestAttachDiagnosticsReplacesPreviousRunState(t *testing.T) {
+	b, err := newBubblewrapSandbox()
+	require.NoError(t, err)
+
+	first := &exec.Cmd{}
+	b.attachDiagnostics(first, &sandbox.SandboxPolicy{Name: "npm-restrictive"})
+	_, err = first.Stderr.Write([]byte("cat: /work/.env: Permission denied\n"))
+	require.NoError(t, err)
+
+	second := &exec.Cmd{}
+	b.attachDiagnostics(second, &sandbox.SandboxPolicy{Name: "npm-strict"})
+
+	report, err := b.BestEffortViolation(errors.New("exit status 1"))
+	require.NoError(t, err)
+	assert.Nil(t, report)
+}
+
+func TestBestEffortViolation(t *testing.T) {
+	tests := []struct {
+		name    string
+		stderr  string
+		runErr  error
+		attach  bool
+		wantNil bool
+	}{
+		{
+			name:    "successful run reports nothing",
+			stderr:  "cat: /work/.env: Permission denied\n",
+			attach:  true,
+			wantNil: true,
+		},
+		{
+			name:    "execute never ran",
+			runErr:  errors.New("exit status 1"),
+			wantNil: true,
+		},
+		{
+			name:    "output holds no denial",
+			stderr:  "npm WARN deprecated left-pad@1.0.0\n",
+			runErr:  errors.New("exit status 1"),
+			attach:  true,
+			wantNil: true,
+		},
+		{
+			name:   "denial is reported",
+			stderr: "cat: /work/.env: Permission denied\n",
+			runErr: errors.New("exit status 1"),
+			attach: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := newBubblewrapSandbox()
+			require.NoError(t, err)
+
+			if tc.attach {
+				cmd := &exec.Cmd{}
+				b.attachDiagnostics(cmd, &sandbox.SandboxPolicy{Name: "npm-restrictive"})
+				_, err = cmd.Stderr.Write([]byte(tc.stderr))
+				require.NoError(t, err)
+			}
+
+			report, err := b.BestEffortViolation(tc.runErr)
+			require.NoError(t, err)
+
+			if tc.wantNil {
+				assert.Nil(t, report)
+				return
+			}
+
+			require.NotNil(t, report)
+			assert.Equal(t, sandbox.DriverBubblewrap, report.SandboxName)
+			assert.Equal(t, "npm-restrictive", report.PolicyName)
+			assert.Equal(t, []sandbox.Violation{{
+				Kind:      sandbox.ViolationKindFSRead,
+				RawKind:   bubblewrapErrnoEACCES,
+				Target:    "/work/.env",
+				Process:   "cat",
+				RawLog:    "cat: /work/.env: Permission denied",
+				RuleLabel: "read access denied: /work/.env",
+			}}, report.Violations)
+		})
+	}
+}
+
+// ExecutionResult reaches the reporter through an unexported interface
+// assertion, which is what silently yielded no diagnostics for this driver.
+func TestExecutionResultReachesBubblewrapReporter(t *testing.T) {
+	b, err := newBubblewrapSandbox()
+	require.NoError(t, err)
+
+	cmd := &exec.Cmd{}
+	b.attachDiagnostics(cmd, &sandbox.SandboxPolicy{Name: "npm-restrictive"})
+	_, err = cmd.Stderr.Write([]byte("cat: /work/.env: Permission denied\n"))
+	require.NoError(t, err)
+
+	result := sandbox.NewExecutionResult(sandbox.WithExecutionResultSandbox(b))
+
+	report, err := result.BestEffortViolation(errors.New("exit status 1"))
+	require.NoError(t, err)
+	require.NotNil(t, report)
+
+	assert.Equal(t, sandbox.DriverBubblewrap, report.SandboxName)
+	require.Len(t, report.Violations, 1)
+
+	explanation := sandbox.BuildExplanation(report)
+	require.NotNil(t, explanation.Primary)
+	assert.Equal(t, "/work/.env", explanation.Primary.Target)
+	require.NotNil(t, explanation.Override)
+	assert.Equal(t, sandbox.ViolationKindFSRead, explanation.Override.Kind)
+	assert.Equal(t, "/work/.env", explanation.Override.Target)
 }
 
 func TestBubblewrapStderrTapAbandonsOversizedLine(t *testing.T) {

--- a/sandbox/platform/bubblewrap_diagnostics_linux_test.go
+++ b/sandbox/platform/bubblewrap_diagnostics_linux_test.go
@@ -3,6 +3,7 @@
 package platform
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -11,115 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBubblewrapErrnoSuffix(t *testing.T) {
-	tests := []struct {
-		name   string
-		line   string
-		want   string
-		wantOK bool
-	}{
-		{
-			name:   "permission denied",
-			line:   "cat: /work/.env: Permission denied",
-			want:   bubblewrapErrnoEACCES,
-			wantOK: true,
-		},
-		{
-			name:   "read only file system",
-			line:   "/bin/sh: 1: cannot create /srv/test: Read-only file system",
-			want:   bubblewrapErrnoEROFS,
-			wantOK: true,
-		},
-		{
-			name:   "operation not permitted",
-			line:   "chown: changing ownership of '/x/y': Operation not permitted",
-			want:   bubblewrapErrnoEPERM,
-			wantOK: true,
-		},
-		{
-			name:   "no such file or directory",
-			line:   "bwrap: execvp /usr/bin/git: No such file or directory",
-			want:   bubblewrapErrnoENOENT,
-			wantOK: true,
-		},
-		{
-			name:   "ordinary package manager noise",
-			line:   "npm WARN deprecated left-pad@1.0.0",
-			wantOK: false,
-		},
-		{
-			name:   "errno phrase away from the end is not a denial line",
-			line:   "PermissionError: [Errno 13] Permission denied: '/work/.env'",
-			wantOK: false,
-		},
-		{
-			name:   "empty",
-			line:   "",
-			wantOK: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, ok := bubblewrapErrnoSuffix(tc.line)
-			assert.Equal(t, tc.wantOK, ok)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
-func TestBubblewrapViolationKind(t *testing.T) {
-	tests := []struct {
-		name    string
-		message string
-		errno   string
-		want    sandbox.ViolationKind
-	}{
-		{
-			name:    "bare path defaults to read",
-			message: "/work/.env",
-			errno:   bubblewrapErrnoEACCES,
-			want:    sandbox.ViolationKindFSRead,
-		},
-		{
-			name:    "create is a write",
-			message: "cannot create /etc/nope",
-			errno:   bubblewrapErrnoEACCES,
-			want:    sandbox.ViolationKindFSWrite,
-		},
-		{
-			name:    "longest verb wins over its own prefix",
-			message: "cannot remove directory '/opt/pkg'",
-			errno:   bubblewrapErrnoEACCES,
-			want:    sandbox.ViolationKindFSDeleteOrRename,
-		},
-		{
-			name:    "execvp is an exec",
-			message: "execvp /usr/bin/git",
-			errno:   bubblewrapErrnoENOENT,
-			want:    sandbox.ViolationKindExec,
-		},
-		{
-			name:    "read only filesystem implies a write without a verb",
-			message: "/srv/test",
-			errno:   bubblewrapErrnoEROFS,
-			want:    sandbox.ViolationKindFSWrite,
-		},
-		{
-			name:    "unrecognised verb falls back to read",
-			message: "failed while doing something to /work/.env",
-			errno:   bubblewrapErrnoEACCES,
-			want:    sandbox.ViolationKindFSRead,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, bubblewrapViolationKind(tc.message, tc.errno))
-		})
-	}
-}
-
+// The lines below were captured from the tools they name, under a real
+// bubblewrap sandbox where the scenario allowed it.
 func TestParseBubblewrapDenial(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -131,7 +25,7 @@ func TestParseBubblewrapDenial(t *testing.T) {
 		wantRawKind string
 	}{
 		{
-			name:        "read denied with relative path",
+			name:        "read denied on a relative path",
 			line:        "cat: work/.env: Permission denied",
 			wantOK:      true,
 			wantKind:    sandbox.ViolationKindFSRead,
@@ -140,11 +34,20 @@ func TestParseBubblewrapDenial(t *testing.T) {
 			wantRawKind: bubblewrapErrnoEACCES,
 		},
 		{
-			name:        "program path is not mistaken for the target",
+			name:        "absolute program path is not mistaken for the target",
 			line:        "/bin/cat: /home/u/.npmrc: Permission denied",
 			wantOK:      true,
 			wantKind:    sandbox.ViolationKindFSRead,
 			wantTarget:  "/home/u/.npmrc",
+			wantProcess: "cat",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "plain project file with no separator or leading dot",
+			line:        "cat: package.json: Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSRead,
+			wantTarget:  "package.json",
 			wantProcess: "cat",
 			wantRawKind: bubblewrapErrnoEACCES,
 		},
@@ -167,6 +70,87 @@ func TestParseBubblewrapDenial(t *testing.T) {
 			wantRawKind: bubblewrapErrnoEROFS,
 		},
 		{
+			name:        "unicode quoting, the coreutils default in a UTF-8 locale",
+			line:        "mkdir: cannot create directory ‘/etc/nope’: Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSWrite,
+			wantTarget:  "/etc/nope",
+			wantProcess: "mkdir",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "ascii quoting, the same tool under LC_ALL=C",
+			line:        "mkdir: cannot create directory '/etc/nope': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSWrite,
+			wantTarget:  "/etc/nope",
+			wantProcess: "mkdir",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "older gnu backtick quoting",
+			line:        "mkdir: cannot create directory `/opt/pkg': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSWrite,
+			wantTarget:  "/opt/pkg",
+			wantProcess: "mkdir",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "prose after the path does not displace it",
+			line:        "head: cannot open '/etc/shadow' for reading: Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSRead,
+			wantTarget:  "/etc/shadow",
+			wantProcess: "head",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "remove is a delete",
+			line:        "rm: cannot remove '/etc/hosts': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSDeleteOrRename,
+			wantTarget:  "/etc/hosts",
+			wantProcess: "rm",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "rmdir words it as a failure to remove",
+			line:        "rmdir: failed to remove '/etc': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSDeleteOrRename,
+			wantTarget:  "/etc",
+			wantProcess: "rmdir",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "move reports the destination it could not write",
+			line:        "mv: cannot move '/etc/hosts' to '/etc/hosts2': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSDeleteOrRename,
+			wantTarget:  "/etc/hosts2",
+			wantProcess: "mv",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "symlink creation is a write",
+			line:        "ln: failed to create symbolic link '/etc/xyz': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSWrite,
+			wantTarget:  "/etc/xyz",
+			wantProcess: "ln",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "ownership change is a write and reports EPERM",
+			line:        "chown: changing ownership of '/etc/shadow': Operation not permitted",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSWrite,
+			wantTarget:  "/etc/shadow",
+			wantProcess: "chown",
+			wantRawKind: bubblewrapErrnoEPERM,
+		},
+		{
 			name:        "colon in the path survives colon-space splitting",
 			line:        "cat: 'work/a:b.txt': Permission denied",
 			wantOK:      true,
@@ -185,30 +169,21 @@ func TestParseBubblewrapDenial(t *testing.T) {
 			wantRawKind: bubblewrapErrnoEACCES,
 		},
 		{
-			name:        "gnu style backtick quoting",
-			line:        "mkdir: cannot create directory `/opt/pkg': Permission denied",
-			wantOK:      true,
-			wantKind:    sandbox.ViolationKindFSWrite,
-			wantTarget:  "/opt/pkg",
-			wantProcess: "mkdir",
-			wantRawKind: bubblewrapErrnoEACCES,
-		},
-		{
-			name:        "delete is distinguished from write",
-			line:        "rm: cannot remove '/etc/hosts': Permission denied",
-			wantOK:      true,
-			wantKind:    sandbox.ViolationKindFSDeleteOrRename,
-			wantTarget:  "/etc/hosts",
-			wantProcess: "rm",
-			wantRawKind: bubblewrapErrnoEACCES,
-		},
-		{
-			name:        "unrecognised verb still yields the target",
-			line:        "tool: failed while doing something to /work/.env: Permission denied",
+			name:        "an extra context field does not shift the target",
+			line:        "sort: cannot read: /etc/shadow: Permission denied",
 			wantOK:      true,
 			wantKind:    sandbox.ViolationKindFSRead,
-			wantTarget:  "/work/.env",
-			wantProcess: "tool",
+			wantTarget:  "/etc/shadow",
+			wantProcess: "sort",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "unlisted verb still yields the target",
+			line:        "ugrep: warning: cannot read /etc/shadow: Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSRead,
+			wantTarget:  "/etc/shadow",
+			wantProcess: "ugrep",
 			wantRawKind: bubblewrapErrnoEACCES,
 		},
 		{
@@ -241,13 +216,23 @@ func TestParseBubblewrapDenial(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "errno phrase with no message before it",
-			line:   "Permission denied",
+			name:   "prose ending in an errno phrase is not a path",
+			line:   "npm ERR! the registry returned Permission denied",
 			wantOK: false,
 		},
 		{
-			name:   "prose ending in an errno phrase is not a path",
-			line:   "npm ERR! the registry returned Permission denied",
+			name:   "elision in narration is not a path",
+			line:   "npm ERR! ... Permission denied",
+			wantOK: false,
+		},
+		{
+			name:   "bare word after a colon is not a path",
+			line:   "npm ERR! syscall: open Permission denied",
+			wantOK: false,
+		},
+		{
+			name:   "errno phrase with no message before it",
+			line:   "Permission denied",
 			wantOK: false,
 		},
 		{
@@ -276,10 +261,91 @@ func TestParseBubblewrapDenial(t *testing.T) {
 	}
 }
 
+func TestParseBubblewrapDenialKeepsRawLineAsPrinted(t *testing.T) {
+	line := "bfs: error: /root: Permission denied."
+
+	got, ok := parseBubblewrapDenial(line)
+	require.True(t, ok)
+
+	assert.Equal(t, "/root", got.target)
+	assert.Equal(t, line, got.raw)
+}
+
 func TestParseBubblewrapDenialRejectsOversizedTarget(t *testing.T) {
 	long := "/" + strings.Repeat("a", bubblewrapMaxTargetLen)
 	require.Greater(t, len(long), bubblewrapMaxTargetLen)
 
 	_, ok := parseBubblewrapDenial("cat: " + long + ": Permission denied")
 	assert.False(t, ok)
+}
+
+func TestBubblewrapStderrTapReassemblesLinesAcrossWrites(t *testing.T) {
+	tap := newBubblewrapStderrTap()
+
+	chunks := []string{"npm WARN x\nca", "t: /work", "/.env: Permis", "sion denied\nnpm ERR! code 1\n"}
+	for _, chunk := range chunks {
+		n, err := tap.Write([]byte(chunk))
+		require.NoError(t, err)
+		assert.Equal(t, len(chunk), n)
+	}
+
+	denials := tap.collect()
+	require.Len(t, denials, 1)
+	assert.Equal(t, "/work/.env", denials[0].target)
+	assert.Equal(t, sandbox.ViolationKindFSRead, denials[0].kind)
+}
+
+func TestBubblewrapStderrTapFlushesUnterminatedLine(t *testing.T) {
+	tap := newBubblewrapStderrTap()
+
+	_, err := tap.Write([]byte("cat: /work/.npmrc: Permission denied"))
+	require.NoError(t, err)
+
+	denials := tap.collect()
+	require.Len(t, denials, 1)
+	assert.Equal(t, "/work/.npmrc", denials[0].target)
+}
+
+// A retry loop on one denied path must not fill the buffer and evict a later
+// distinct denial, so dedupe happens before the cap applies.
+func TestBubblewrapStderrTapDedupesBeforeCapping(t *testing.T) {
+	tap := newBubblewrapStderrTap()
+
+	for range bubblewrapDenialCap * 2 {
+		_, err := tap.Write([]byte("cat: /work/.env: Permission denied\n"))
+		require.NoError(t, err)
+	}
+
+	_, err := tap.Write([]byte("cat: /work/.npmrc: Permission denied\n"))
+	require.NoError(t, err)
+
+	denials := tap.collect()
+	require.Len(t, denials, 2)
+	assert.Equal(t, "/work/.env", denials[0].target)
+	assert.Equal(t, "/work/.npmrc", denials[1].target)
+}
+
+func TestBubblewrapStderrTapBoundsDistinctDenials(t *testing.T) {
+	tap := newBubblewrapStderrTap()
+
+	for i := range bubblewrapDenialCap + 100 {
+		_, err := fmt.Fprintf(tap, "cat: /work/%d.env: Permission denied\n", i)
+		require.NoError(t, err)
+	}
+
+	assert.Len(t, tap.collect(), bubblewrapDenialCap)
+	assert.Len(t, tap.seen, bubblewrapDenialCap)
+}
+
+func TestBubblewrapStderrTapAbandonsOversizedLine(t *testing.T) {
+	tap := newBubblewrapStderrTap()
+
+	flood := strings.Repeat("x", bubblewrapMaxLineLen+1)
+	_, err := tap.Write([]byte(flood + "/work/.env: Permission denied\n"))
+	require.NoError(t, err)
+	assert.Empty(t, tap.collect())
+
+	_, err = tap.Write([]byte("cat: /work/.env: Permission denied\n"))
+	require.NoError(t, err)
+	assert.Len(t, tap.collect(), 1)
 }

--- a/sandbox/platform/bubblewrap_diagnostics_linux_test.go
+++ b/sandbox/platform/bubblewrap_diagnostics_linux_test.go
@@ -497,9 +497,7 @@ func TestExecutionResultReachesBubblewrapReporter(t *testing.T) {
 	explanation := sandbox.BuildExplanation(report)
 	require.NotNil(t, explanation.Primary)
 	assert.Equal(t, "/work/.env", explanation.Primary.Target)
-	require.NotNil(t, explanation.Override)
-	assert.Equal(t, sandbox.ViolationKindFSRead, explanation.Override.Kind)
-	assert.Equal(t, "/work/.env", explanation.Override.Target)
+	assert.Nil(t, explanation.Override, "output-derived evidence is not offered as an allowance")
 }
 
 func TestBubblewrapStderrTapAbandonsOversizedLine(t *testing.T) {
@@ -513,4 +511,54 @@ func TestBubblewrapStderrTapAbandonsOversizedLine(t *testing.T) {
 	_, err = tap.Write([]byte("cat: /work/.env: Permission denied\n"))
 	require.NoError(t, err)
 	assert.Len(t, tap.collect(), 1)
+}
+
+// A line the sandboxed command invented is reported as diagnostics but must not
+// become actionable. See ViolationReport.OutputDerived.
+func TestBestEffortViolationForgedDenialIsNotActionable(t *testing.T) {
+	b, err := newBubblewrapSandbox()
+	require.NoError(t, err)
+
+	cmd := &exec.Cmd{}
+	b.attachDiagnostics(cmd, &sandbox.SandboxPolicy{Name: "npm-restrictive"})
+
+	_, err = cmd.Stderr.Write([]byte("cat: /home/u/.ssh/id_rsa: Permission denied\n"))
+	require.NoError(t, err)
+
+	report, err := b.BestEffortViolation(errors.New("exit status 1"))
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.True(t, report.OutputDerived)
+
+	explanation := sandbox.BuildExplanation(report)
+	require.NotNil(t, explanation.Primary, "the denial is still reported")
+	assert.Equal(t, "/home/u/.ssh/id_rsa", explanation.Primary.Target)
+
+	assert.Nil(t, explanation.Override, "no allowance is suggested")
+	assert.Nil(t, sandbox.BuildAllOverrides(report), "and none can be persisted")
+}
+
+func TestAttachDiagnosticsPinsMessageLocale(t *testing.T) {
+	b, err := newBubblewrapSandbox()
+	require.NoError(t, err)
+
+	cmd := &exec.Cmd{Env: []string{"LANG=es_ES.UTF-8", "PATH=/usr/bin"}}
+	b.attachDiagnostics(cmd, &sandbox.SandboxPolicy{Name: "npm-restrictive"})
+
+	// exec uses the last value for a duplicated key, so appending wins.
+	assert.Equal(t, "LC_MESSAGES=C", cmd.Env[len(cmd.Env)-1])
+	assert.Contains(t, cmd.Env, "LANG=es_ES.UTF-8", "the rest of the environment is untouched")
+}
+
+func TestAttachDiagnosticsKeepsInheritedEnvironment(t *testing.T) {
+	b, err := newBubblewrapSandbox()
+	require.NoError(t, err)
+
+	// A nil Env means "inherit"; appending to it directly would hand the child
+	// LC_MESSAGES and nothing else.
+	cmd := &exec.Cmd{}
+	b.attachDiagnostics(cmd, &sandbox.SandboxPolicy{Name: "npm-restrictive"})
+
+	assert.Greater(t, len(cmd.Env), 1)
+	assert.Equal(t, "LC_MESSAGES=C", cmd.Env[len(cmd.Env)-1])
 }

--- a/sandbox/platform/bubblewrap_diagnostics_linux_test.go
+++ b/sandbox/platform/bubblewrap_diagnostics_linux_test.go
@@ -1,0 +1,285 @@
+//go:build linux
+
+package platform
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/safedep/pmg/sandbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBubblewrapErrnoSuffix(t *testing.T) {
+	tests := []struct {
+		name   string
+		line   string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "permission denied",
+			line:   "cat: /work/.env: Permission denied",
+			want:   bubblewrapErrnoEACCES,
+			wantOK: true,
+		},
+		{
+			name:   "read only file system",
+			line:   "/bin/sh: 1: cannot create /srv/test: Read-only file system",
+			want:   bubblewrapErrnoEROFS,
+			wantOK: true,
+		},
+		{
+			name:   "operation not permitted",
+			line:   "chown: changing ownership of '/x/y': Operation not permitted",
+			want:   bubblewrapErrnoEPERM,
+			wantOK: true,
+		},
+		{
+			name:   "no such file or directory",
+			line:   "bwrap: execvp /usr/bin/git: No such file or directory",
+			want:   bubblewrapErrnoENOENT,
+			wantOK: true,
+		},
+		{
+			name:   "ordinary package manager noise",
+			line:   "npm WARN deprecated left-pad@1.0.0",
+			wantOK: false,
+		},
+		{
+			name:   "errno phrase away from the end is not a denial line",
+			line:   "PermissionError: [Errno 13] Permission denied: '/work/.env'",
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			line:   "",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := bubblewrapErrnoSuffix(tc.line)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBubblewrapViolationKind(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		errno   string
+		want    sandbox.ViolationKind
+	}{
+		{
+			name:    "bare path defaults to read",
+			message: "/work/.env",
+			errno:   bubblewrapErrnoEACCES,
+			want:    sandbox.ViolationKindFSRead,
+		},
+		{
+			name:    "create is a write",
+			message: "cannot create /etc/nope",
+			errno:   bubblewrapErrnoEACCES,
+			want:    sandbox.ViolationKindFSWrite,
+		},
+		{
+			name:    "longest verb wins over its own prefix",
+			message: "cannot remove directory '/opt/pkg'",
+			errno:   bubblewrapErrnoEACCES,
+			want:    sandbox.ViolationKindFSDeleteOrRename,
+		},
+		{
+			name:    "execvp is an exec",
+			message: "execvp /usr/bin/git",
+			errno:   bubblewrapErrnoENOENT,
+			want:    sandbox.ViolationKindExec,
+		},
+		{
+			name:    "read only filesystem implies a write without a verb",
+			message: "/srv/test",
+			errno:   bubblewrapErrnoEROFS,
+			want:    sandbox.ViolationKindFSWrite,
+		},
+		{
+			name:    "unrecognised verb falls back to read",
+			message: "failed while doing something to /work/.env",
+			errno:   bubblewrapErrnoEACCES,
+			want:    sandbox.ViolationKindFSRead,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, bubblewrapViolationKind(tc.message, tc.errno))
+		})
+	}
+}
+
+func TestParseBubblewrapDenial(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantOK      bool
+		wantKind    sandbox.ViolationKind
+		wantTarget  string
+		wantProcess string
+		wantRawKind string
+	}{
+		{
+			name:        "read denied with relative path",
+			line:        "cat: work/.env: Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSRead,
+			wantTarget:  "work/.env",
+			wantProcess: "cat",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "program path is not mistaken for the target",
+			line:        "/bin/cat: /home/u/.npmrc: Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSRead,
+			wantTarget:  "/home/u/.npmrc",
+			wantProcess: "cat",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "shell write denial carries an extra line number field",
+			line:        "sh: 1: cannot create /etc/nope: Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSWrite,
+			wantTarget:  "/etc/nope",
+			wantProcess: "sh",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "write to a read only bind mount",
+			line:        "/bin/sh: 1: cannot create /srv/test: Read-only file system",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSWrite,
+			wantTarget:  "/srv/test",
+			wantProcess: "sh",
+			wantRawKind: bubblewrapErrnoEROFS,
+		},
+		{
+			name:        "colon in the path survives colon-space splitting",
+			line:        "cat: 'work/a:b.txt': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSRead,
+			wantTarget:  "work/a:b.txt",
+			wantProcess: "cat",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "quoting recovers a path containing spaces",
+			line:        "cat: '/work/my notes.txt': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSRead,
+			wantTarget:  "/work/my notes.txt",
+			wantProcess: "cat",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "gnu style backtick quoting",
+			line:        "mkdir: cannot create directory `/opt/pkg': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSWrite,
+			wantTarget:  "/opt/pkg",
+			wantProcess: "mkdir",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "delete is distinguished from write",
+			line:        "rm: cannot remove '/etc/hosts': Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSDeleteOrRename,
+			wantTarget:  "/etc/hosts",
+			wantProcess: "rm",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "unrecognised verb still yields the target",
+			line:        "tool: failed while doing something to /work/.env: Permission denied",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindFSRead,
+			wantTarget:  "/work/.env",
+			wantProcess: "tool",
+			wantRawKind: bubblewrapErrnoEACCES,
+		},
+		{
+			name:        "bwrap reported exec failure is a trustworthy ENOENT",
+			line:        "bwrap: execvp /usr/bin/git: No such file or directory",
+			wantOK:      true,
+			wantKind:    sandbox.ViolationKindExec,
+			wantTarget:  "/usr/bin/git",
+			wantProcess: "bwrap",
+			wantRawKind: bubblewrapErrnoENOENT,
+		},
+		{
+			name:   "program reported ENOENT is ambiguous and skipped",
+			line:   "/bin/cat: /home/u/.ssh/id_rsa: No such file or directory",
+			wantOK: false,
+		},
+		{
+			name:   "bwrap setup failure is not a runtime denial",
+			line:   "bwrap: Can't find source path /nonexistent: No such file or directory",
+			wantOK: false,
+		},
+		{
+			name:   "python inverts path and errno so it is not parsed",
+			line:   "PermissionError: [Errno 13] Permission denied: '/work/.env'",
+			wantOK: false,
+		},
+		{
+			name:   "ordinary package manager noise",
+			line:   "npm WARN deprecated left-pad@1.0.0",
+			wantOK: false,
+		},
+		{
+			name:   "errno phrase with no message before it",
+			line:   "Permission denied",
+			wantOK: false,
+		},
+		{
+			name:   "prose ending in an errno phrase is not a path",
+			line:   "npm ERR! the registry returned Permission denied",
+			wantOK: false,
+		},
+		{
+			name:   "blank line",
+			line:   "   ",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseBubblewrapDenial(tc.line)
+
+			if !tc.wantOK {
+				assert.False(t, ok)
+				return
+			}
+
+			require.True(t, ok)
+			assert.Equal(t, tc.wantKind, got.kind)
+			assert.Equal(t, tc.wantTarget, got.target)
+			assert.Equal(t, tc.wantProcess, got.process)
+			assert.Equal(t, tc.wantRawKind, got.rawKind)
+			assert.Equal(t, strings.TrimSpace(tc.line), got.raw)
+		})
+	}
+}
+
+func TestParseBubblewrapDenialRejectsOversizedTarget(t *testing.T) {
+	long := "/" + strings.Repeat("a", bubblewrapMaxTargetLen)
+	require.Greater(t, len(long), bubblewrapMaxTargetLen)
+
+	_, ok := parseBubblewrapDenial("cat: " + long + ": Permission denied")
+	assert.False(t, ok)
+}

--- a/sandbox/platform/bubblewrap_e2e_linux_test.go
+++ b/sandbox/platform/bubblewrap_e2e_linux_test.go
@@ -1,0 +1,190 @@
+//go:build linux
+
+package platform
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/safedep/pmg/sandbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests run real commands under a real bwrap sandbox and assert that the
+// resulting denial reaches a violation report. They skip when bwrap is absent
+// rather than being opted into by env var, since bwrap is the only requirement.
+
+func requireBubblewrap(t *testing.T) *bubblewrapSandbox {
+	t.Helper()
+
+	b, err := newBubblewrapSandbox()
+	require.NoError(t, err)
+
+	if !b.IsAvailable() {
+		t.Skip("bwrap not available on this host")
+	}
+
+	return b
+}
+
+// bubblewrapE2EWorkdir returns a project directory outside the sandbox tmpdir.
+// The translator binds os.TempDir() read-write as its final step, so a deny rule
+// under it would be overridden by that later mount.
+func bubblewrapE2EWorkdir(t *testing.T) string {
+	t.Helper()
+
+	workdir := t.TempDir()
+	t.Setenv("TMPDIR", t.TempDir())
+
+	return workdir
+}
+
+func bubblewrapE2EPolicy(t *testing.T, workdir string) *sandbox.SandboxPolicy {
+	t.Helper()
+
+	return &sandbox.SandboxPolicy{
+		Name:            "bubblewrap-e2e",
+		PackageManagers: []string{"npm"},
+		Filesystem: sandbox.FilesystemPolicy{
+			AllowRead:  []string{"/usr", "/bin", "/lib", "/lib64", workdir},
+			AllowWrite: []string{workdir},
+		},
+		Process: sandbox.ProcessPolicy{
+			AllowExec: []string{"/usr/bin", "/bin"},
+		},
+	}
+}
+
+type sandboxRun struct {
+	result *sandbox.ExecutionResult
+	err    error
+	stdout string
+	stderr string
+}
+
+func runSandboxed(t *testing.T, b *bubblewrapSandbox, policy *sandbox.SandboxPolicy, argv ...string) sandboxRun {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	result, err := b.Execute(context.Background(), cmd, policy, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, result.Close())
+	})
+	require.True(t, result.ShouldRun())
+
+	return sandboxRun{
+		result: result,
+		err:    cmd.Run(),
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+	}
+}
+
+func (r sandboxRun) report(t *testing.T) *sandbox.ViolationReport {
+	t.Helper()
+
+	report, err := r.result.BestEffortViolation(r.err)
+	require.NoError(t, err)
+
+	return report
+}
+
+// A credential read is the case the sandbox exists for, so it is asserted end to
+// end: the secret must not reach the process, and the user must be told why.
+func TestBubblewrapE2EReportsDeniedCredentialRead(t *testing.T) {
+	b := requireBubblewrap(t)
+
+	workdir := bubblewrapE2EWorkdir(t)
+	secret := filepath.Join(workdir, ".env")
+	require.NoError(t, os.WriteFile(secret, []byte("TOKEN=secret\n"), 0o600))
+
+	policy := bubblewrapE2EPolicy(t, workdir)
+	policy.Filesystem.DenyRead = []string{secret}
+
+	run := runSandboxed(t, b, policy, "/bin/cat", secret)
+	require.Error(t, run.err)
+	assert.NotContains(t, run.stdout, "TOKEN=secret", "the secret must not reach the process")
+
+	report := run.report(t)
+	require.NotNil(t, report, "stderr: %s", run.stderr)
+	assert.Equal(t, sandbox.DriverBubblewrap, report.SandboxName)
+	assert.Equal(t, "bubblewrap-e2e", report.PolicyName)
+
+	explanation := sandbox.BuildExplanation(report)
+	require.NotNil(t, explanation.Primary)
+	assert.Equal(t, secret, explanation.Primary.Target)
+	assert.Equal(t, sandbox.ViolationKindFSRead, explanation.Primary.Kind)
+	assert.Equal(t, "cat", explanation.Primary.Process)
+
+	require.NotNil(t, explanation.Override)
+	assert.Equal(t, sandbox.ViolationKindFSRead, explanation.Override.Kind)
+	assert.Equal(t, secret, explanation.Override.Target)
+}
+
+func TestBubblewrapE2EReportsDeniedWrite(t *testing.T) {
+	b := requireBubblewrap(t)
+
+	workdir := bubblewrapE2EWorkdir(t)
+	protected := filepath.Join(workdir, "locked.txt")
+	require.NoError(t, os.WriteFile(protected, []byte("original\n"), 0o600))
+
+	policy := bubblewrapE2EPolicy(t, workdir)
+	policy.Filesystem.DenyWrite = []string{protected}
+
+	run := runSandboxed(t, b, policy, "/bin/sh", "-c", "echo tampered > "+protected)
+	require.Error(t, run.err)
+
+	report := run.report(t)
+	require.NotNil(t, report, "stderr: %s", run.stderr)
+
+	explanation := sandbox.BuildExplanation(report)
+	require.NotNil(t, explanation.Primary)
+	assert.Equal(t, protected, explanation.Primary.Target)
+	assert.Equal(t, sandbox.ViolationKindFSWrite, explanation.Primary.Kind)
+
+	contents, err := os.ReadFile(protected)
+	require.NoError(t, err)
+	assert.Equal(t, "original\n", string(contents), "the write must not have landed")
+}
+
+func TestBubblewrapE2EReportsReadOnlyWrite(t *testing.T) {
+	b := requireBubblewrap(t)
+
+	workdir := bubblewrapE2EWorkdir(t)
+
+	run := runSandboxed(t, b, bubblewrapE2EPolicy(t, workdir),
+		"/bin/sh", "-c", "echo denied > /usr/pmg-e2e-should-not-exist")
+	require.Error(t, run.err)
+
+	report := run.report(t)
+	require.NotNil(t, report, "stderr: %s", run.stderr)
+
+	explanation := sandbox.BuildExplanation(report)
+	require.NotNil(t, explanation.Primary)
+	assert.Equal(t, "/usr/pmg-e2e-should-not-exist", explanation.Primary.Target)
+	assert.Equal(t, sandbox.ViolationKindFSWrite, explanation.Primary.Kind)
+}
+
+func TestBubblewrapE2ESuccessfulRunReportsNothing(t *testing.T) {
+	b := requireBubblewrap(t)
+
+	workdir := bubblewrapE2EWorkdir(t)
+	readable := filepath.Join(workdir, "ok.txt")
+	require.NoError(t, os.WriteFile(readable, []byte("fine\n"), 0o600))
+
+	run := runSandboxed(t, b, bubblewrapE2EPolicy(t, workdir), "/bin/cat", readable)
+	require.NoError(t, run.err, "stderr: %s", run.stderr)
+
+	assert.Nil(t, run.report(t))
+}

--- a/sandbox/platform/bubblewrap_e2e_linux_test.go
+++ b/sandbox/platform/bubblewrap_e2e_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/safedep/pmg/sandbox"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,12 @@ import (
 // resulting denial reaches a violation report. They skip when bwrap is absent
 // rather than being opted into by env var, since bwrap is the only requirement.
 
+// requireBubblewrap skips unless bwrap is present and can actually spawn a
+// sandbox: a host that disables unprivileged user namespaces has bwrap on PATH
+// while every spawn fails, which would fail these tests instead of skipping.
+//
+// The probe succeeds rather than denies, because a denial and a failure to
+// start both exit non-zero.
 func requireBubblewrap(t *testing.T) *bubblewrapSandbox {
 	t.Helper()
 
@@ -26,7 +33,15 @@ func requireBubblewrap(t *testing.T) *bubblewrapSandbox {
 	require.NoError(t, err)
 
 	if !b.IsAvailable() {
-		t.Skip("bwrap not available on this host")
+		t.Skip("bwrap not found on PATH")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	probe := exec.CommandContext(ctx, "bwrap", "--ro-bind", "/", "/", "--dev", "/dev", "--", "/bin/true")
+	if out, err := probe.CombinedOutput(); err != nil {
+		t.Skipf("bwrap cannot spawn a sandbox on this host: %v: %s", err, out)
 	}
 
 	return b
@@ -127,9 +142,8 @@ func TestBubblewrapE2EReportsDeniedCredentialRead(t *testing.T) {
 	assert.Equal(t, sandbox.ViolationKindFSRead, explanation.Primary.Kind)
 	assert.Equal(t, "cat", explanation.Primary.Process)
 
-	require.NotNil(t, explanation.Override)
-	assert.Equal(t, sandbox.ViolationKindFSRead, explanation.Override.Kind)
-	assert.Equal(t, secret, explanation.Override.Target)
+	assert.True(t, report.OutputDerived)
+	assert.Nil(t, explanation.Override, "output-derived evidence is not offered as an allowance")
 }
 
 func TestBubblewrapE2EReportsDeniedWrite(t *testing.T) {

--- a/sandbox/platform/bubblewrap_linux.go
+++ b/sandbox/platform/bubblewrap_linux.go
@@ -26,6 +26,11 @@ import (
 type bubblewrapSandbox struct {
 	config     *bubblewrapConfig
 	translator *bubblewrapPolicyTranslator
+
+	// Diagnostics state from the last Execute(), consumed by
+	// BestEffortViolation (see bubblewrap_diagnostics_linux.go).
+	policyName string
+	tap        *bubblewrapStderrTap
 }
 
 // newBubblewrapSandbox creates a new Bubblewrap sandbox instance with default configuration.
@@ -92,6 +97,8 @@ func (b *bubblewrapSandbox) Execute(ctx context.Context, cmd *exec.Cmd, policy *
 	}
 
 	log.Debugf("Sandboxed command: %s %v", cmd.Path, cmd.Args)
+
+	b.attachDiagnostics(cmd, policy)
 
 	return sandbox.NewExecutionResult(sandbox.WithExecutionResultSandbox(b)), nil
 }

--- a/sandbox/platform/landlock_diagnostics_linux.go
+++ b/sandbox/platform/landlock_diagnostics_linux.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"time"
 
@@ -148,7 +147,7 @@ func extractLandlockViolations(events []capturedAuditEvent) []sandbox.Violation 
 			RuleTarget: e.RulePath,
 			Process:    e.Comm,
 			RawLog:     e.raw,
-			RuleLabel:  summarizeLandlockViolation(kind, e.Path),
+			RuleLabel:  summarizeViolation(kind, e.Path),
 		})
 	}
 
@@ -176,24 +175,5 @@ func landlockViolationKind(e auditEvent) sandbox.ViolationKind {
 		return sandbox.ViolationKindNetworkConnect
 	default:
 		return sandbox.ViolationKindGenericDeny
-	}
-}
-
-func summarizeLandlockViolation(kind sandbox.ViolationKind, target string) string {
-	switch kind {
-	case sandbox.ViolationKindFSRead:
-		return fmt.Sprintf("read access denied: %s", target)
-	case sandbox.ViolationKindFSWrite:
-		return fmt.Sprintf("write access denied: %s", target)
-	case sandbox.ViolationKindExec:
-		return fmt.Sprintf("process execution denied: %s", target)
-	case sandbox.ViolationKindNetworkConnect:
-		// Same posture message as the Seatbelt driver (seatbelt_diagnostics_darwin.go).
-		return fmt.Sprintf("direct network access blocked by network_via_proxy_only (%s) — traffic must flow through the PMG proxy (a tool may have ignored HTTP_PROXY/HTTPS_PROXY)", target)
-	default:
-		if target == "" {
-			return "sandbox denied an operation"
-		}
-		return fmt.Sprintf("sandbox denied access to %s", target)
 	}
 }

--- a/sandbox/platform/landlock_diagnostics_linux_test.go
+++ b/sandbox/platform/landlock_diagnostics_linux_test.go
@@ -219,25 +219,6 @@ func TestExtractLandlockViolations(t *testing.T) {
 	}
 }
 
-func TestSummarizeLandlockViolation(t *testing.T) {
-	tests := []struct {
-		kind   sandbox.ViolationKind
-		target string
-		want   string
-	}{
-		{sandbox.ViolationKindFSRead, "/tmp/.env", "read access denied: /tmp/.env"},
-		{sandbox.ViolationKindFSWrite, "/tmp/out", "write access denied: /tmp/out"},
-		{sandbox.ViolationKindExec, "/usr/bin/curl", "process execution denied: /usr/bin/curl"},
-		{sandbox.ViolationKindNetworkConnect, "203.0.113.9:443", "direct network access blocked by network_via_proxy_only (203.0.113.9:443) — traffic must flow through the PMG proxy (a tool may have ignored HTTP_PROXY/HTTPS_PROXY)"},
-		{sandbox.ViolationKindGenericDeny, "/tmp/x", "sandbox denied access to /tmp/x"},
-		{sandbox.ViolationKindGenericDeny, "", "sandbox denied an operation"},
-	}
-
-	for _, tc := range tests {
-		assert.Equal(t, tc.want, summarizeLandlockViolation(tc.kind, tc.target))
-	}
-}
-
 func TestCaptureAuditEvents(t *testing.T) {
 	input := `{"type":"seccomp_deny","syscall":"openat","path":"/home/dev/.ssh/id_rsa","access":"read","comm":"node","pid":42,"ts":0}
 

--- a/sandbox/platform/violation_summary.go
+++ b/sandbox/platform/violation_summary.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"fmt"
+
+	"github.com/safedep/pmg/sandbox"
+)
+
+// summarizeViolation renders the short label carried on
+// sandbox.Violation.RuleLabel. Drivers reporting normalized kinds share it;
+// Seatbelt keeps its own because it labels from raw operation strings.
+func summarizeViolation(kind sandbox.ViolationKind, target string) string {
+	switch kind {
+	case sandbox.ViolationKindFSRead:
+		return fmt.Sprintf("read access denied: %s", target)
+	case sandbox.ViolationKindFSWrite:
+		return fmt.Sprintf("write access denied: %s", target)
+	case sandbox.ViolationKindFSDeleteOrRename:
+		return fmt.Sprintf("rename or unlink denied: %s", target)
+	case sandbox.ViolationKindExec:
+		return fmt.Sprintf("process execution denied: %s", target)
+	case sandbox.ViolationKindNetworkConnect:
+		// Same posture message as the Seatbelt driver (seatbelt_diagnostics_darwin.go).
+		return fmt.Sprintf("direct network access blocked by network_via_proxy_only (%s) — traffic must flow through the PMG proxy (a tool may have ignored HTTP_PROXY/HTTPS_PROXY)", target)
+	default:
+		if target == "" {
+			return "sandbox denied an operation"
+		}
+		return fmt.Sprintf("sandbox denied access to %s", target)
+	}
+}

--- a/sandbox/platform/violation_summary_test.go
+++ b/sandbox/platform/violation_summary_test.go
@@ -1,0 +1,28 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/safedep/pmg/sandbox"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSummarizeViolation(t *testing.T) {
+	tests := []struct {
+		kind   sandbox.ViolationKind
+		target string
+		want   string
+	}{
+		{sandbox.ViolationKindFSRead, "/tmp/.env", "read access denied: /tmp/.env"},
+		{sandbox.ViolationKindFSWrite, "/tmp/out", "write access denied: /tmp/out"},
+		{sandbox.ViolationKindFSDeleteOrRename, "/tmp/x", "rename or unlink denied: /tmp/x"},
+		{sandbox.ViolationKindExec, "/usr/bin/curl", "process execution denied: /usr/bin/curl"},
+		{sandbox.ViolationKindNetworkConnect, "203.0.113.9:443", "direct network access blocked by network_via_proxy_only (203.0.113.9:443) — traffic must flow through the PMG proxy (a tool may have ignored HTTP_PROXY/HTTPS_PROXY)"},
+		{sandbox.ViolationKindGenericDeny, "/tmp/x", "sandbox denied access to /tmp/x"},
+		{sandbox.ViolationKindGenericDeny, "", "sandbox denied an operation"},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, summarizeViolation(tc.kind, tc.target))
+	}
+}

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"os/exec"
 	"strconv"
@@ -100,6 +101,12 @@ type violationReporter interface {
 	BestEffortViolation(err error) (*ViolationReport, error)
 }
 
+// diagnosticsWriter is implemented by drivers that collect diagnostics from the
+// command's own output rather than from a kernel or platform channel.
+type diagnosticsWriter interface {
+	DiagnosticsWriter() io.Writer
+}
+
 // ExecutionResult represents the result of executing a command in a sandbox.
 // It contains sandbox internal state and allows for future extension with
 // additional metadata (e.g., exit codes, resource usage, violation events).
@@ -173,6 +180,22 @@ func (r *ExecutionResult) BestEffortViolation(err error) (*ViolationReport, erro
 	}
 
 	return reporter.BestEffortViolation(err)
+}
+
+// DiagnosticsWriter returns a writer that execution paths routing command
+// output themselves, such as a PTY session, must tee into for the sandbox to
+// observe denials. Drivers that read a kernel or platform channel return nil.
+func (r *ExecutionResult) DiagnosticsWriter() io.Writer {
+	if r == nil || r.sandbox == nil {
+		return nil
+	}
+
+	writer, ok := r.sandbox.(diagnosticsWriter)
+	if !ok {
+		return nil
+	}
+
+	return writer.DiagnosticsWriter()
 }
 
 // Close cleans up any resources allocated by the sandbox.

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -84,6 +84,13 @@ type ViolationReport struct {
 	PolicyName    string
 	CorrelationID string
 	Violations    []Violation
+
+	// OutputDerived marks a report parsed from the sandboxed command's own
+	// output rather than read from a kernel or platform channel. A malicious
+	// package can print a denial that never happened, naming any target it
+	// likes, so these violations are shown as diagnostics but never converted
+	// into an override suggestion the user could be talked into persisting.
+	OutputDerived bool
 }
 
 // Violation captures one sandbox denial event.

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -1,10 +1,31 @@
 package sandbox
 
 import (
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type stubSandbox struct{}
+
+func (stubSandbox) Execute(context.Context, *exec.Cmd, *SandboxPolicy, *ExecutionContext) (*ExecutionResult, error) {
+	return nil, nil
+}
+func (stubSandbox) Name() DriverName  { return "stub" }
+func (stubSandbox) IsAvailable() bool { return true }
+func (stubSandbox) Close() error      { return nil }
+
+type stubDiagnosticsSandbox struct {
+	stubSandbox
+	writer io.Writer
+}
+
+func (s stubDiagnosticsSandbox) DiagnosticsWriter() io.Writer { return s.writer }
 
 func TestExecutionResultScrubbedEnvCount(t *testing.T) {
 	r := NewExecutionResult()
@@ -17,4 +38,46 @@ func TestExecutionResultScrubbedEnvCount(t *testing.T) {
 func TestExecutionResultScrubbedEnvCountNilReceiver(t *testing.T) {
 	var r *ExecutionResult
 	assert.Equal(t, 0, r.ScrubbedEnvCount())
+}
+
+func TestExecutionResultDiagnosticsWriter(t *testing.T) {
+	var sink bytes.Buffer
+
+	tests := []struct {
+		name   string
+		result *ExecutionResult
+		want   io.Writer
+	}{
+		{
+			name:   "nil result",
+			result: nil,
+		},
+		{
+			name:   "no sandbox",
+			result: NewExecutionResult(),
+		},
+		{
+			name:   "driver without diagnostics",
+			result: NewExecutionResult(WithExecutionResultSandbox(stubSandbox{})),
+		},
+		{
+			name:   "driver with diagnostics",
+			result: NewExecutionResult(WithExecutionResultSandbox(stubDiagnosticsSandbox{writer: &sink})),
+			want:   &sink,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.result.DiagnosticsWriter())
+		})
+	}
+}
+
+func TestExecutionResultDiagnosticsWriterNilWhenDriverHasNoTap(t *testing.T) {
+	result := NewExecutionResult(WithExecutionResultSandbox(stubDiagnosticsSandbox{}))
+
+	// A driver that has not run yet must report no writer, so that callers never
+	// pass a nil into io.MultiWriter.
+	require.Nil(t, result.DiagnosticsWriter())
 }

--- a/sandbox/violation.go
+++ b/sandbox/violation.go
@@ -35,13 +35,16 @@ type OverrideSuggestion struct {
 	Target string
 }
 
-// BuildExplanation produces an Explanation for the given report.
+// BuildExplanation produces an Explanation for the given report. An
+// OutputDerived report yields no Override, since its evidence is forgeable.
 func BuildExplanation(report *ViolationReport) Explanation {
 	primary := primaryViolation(report)
 	exp := Explanation{Primary: primary}
 	if primary != nil {
-		exp.Override = overrideSuggestion(*primary)
-		if report != nil && len(report.Violations) > 1 {
+		if !report.OutputDerived {
+			exp.Override = overrideSuggestion(*primary)
+		}
+		if len(report.Violations) > 1 {
 			exp.AdditionalDenials = len(report.Violations) - 1
 		}
 	}

--- a/sandbox/violation_test.go
+++ b/sandbox/violation_test.go
@@ -224,3 +224,26 @@ func TestIsSensitiveProjectTargetGNUPGFiles(t *testing.T) {
 	assert.True(t, IsSensitiveProjectTarget("/home/user/.gnupg/pubring.kbx"))
 	assert.True(t, IsSensitiveProjectTarget("/home/user/.gnupg/private-keys-v1.d/abc.key"))
 }
+
+// See ViolationReport.OutputDerived: such a report describes the denial but
+// must never offer it as an allowance.
+func TestOutputDerivedReportYieldsNoOverrides(t *testing.T) {
+	report := &ViolationReport{
+		SandboxName:   DriverBubblewrap,
+		OutputDerived: true,
+		Violations: []Violation{{
+			Kind:   ViolationKindFSRead,
+			Target: "/home/dev/.ssh/id_rsa",
+		}},
+	}
+
+	exp := BuildExplanation(report)
+	require.NotNil(t, exp.Primary, "the denial is still reported as diagnostics")
+	assert.Nil(t, exp.Override, "forgeable evidence must not become an allowance")
+	assert.Nil(t, BuildAllOverrides(report), "and must not be persistable via allow --last")
+
+	// The same violation from a driver reading a kernel channel stays actionable.
+	report.OutputDerived = false
+	assert.NotNil(t, BuildExplanation(report).Override)
+	assert.Len(t, BuildAllOverrides(report), 1)
+}


### PR DESCRIPTION
Closes #267

## Problem

`bubblewrapSandbox` never implemented `violationReporter`, so the type assertion in `ExecutionResult.BestEffortViolation` fell through and returned nil. On Bubblewrap hosts the violation cache was never written: `violations list` showed "no violations cached" and `explain --last` asked the user to run a sandboxed command, right after one had been run and blocked.

## Approach

Seatbelt reads the macOS unified log and Landlock reads its seccomp audit socket. Bubblewrap has no such channel: it isolates with namespaces and mounts rather than a security module, so the kernel fails the syscall and the sandboxed program is the only thing that learns about it. Its own output is the only signal.

The message prefix varies by program (`cat:`, `npm ERR!`, `/bin/sh: 1: cannot create`) but the `strerror(3)` phrase it ends with does not, so parsing is anchored on the suffix. A bounded tap on the command's stderr collects those lines and `BestEffortViolation` maps them to violations. The cache, list, explain and override-suggestion pipeline is unchanged.

`internal/runner` changes because PTY runs, which is the interactive default, build their own session and never write to `cmd.Stderr`. `ExecutionResult.DiagnosticsWriter` exposes the tap so the PTY output router can be teed into it. Drivers that read a kernel channel do not implement it.

## Not covered

- ENOENT from the sandboxed program, which cannot be told apart from a genuinely missing file. Accepted only when bwrap reports it for a failed exec.
- Node and Python, which print the path after the errno phrase. Shell install scripts and the coreutils they call are covered.

Documented in `docs/sandbox.md`.

## Verification

- Unit tests for the parser, table-driven, with each case a line captured from the tool that emits it. Tap tests cover lines split across writes, repeated denials, the buffer bounds & control-character stripping.
- `bubblewrap_e2e_linux_test.go` runs real commands under a real bwrap sandbox and asserts the report reaches `BuildExplanation`. It skips when bwrap is absent, so it needs no opt-in env var: `go test ./sandbox/platform/ -run TestBubblewrapE2E -v`
- Exercised live on bwrap 0.9.0, installing a local package whose `postinstall` is `cat ../../.env` under `PMG_SANDBOX_DRIVER=bubblewrap`, against builds of `main` and this branch in both direct and PTY execution modes. Both block the read; only this branch records it.

**Before:**

<img width="891" height="273" alt="Screenshot from 2026-08-11 22-36-43" src="https://github.com/user-attachments/assets/ae94a014-a4d6-414b-8954-0baa3ff91752" />


**After:**

<img width="837" height="730" alt="Screenshot from 2026-08-11 22-36-12" src="https://github.com/user-attachments/assets/19ca6f32-271c-4dde-b66f-d2d426f85524" />
<br><br/>

Generated with the help of [Claude Code](https://claude.com/claude-code)