### PR TITLE
feat(cooldown): explain install failures caused by withheld versions

### DIFF
--- a/docs/dependency-cooldown.md
+++ b/docs/dependency-cooldown.md
@@ -8,6 +8,28 @@ When cooldown is enabled, PMG intercepts package metadata responses from the reg
 
 Cooldown is enforced through metadata filtering and does not apply to direct tarball installs or workflows that already have a resolved tarball URL (e.g., lockfile or cache scenarios).
 
+## How PMG Reports Cooldown
+
+PMG reports cooldown in the install summary in three ways:
+
+- **Block: no version is eligible.** Every version of the package is within the
+  cooldown window. The install fails and PMG reports the package as blocked,
+  with the version closest to exiting the window.
+- **Block: a requested version is withheld.** You pinned a version on the
+  command line (for example `pmg npm install pkg@1.2.3`) and that version is
+  within the window. The install fails and PMG reports that version as blocked.
+- **Hint: versions withheld, eligible versions remain.** Recent versions were
+  withheld but older eligible versions survive. The resolver normally falls
+  back to an eligible version and the install succeeds with no extra output.
+  The install can still fail when something requires exactly a withheld
+  version, for example a lockfile entry or a dependency with an exact version
+  pin. PMG cannot see that requirement in the metadata, so in this case it
+  prints the withheld versions after the package manager error as the likely
+  cause of the failure.
+
+Run PMG with `--verbose` to always list the withheld versions in the execution
+report, including on successful installs.
+
 ## Configuration
 
 Dependency cooldown is configured in `config.yml`. See [config template](../config/config.template.yml) for the full schema. If you don't have a `config.yml` file, create one by running `pmg setup install`.

--- a/docs/dependency-cooldown.md
+++ b/docs/dependency-cooldown.md
@@ -25,7 +25,9 @@ PMG reports cooldown in the install summary in three ways:
   version, for example a lockfile entry or a dependency with an exact version
   pin. PMG cannot see that requirement in the metadata, so in this case it
   prints the withheld versions after the package manager error as the likely
-  cause of the failure.
+  cause of the failure. When more than 3 packages had versions withheld, the
+  hint lists package names only; the package manager error above it names the
+  exact version it could not find.
 
 Run PMG with `--verbose` to always list the withheld versions in the execution
 report, including on successful installs.

--- a/internal/flows/proxy_flow.go
+++ b/internal/flows/proxy_flow.go
@@ -302,6 +302,7 @@ func (f *proxyFlow) Run(ctx context.Context, args []string, parsedCmd *packagema
 	reportData.BlockedPackages = statsCollector.GetBlockedPackages()
 	reportData.ConfirmedPackages = statsCollector.GetConfirmedPackages()
 	reportData.CooldownBlockedPackages = statsCollector.GetCooldownBlocks()
+	reportData.CooldownWithheldPackages = statsCollector.GetCooldownWithheld()
 	reportData.AdvisoryMessage = cfg.Config.AdvisoryMessage
 
 	// Set outcome based on execution result using shared inference logic

--- a/internal/models/cooldown.go
+++ b/internal/models/cooldown.go
@@ -11,3 +11,19 @@ type CooldownBlock struct {
 	DaysLeft     int
 	CooldownDays int
 }
+
+// CooldownWithheldVersion is one version stripped from registry metadata by the
+// dependency cooldown policy.
+type CooldownWithheldVersion struct {
+	Version  string
+	DaysLeft int
+}
+
+// CooldownWithheld records versions stripped from a package's metadata while
+// older eligible versions remained. It is a hint, not a definite block: the
+// resolver may have fallen back to an eligible version, or it may have failed
+// because a dependency required exactly a withheld version.
+type CooldownWithheld struct {
+	Name     string
+	Versions []CooldownWithheldVersion
+}

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -344,10 +344,8 @@ func reportVerbose(data *ReportData) {
 		fmt.Println()
 		fmt.Println(Colors.Yellow("  Versions withheld by dependency cooldown:"))
 		for _, pkg := range data.CooldownWithheldPackages {
-			for _, v := range pkg.Versions {
-				fmt.Printf("    %s %s\n", Colors.Yellow("⊘"), Colors.Yellow(fmt.Sprintf("%s@%s", pkg.Name, v.Version)))
-				fmt.Printf("      %s\n", Colors.Dim(fmt.Sprintf("Available in %s", pluralizeDays(v.DaysLeft))))
-			}
+			fmt.Printf("    %s %s\n", Colors.Yellow("⊘"), Colors.Yellow(pkg.Name))
+			fmt.Printf("      %s\n", Colors.Dim(termWidthFormatTextIndent(withheldVersionsLine(pkg, 0), 76, "      ")))
 		}
 	}
 
@@ -403,26 +401,32 @@ func printCooldownWithheldDetail(packages []models.CooldownWithheld) {
 		Colors.Yellow(fmt.Sprintf("Dependency cooldown withheld %s during version resolution", pluralizeVersions(total))))
 
 	for _, pkg := range packages {
-		shown := pkg.Versions
-		hidden := 0
-		if len(shown) > cooldownWithheldHintMaxVersions {
-			hidden = len(shown) - cooldownWithheldHintMaxVersions
-			shown = shown[:cooldownWithheldHintMaxVersions]
-		}
-
-		parts := make([]string, 0, len(shown)+1)
-		for _, v := range shown {
-			parts = append(parts, fmt.Sprintf("%s (available in %s)", v.Version, pluralizeDays(v.DaysLeft)))
-		}
-		if hidden > 0 {
-			parts = append(parts, fmt.Sprintf("and %d more", hidden))
-		}
-
 		fmt.Printf("    %s\n", Colors.Yellow(pkg.Name))
-		fmt.Printf("      %s\n", Colors.Dim(strings.Join(parts, ", ")))
+		fmt.Printf("      %s\n", Colors.Dim(withheldVersionsLine(pkg, cooldownWithheldHintMaxVersions)))
 	}
 
 	fmt.Printf("  %s\n", Colors.Dim("If the install failed because a version was not found, this is the likely cause."))
+}
+
+// withheldVersionsLine formats a package's withheld versions as one
+// comma-separated line. maxVersions caps the list ("and N more" for the rest);
+// 0 lists every version.
+func withheldVersionsLine(pkg models.CooldownWithheld, maxVersions int) string {
+	shown := pkg.Versions
+	hidden := 0
+	if maxVersions > 0 && len(shown) > maxVersions {
+		hidden = len(shown) - maxVersions
+		shown = shown[:maxVersions]
+	}
+
+	parts := make([]string, 0, len(shown)+1)
+	for _, v := range shown {
+		parts = append(parts, fmt.Sprintf("%s (available in %s)", v.Version, pluralizeDays(v.DaysLeft)))
+	}
+	if hidden > 0 {
+		parts = append(parts, fmt.Sprintf("and %d more", hidden))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func printCooldownWithheldSummary(packages []models.CooldownWithheld) {

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/safedep/pmg/analyzer"
@@ -78,6 +79,12 @@ type ReportData struct {
 
 	// Packages blocked by the dependency cooldown policy (proxy mode only)
 	CooldownBlockedPackages []models.CooldownBlock
+
+	// Versions stripped by cooldown while eligible versions remained (proxy
+	// mode only). Not blocks: the resolver usually falls back, but an install
+	// can still fail when a dependency requires exactly a withheld version.
+	// Rendered as a hint when the install fails.
+	CooldownWithheldPackages []models.CooldownWithheld
 
 	// AdvisoryMessage is the optional org-configured message appended to block
 	// output regardless of which control blocked. Set from advisory_message.
@@ -171,7 +178,11 @@ func reportNormal(data *ReportData) {
 	}
 
 	if data.Outcome == OutcomeError {
-		return // Error handling done elsewhere
+		// The child's own error output and PMG's exit line render elsewhere.
+		// Withheld versions are the one PMG-side fact that can explain a
+		// resolution failure, so surface them here.
+		printCooldownWithheldHint(data.CooldownWithheldPackages)
+		return
 	}
 
 	if data.Outcome == OutcomeInsecureBypass {
@@ -329,11 +340,69 @@ func reportVerbose(data *ReportData) {
 		}
 	}
 
+	if len(data.CooldownWithheldPackages) > 0 {
+		fmt.Println()
+		fmt.Println(Colors.Yellow("  Versions withheld by dependency cooldown:"))
+		for _, pkg := range data.CooldownWithheldPackages {
+			for _, v := range pkg.Versions {
+				fmt.Printf("    %s %s\n", Colors.Yellow("⊘"), Colors.Yellow(fmt.Sprintf("%s@%s", pkg.Name, v.Version)))
+				fmt.Printf("      %s\n", Colors.Dim(fmt.Sprintf("Available in %s", pluralizeDays(v.DaysLeft))))
+			}
+		}
+	}
+
 	if data.Outcome == OutcomeBlocked && data.AdvisoryMessage != "" {
 		fmt.Println()
 		printAdvisoryMessage(data.AdvisoryMessage)
 	}
 
+	fmt.Println()
+}
+
+// cooldownWithheldHintMaxVersions bounds how many withheld versions are listed
+// per package in the failure hint. Packages with frequent releases can have
+// many versions inside the window; the hint must stay short.
+const cooldownWithheldHintMaxVersions = 3
+
+// printCooldownWithheldHint explains a failed install that may have been caused
+// by cooldown stripping. PMG cannot know whether the resolver failed because of
+// the withheld versions, so this renders as a hint, not a block report.
+func printCooldownWithheldHint(packages []models.CooldownWithheld) {
+	if len(packages) == 0 {
+		return
+	}
+
+	total := 0
+	for _, pkg := range packages {
+		total += len(pkg.Versions)
+	}
+
+	fmt.Println()
+	fmt.Printf("%s %s\n",
+		Colors.Yellow("⊘"),
+		Colors.Yellow(fmt.Sprintf("Dependency cooldown withheld %s during version resolution", pluralizeVersions(total))))
+
+	for _, pkg := range packages {
+		shown := pkg.Versions
+		hidden := 0
+		if len(shown) > cooldownWithheldHintMaxVersions {
+			hidden = len(shown) - cooldownWithheldHintMaxVersions
+			shown = shown[:cooldownWithheldHintMaxVersions]
+		}
+
+		parts := make([]string, 0, len(shown)+1)
+		for _, v := range shown {
+			parts = append(parts, fmt.Sprintf("%s (available in %s)", v.Version, pluralizeDays(v.DaysLeft)))
+		}
+		if hidden > 0 {
+			parts = append(parts, fmt.Sprintf("and %d more", hidden))
+		}
+
+		fmt.Printf("    %s\n", Colors.Yellow(pkg.Name))
+		fmt.Printf("      %s\n", Colors.Dim(strings.Join(parts, ", ")))
+	}
+
+	fmt.Printf("  %s\n", Colors.Dim("If the install failed because a version was not found, this is the likely cause."))
 	fmt.Println()
 }
 

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -360,9 +360,20 @@ func reportVerbose(data *ReportData) {
 }
 
 // cooldownWithheldHintMaxVersions bounds how many withheld versions are listed
-// per package in the failure hint. Packages with frequent releases can have
-// many versions inside the window; the hint must stay short.
+// per package in the detailed failure hint. Packages with frequent releases can
+// have many versions inside the window; the hint must stay short.
 const cooldownWithheldHintMaxVersions = 3
+
+// cooldownWithheldHintDetailMaxPackages is the package count up to which the
+// failure hint lists versions per package. Above it, the hint collapses to a
+// name list: a large install can withhold versions of dozens of transitive
+// dependencies, and per-version detail would drown the package manager error
+// the hint annotates.
+const cooldownWithheldHintDetailMaxPackages = 3
+
+// cooldownWithheldHintMaxPackageNames bounds how many package names the
+// collapsed hint lists before "and N more".
+const cooldownWithheldHintMaxPackageNames = 5
 
 // printCooldownWithheldHint explains a failed install that may have been caused
 // by cooldown stripping. PMG cannot know whether the resolver failed because of
@@ -372,12 +383,21 @@ func printCooldownWithheldHint(packages []models.CooldownWithheld) {
 		return
 	}
 
+	fmt.Println()
+	if len(packages) <= cooldownWithheldHintDetailMaxPackages {
+		printCooldownWithheldDetail(packages)
+	} else {
+		printCooldownWithheldSummary(packages)
+	}
+	fmt.Println()
+}
+
+func printCooldownWithheldDetail(packages []models.CooldownWithheld) {
 	total := 0
 	for _, pkg := range packages {
 		total += len(pkg.Versions)
 	}
 
-	fmt.Println()
 	fmt.Printf("%s %s\n",
 		Colors.Yellow("⊘"),
 		Colors.Yellow(fmt.Sprintf("Dependency cooldown withheld %s during version resolution", pluralizeVersions(total))))
@@ -403,7 +423,23 @@ func printCooldownWithheldHint(packages []models.CooldownWithheld) {
 	}
 
 	fmt.Printf("  %s\n", Colors.Dim("If the install failed because a version was not found, this is the likely cause."))
-	fmt.Println()
+}
+
+func printCooldownWithheldSummary(packages []models.CooldownWithheld) {
+	fmt.Printf("%s %s\n",
+		Colors.Yellow("⊘"),
+		Colors.Yellow(fmt.Sprintf("Dependency cooldown withheld versions of %s during resolution", pluralizePackages(len(packages)))))
+
+	names := make([]string, 0, cooldownWithheldHintMaxPackageNames+1)
+	for _, pkg := range packages[:min(len(packages), cooldownWithheldHintMaxPackageNames)] {
+		names = append(names, pkg.Name)
+	}
+	if hidden := len(packages) - len(names); hidden > 0 {
+		names = append(names, fmt.Sprintf("and %d more", hidden))
+	}
+
+	fmt.Printf("    %s\n", Colors.Dim(termWidthFormatTextIndent(strings.Join(names, ", "), 76, "    ")))
+	fmt.Printf("  %s\n", Colors.Dim("If the install failed because a version was not found, this is the likely cause. Run with --verbose to list all withheld versions."))
 }
 
 func printOutcomeLine(data *ReportData) {

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -434,15 +434,13 @@ func printCooldownWithheldSummary(packages []models.CooldownWithheld) {
 		Colors.Yellow("⊘"),
 		Colors.Yellow(fmt.Sprintf("Dependency cooldown withheld versions of %s during resolution", pluralizePackages(len(packages)))))
 
-	names := make([]string, 0, cooldownWithheldHintMaxPackageNames+1)
-	for _, pkg := range packages[:min(len(packages), cooldownWithheldHintMaxPackageNames)] {
-		names = append(names, pkg.Name)
+	shown := packages[:min(len(packages), cooldownWithheldHintMaxPackageNames)]
+	for _, pkg := range shown {
+		fmt.Printf("    %s\n", Colors.Dim(pkg.Name))
 	}
-	if hidden := len(packages) - len(names); hidden > 0 {
-		names = append(names, fmt.Sprintf("and %d more", hidden))
+	if hidden := len(packages) - len(shown); hidden > 0 {
+		fmt.Printf("    %s\n", Colors.Dim(fmt.Sprintf("and %d more...", hidden)))
 	}
-
-	fmt.Printf("    %s\n", Colors.Dim(termWidthFormatTextIndent(strings.Join(names, ", "), 76, "    ")))
 	fmt.Printf("  %s\n", Colors.Dim("If the install failed because a version was not found, this is the likely cause. Run with --verbose to list all withheld versions."))
 }
 

--- a/internal/ui/report_test.go
+++ b/internal/ui/report_test.go
@@ -238,10 +238,19 @@ func TestReportSilentWithheldStaysQuiet(t *testing.T) {
 func TestReportVerboseWithheldSection(t *testing.T) {
 	withVerbosity(t, VerbosityLevelVerbose)
 
-	out := captureStdout(t, func() { Report(withheldData(OutcomeError)) })
+	data := withheldData(OutcomeError)
+	data.CooldownWithheldPackages[0].Versions = append(data.CooldownWithheldPackages[0].Versions,
+		models.CooldownWithheldVersion{Version: "1.47.1", DaysLeft: 3},
+		models.CooldownWithheldVersion{Version: "1.48.0", DaysLeft: 4},
+		models.CooldownWithheldVersion{Version: "1.48.1", DaysLeft: 5},
+	)
+
+	out := captureStdout(t, func() { Report(data) })
 	assert.Contains(t, out, "Versions withheld by dependency cooldown:")
-	assert.Contains(t, out, "@posthog/core@1.47.0")
-	assert.Contains(t, out, "Available in 2 days")
+	assert.Contains(t, out, "⊘ @posthog/core")
+	assert.Contains(t, out, "1.47.0 (available in 2 days)")
+	assert.Contains(t, out, "1.48.1 (available in 5 days)", "verbose must list every version, no cap")
+	assert.NotContains(t, out, "and 1 more", "verbose must not truncate the version list")
 }
 
 func TestTermWidthFormatTextIndent(t *testing.T) {

--- a/internal/ui/report_test.go
+++ b/internal/ui/report_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -187,6 +188,44 @@ func TestReportNormalWithheldHintCapsVersions(t *testing.T) {
 	assert.Contains(t, out, "1.0.3 (available in 3 days)")
 	assert.NotContains(t, out, "1.0.4")
 	assert.Contains(t, out, "and 2 more")
+}
+
+func manyWithheldPackages(n int) []models.CooldownWithheld {
+	packages := make([]models.CooldownWithheld, 0, n)
+	for i := range n {
+		packages = append(packages, models.CooldownWithheld{
+			Name:     fmt.Sprintf("pkg-%02d", i),
+			Versions: []models.CooldownWithheldVersion{{Version: "1.0.0", DaysLeft: 2}},
+		})
+	}
+	return packages
+}
+
+func TestReportNormalWithheldHintDetailAtThreshold(t *testing.T) {
+	withVerbosity(t, VerbosityLevelNormal)
+
+	data := NewReportData()
+	data.Outcome = OutcomeError
+	data.CooldownWithheldPackages = manyWithheldPackages(3)
+
+	out := captureStdout(t, func() { Report(data) })
+	assert.Contains(t, out, "withheld 3 versions during version resolution")
+	assert.Contains(t, out, "1.0.0 (available in 2 days)")
+}
+
+func TestReportNormalWithheldHintCollapsesManyPackages(t *testing.T) {
+	withVerbosity(t, VerbosityLevelNormal)
+
+	data := NewReportData()
+	data.Outcome = OutcomeError
+	data.CooldownWithheldPackages = manyWithheldPackages(24)
+
+	out := captureStdout(t, func() { Report(data) })
+	assert.Contains(t, out, "Dependency cooldown withheld versions of 24 packages during resolution")
+	assert.Contains(t, out, "pkg-00, pkg-01, pkg-02, pkg-03, pkg-04, and 19 more")
+	assert.NotContains(t, out, "pkg-05", "collapsed hint must cap the name list")
+	assert.NotContains(t, out, "available in", "collapsed hint must not list versions")
+	assert.Contains(t, out, "Run with --verbose to list all withheld versions.")
 }
 
 func TestReportSilentWithheldStaysQuiet(t *testing.T) {

--- a/internal/ui/report_test.go
+++ b/internal/ui/report_test.go
@@ -222,7 +222,8 @@ func TestReportNormalWithheldHintCollapsesManyPackages(t *testing.T) {
 
 	out := captureStdout(t, func() { Report(data) })
 	assert.Contains(t, out, "Dependency cooldown withheld versions of 24 packages during resolution")
-	assert.Contains(t, out, "pkg-00, pkg-01, pkg-02, pkg-03, pkg-04, and 19 more")
+	assert.Contains(t, out, "    pkg-00\n    pkg-01\n    pkg-02\n    pkg-03\n    pkg-04\n    and 19 more...",
+		"collapsed hint lists one package name per line")
 	assert.NotContains(t, out, "pkg-05", "collapsed hint must cap the name list")
 	assert.NotContains(t, out, "available in", "collapsed hint must not list versions")
 	assert.Contains(t, out, "Run with --verbose to list all withheld versions.")

--- a/internal/ui/report_test.go
+++ b/internal/ui/report_test.go
@@ -127,6 +127,84 @@ func TestReportVerboseAdvisoryMessage(t *testing.T) {
 	assert.Contains(t, out, "ℹ Contact #security-help")
 }
 
+func withheldData(outcome ExecutionOutcome) *ReportData {
+	data := NewReportData()
+	data.Outcome = outcome
+	data.CooldownWithheldPackages = []models.CooldownWithheld{
+		{Name: "@posthog/core", Versions: []models.CooldownWithheldVersion{{Version: "1.47.0", DaysLeft: 2}}},
+	}
+	return data
+}
+
+func TestReportNormalWithheldHintOnError(t *testing.T) {
+	withVerbosity(t, VerbosityLevelNormal)
+
+	out := captureStdout(t, func() { Report(withheldData(OutcomeError)) })
+	assert.Contains(t, out, "Dependency cooldown withheld 1 version during version resolution")
+	assert.Contains(t, out, "@posthog/core")
+	assert.Contains(t, out, "1.47.0 (available in 2 days)")
+	assert.Contains(t, out, "this is the likely cause")
+}
+
+func TestReportNormalNoWithheldHintOnSuccess(t *testing.T) {
+	withVerbosity(t, VerbosityLevelNormal)
+
+	data := withheldData(OutcomeSuccess)
+	data.TotalAnalyzed = 2
+	data.AllowedCount = 2
+
+	out := captureStdout(t, func() { Report(data) })
+	assert.NotContains(t, out, "withheld", "resolver fallback succeeded, hint would be noise")
+}
+
+func TestReportNormalErrorWithoutWithheldStaysQuiet(t *testing.T) {
+	withVerbosity(t, VerbosityLevelNormal)
+
+	data := NewReportData()
+	data.Outcome = OutcomeError
+
+	out := captureStdout(t, func() { Report(data) })
+	assert.Empty(t, out)
+}
+
+func TestReportNormalWithheldHintCapsVersions(t *testing.T) {
+	withVerbosity(t, VerbosityLevelNormal)
+
+	data := NewReportData()
+	data.Outcome = OutcomeError
+	data.CooldownWithheldPackages = []models.CooldownWithheld{
+		{Name: "busy-pkg", Versions: []models.CooldownWithheldVersion{
+			{Version: "1.0.1", DaysLeft: 1},
+			{Version: "1.0.2", DaysLeft: 2},
+			{Version: "1.0.3", DaysLeft: 3},
+			{Version: "1.0.4", DaysLeft: 4},
+			{Version: "1.0.5", DaysLeft: 5},
+		}},
+	}
+
+	out := captureStdout(t, func() { Report(data) })
+	assert.Contains(t, out, "withheld 5 versions")
+	assert.Contains(t, out, "1.0.3 (available in 3 days)")
+	assert.NotContains(t, out, "1.0.4")
+	assert.Contains(t, out, "and 2 more")
+}
+
+func TestReportSilentWithheldStaysQuiet(t *testing.T) {
+	withVerbosity(t, VerbosityLevelSilent)
+
+	out := captureStdout(t, func() { Report(withheldData(OutcomeError)) })
+	assert.Empty(t, out)
+}
+
+func TestReportVerboseWithheldSection(t *testing.T) {
+	withVerbosity(t, VerbosityLevelVerbose)
+
+	out := captureStdout(t, func() { Report(withheldData(OutcomeError)) })
+	assert.Contains(t, out, "Versions withheld by dependency cooldown:")
+	assert.Contains(t, out, "@posthog/core@1.47.0")
+	assert.Contains(t, out, "Available in 2 days")
+}
+
 func TestTermWidthFormatTextIndent(t *testing.T) {
 	text := strings.Repeat("word ", 40)
 	out := termWidthFormatTextIndent(text, 20, "    ")

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -252,6 +252,13 @@ func pluralizePackages(n int) string {
 	return fmt.Sprintf("%d packages", n)
 }
 
+func pluralizeVersions(n int) string {
+	if n == 1 {
+		return "1 version"
+	}
+	return fmt.Sprintf("%d versions", n)
+}
+
 // termWidthFormatTextIndent wraps text at maxWidth and indents continuation
 // lines so wrapped output stays aligned with the first line.
 func termWidthFormatTextIndent(text string, maxWidth int, indent string) string {

--- a/proxy/interceptors/cooldown.go
+++ b/proxy/interceptors/cooldown.go
@@ -9,6 +9,7 @@ import (
 	"github.com/safedep/dry/log"
 	pmgconfig "github.com/safedep/pmg/config"
 	"github.com/safedep/pmg/internal/audit"
+	"github.com/safedep/pmg/internal/models"
 )
 
 // cooldownExemptions describes the in-window versions that survive cooldown
@@ -96,11 +97,15 @@ func cooldownOldestVersion(dates map[string]time.Time) (string, time.Time) {
 	return oldest, oldestTime
 }
 
-// recordCooldownStats records a cooldown block event. When all versions are blocked
-// (remaining == 0), it reports the oldest version (closest to exiting cooldown).
-// Otherwise, if a pinned version was stripped, it reports that specific version.
-func recordCooldownStats(statsCollector *AnalysisStatsCollector, ecosystem packagev1.Ecosystem, packageName string, pinnedVersion string, dates map[string]time.Time, remaining int, cooldownDays int) {
-	if statsCollector == nil {
+// recordCooldownStats records the outcome of a metadata strip. Two cases are
+// definite blocks: all versions stripped (remaining == 0, reported via the
+// oldest version, closest to exiting cooldown) and a stripped CLI-pinned
+// version. Anything else is recorded as a withheld hint: the resolver had
+// eligible versions to fall back to, but may still fail when a dependency
+// requires exactly a stripped version (a transitive exact pin), so the report
+// can surface the withheld set if the install fails.
+func recordCooldownStats(statsCollector *AnalysisStatsCollector, ecosystem packagev1.Ecosystem, packageName string, pinnedVersion string, dates map[string]time.Time, stripped []string, remaining int, cooldownDays int) {
+	if statsCollector == nil || len(stripped) == 0 {
 		return
 	}
 
@@ -121,13 +126,31 @@ func recordCooldownStats(statsCollector *AnalysisStatsCollector, ecosystem packa
 			_, daysAgo, daysLeft := cooldownIsWithinWindow(oldestDate, cooldownDays)
 			logCooldown(oldestVer, oldestDate, daysAgo, daysLeft)
 		}
-	} else if pinnedVersion != "" {
-		if pinnedDate, ok := dates[pinnedVersion]; ok {
-			if withinCooldown, daysAgo, daysLeft := cooldownIsWithinWindow(pinnedDate, cooldownDays); withinCooldown {
-				logCooldown(pinnedVersion, pinnedDate, daysAgo, daysLeft)
-			}
-		}
+		return
 	}
+
+	// Membership in the stripped set, not window membership, decides the
+	// pinned block: an in-window pinned version that survived stripping via
+	// the skip list or trusted_packages is installable and must not be
+	// reported as blocked.
+	strippedSet := make(map[string]bool, len(stripped))
+	for _, v := range stripped {
+		strippedSet[v] = true
+	}
+
+	if pinnedVersion != "" && strippedSet[pinnedVersion] {
+		pinnedDate := dates[pinnedVersion]
+		_, daysAgo, daysLeft := cooldownIsWithinWindow(pinnedDate, cooldownDays)
+		logCooldown(pinnedVersion, pinnedDate, daysAgo, daysLeft)
+		return
+	}
+
+	withheld := make([]models.CooldownWithheldVersion, 0, len(stripped))
+	for _, v := range stripped {
+		_, _, daysLeft := cooldownIsWithinWindow(dates[v], cooldownDays)
+		withheld = append(withheld, models.CooldownWithheldVersion{Version: v, DaysLeft: daysLeft})
+	}
+	statsCollector.RecordCooldownWithheld(packageName, withheld)
 }
 
 // cooldownHighestStableVersion returns the highest stable (non-prerelease) version

--- a/proxy/interceptors/cooldown_test.go
+++ b/proxy/interceptors/cooldown_test.go
@@ -6,6 +6,7 @@ import (
 
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	pmgconfig "github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/internal/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -275,4 +276,128 @@ func TestCooldownHighestStableVersion(t *testing.T) {
 			assert.Equal(t, tt.want, cooldownHighestStableVersion(tt.candidates, tt.upperBound))
 		})
 	}
+}
+
+func TestRecordCooldownStats(t *testing.T) {
+	now := time.Now()
+	day := 24 * time.Hour
+
+	tests := []struct {
+		name          string
+		pinnedVersion string
+		dates         map[string]time.Time
+		stripped      []string
+		remaining     int
+		wantBlocked   []string
+		wantWithheld  map[string][]string
+	}{
+		{
+			name: "all versions stripped records oldest as block",
+			dates: map[string]time.Time{
+				"1.0.0": now.Add(-3 * day),
+				"1.1.0": now.Add(-1 * day),
+			},
+			stripped:     []string{"1.0.0", "1.1.0"},
+			remaining:    0,
+			wantBlocked:  []string{"1.0.0"},
+			wantWithheld: map[string][]string{},
+		},
+		{
+			name:          "stripped pinned version records a block",
+			pinnedVersion: "2.0.0",
+			dates: map[string]time.Time{
+				"1.0.0": now.Add(-100 * day),
+				"2.0.0": now.Add(-1 * day),
+			},
+			stripped:     []string{"2.0.0"},
+			remaining:    1,
+			wantBlocked:  []string{"2.0.0"},
+			wantWithheld: map[string][]string{},
+		},
+		{
+			name:          "surviving pinned version records others as withheld",
+			pinnedVersion: "2.0.0",
+			dates: map[string]time.Time{
+				"1.0.0": now.Add(-100 * day),
+				"2.0.0": now.Add(-1 * day), // exempt: survived stripping
+				"2.1.0": now.Add(-1 * day),
+			},
+			stripped:     []string{"2.1.0"},
+			remaining:    2,
+			wantBlocked:  nil,
+			wantWithheld: map[string][]string{"pkg": {"2.1.0"}},
+		},
+		{
+			name: "no pin with eligible versions records withheld only",
+			dates: map[string]time.Time{
+				"1.0.0": now.Add(-100 * day),
+				"2.0.0": now.Add(-1 * day),
+				"2.1.0": now.Add(-2 * day),
+			},
+			stripped:     []string{"2.0.0", "2.1.0"},
+			remaining:    1,
+			wantBlocked:  nil,
+			wantWithheld: map[string][]string{"pkg": {"2.0.0", "2.1.0"}},
+		},
+		{
+			name: "nothing stripped records nothing",
+			dates: map[string]time.Time{
+				"1.0.0": now.Add(-100 * day),
+			},
+			stripped:     nil,
+			remaining:    1,
+			wantBlocked:  nil,
+			wantWithheld: map[string][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := NewAnalysisStatsCollector()
+			recordCooldownStats(collector, packagev1.Ecosystem_ECOSYSTEM_NPM, "pkg", tt.pinnedVersion, tt.dates, tt.stripped, tt.remaining, 5)
+
+			var blocked []string
+			for _, b := range collector.GetCooldownBlocks() {
+				blocked = append(blocked, b.Version)
+			}
+			assert.ElementsMatch(t, tt.wantBlocked, blocked)
+
+			withheld := map[string][]string{}
+			for _, w := range collector.GetCooldownWithheld() {
+				for _, v := range w.Versions {
+					withheld[w.Name] = append(withheld[w.Name], v.Version)
+				}
+			}
+			assert.Equal(t, tt.wantWithheld, withheld)
+		})
+	}
+}
+
+func TestRecordCooldownStats_NilCollector(t *testing.T) {
+	assert.NotPanics(t, func() {
+		recordCooldownStats(nil, packagev1.Ecosystem_ECOSYSTEM_NPM, "pkg", "", nil, []string{"1.0.0"}, 0, 5)
+	})
+}
+
+func TestRecordCooldownWithheld_DeduplicatesAcrossFetches(t *testing.T) {
+	collector := NewAnalysisStatsCollector()
+
+	versions := []models.CooldownWithheldVersion{
+		{Version: "2.0.0", DaysLeft: 4},
+		{Version: "2.1.0", DaysLeft: 5},
+	}
+	collector.RecordCooldownWithheld("pkg", versions)
+	collector.RecordCooldownWithheld("pkg", versions)
+	collector.RecordCooldownWithheld("other", []models.CooldownWithheldVersion{{Version: "1.0.0", DaysLeft: 1}})
+
+	withheld := collector.GetCooldownWithheld()
+	assert.Len(t, withheld, 2)
+	assert.Equal(t, "other", withheld[0].Name)
+	assert.Equal(t, "pkg", withheld[1].Name)
+	assert.Equal(t, versions, withheld[1].Versions)
+
+	stats := collector.GetStats()
+	assert.Equal(t, 0, stats.TotalAnalyzed, "withheld versions are not analyzed packages")
+	assert.Equal(t, 0, stats.BlockedCount, "withheld versions are not blocks")
+	assert.Equal(t, 0, stats.CooldownBlockedCount)
 }

--- a/proxy/interceptors/npm_cooldown.go
+++ b/proxy/interceptors/npm_cooldown.go
@@ -3,7 +3,9 @@ package interceptors
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"time"
 
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
@@ -75,11 +77,11 @@ func (h *npmCooldownHandler) HandleMetadataRequest(ctx *proxy.RequestContext, pa
 		exempt := cooldownExemptVersions(packagev1.Ecosystem_ECOSYSTEM_NPM, packageName, skip, dates, cooldownDays)
 		auditCooldownSkips(ctx.RequestID, packagev1.Ecosystem_ECOSYSTEM_NPM, packageName, exempt)
 		strippedBody, stripped, remaining := h.stripCooldownVersions(body, dates, cooldownDays, exempt.all)
-		if stripped > 0 {
+		if len(stripped) > 0 {
 			log.Infof("[%s] Cooldown: stripped %d version(s) from %s metadata (%d days, %d eligible remain)",
-				ctx.RequestID, stripped, packageName, cooldownDays, remaining)
+				ctx.RequestID, len(stripped), packageName, cooldownDays, remaining)
 
-			recordCooldownStats(h.statsCollector, packagev1.Ecosystem_ECOSYSTEM_NPM, packageName, pinnedVersion, dates, remaining, cooldownDays)
+			recordCooldownStats(h.statsCollector, packagev1.Ecosystem_ECOSYSTEM_NPM, packageName, pinnedVersion, dates, stripped, remaining, cooldownDays)
 
 			// Prevent npm from caching the modified response. Without this,
 			// npm would serve the stripped metadata from cache even after the
@@ -135,7 +137,8 @@ func (h *npmCooldownHandler) parseMetadataTime(body []byte) (map[string]time.Tim
 
 // stripCooldownVersions removes versions published within the cooldown window from the
 // NPM metadata response. It strips entries from "versions", "time", and updates "dist-tags".
-func (h *npmCooldownHandler) stripCooldownVersions(body []byte, dates map[string]time.Time, cooldownDays int, exemptVersions map[string]bool) ([]byte, int, int) {
+// Returns the modified body, the stripped versions, and the count of versions remaining.
+func (h *npmCooldownHandler) stripCooldownVersions(body []byte, dates map[string]time.Time, cooldownDays int, exemptVersions map[string]bool) ([]byte, []string, int) {
 	tooNew := make(map[string]bool)
 	for version, publishDate := range dates {
 		// Version-pinned skip entries are never stripped, even inside the window.
@@ -150,13 +153,13 @@ func (h *npmCooldownHandler) stripCooldownVersions(body []byte, dates map[string
 	remaining := len(dates) - len(tooNew)
 
 	if len(tooNew) == 0 {
-		return body, 0, remaining
+		return body, nil, remaining
 	}
 
 	var metadata map[string]json.RawMessage
 	if err := json.Unmarshal(body, &metadata); err != nil {
 		log.Warnf("Cooldown: failed to unmarshal metadata body: %v", err)
-		return body, 0, remaining
+		return body, nil, remaining
 	}
 
 	// survivingVersions holds the version keys still present in the "versions" object
@@ -263,8 +266,8 @@ func (h *npmCooldownHandler) stripCooldownVersions(body []byte, dates map[string
 	result, err := json.Marshal(metadata)
 	if err != nil {
 		log.Warnf("Cooldown: failed to marshal final metadata: %v", err)
-		return body, 0, remaining
+		return body, nil, remaining
 	}
 
-	return result, len(tooNew), remaining
+	return result, slices.Collect(maps.Keys(tooNew)), remaining
 }

--- a/proxy/interceptors/npm_cooldown_test.go
+++ b/proxy/interceptors/npm_cooldown_test.go
@@ -184,7 +184,7 @@ func TestStripCooldownVersions_MixedVersions(t *testing.T) {
 	require.NoError(t, err)
 
 	newBody, stripped, remaining := handler.stripCooldownVersions(body, dates, 5, nil)
-	assert.Equal(t, 1, stripped)
+	assert.ElementsMatch(t, []string{"1.0.2"}, stripped)
 	assert.Equal(t, 2, remaining)
 
 	var result map[string]json.RawMessage
@@ -224,7 +224,7 @@ func TestStripCooldownVersions_AllVersionsTooNew(t *testing.T) {
 	require.NoError(t, err)
 
 	newBody, stripped, remaining := handler.stripCooldownVersions(body, dates, 5, nil)
-	assert.Equal(t, 2, stripped)
+	assert.ElementsMatch(t, []string{"1.0.0", "1.0.1"}, stripped)
 	assert.Equal(t, 0, remaining)
 
 	var result map[string]json.RawMessage
@@ -250,7 +250,7 @@ func TestStripCooldownVersions_NoVersionsTooNew(t *testing.T) {
 	require.NoError(t, err)
 
 	newBody, stripped, remaining := handler.stripCooldownVersions(body, dates, 5, nil)
-	assert.Equal(t, 0, stripped)
+	assert.Empty(t, stripped)
 	assert.Equal(t, 2, remaining)
 	assert.Equal(t, body, newBody) // body unchanged
 }
@@ -268,7 +268,7 @@ func TestStripCooldownVersions_SingleVersionInCooldown(t *testing.T) {
 	require.NoError(t, err)
 
 	_, stripped, remaining := handler.stripCooldownVersions(body, dates, 5, nil)
-	assert.Equal(t, 1, stripped)
+	assert.ElementsMatch(t, []string{"1.0.0"}, stripped)
 	assert.Equal(t, 0, remaining)
 }
 
@@ -278,7 +278,7 @@ func TestStripCooldownVersions_MalformedJSON(t *testing.T) {
 	dates := map[string]time.Time{"1.0.0": time.Now().Add(-1 * time.Hour)}
 
 	newBody, stripped, _ := handler.stripCooldownVersions(body, dates, 5, nil)
-	assert.Equal(t, 0, stripped)
+	assert.Empty(t, stripped)
 	assert.Equal(t, body, newBody)
 }
 

--- a/proxy/interceptors/pypi_cooldown.go
+++ b/proxy/interceptors/pypi_cooldown.go
@@ -3,7 +3,9 @@ package interceptors
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -78,11 +80,11 @@ func (h *pypiCooldownHandler) HandleMetadataRequest(ctx *proxy.RequestContext, p
 		exempt := cooldownExemptVersions(packagev1.Ecosystem_ECOSYSTEM_PYPI, canonical, skip, dates, cooldownDays)
 		auditCooldownSkips(ctx.RequestID, packagev1.Ecosystem_ECOSYSTEM_PYPI, canonical, exempt)
 		strippedBody, stripped, remaining := h.stripCooldownFiles(body, dates, cooldownDays, exempt.all)
-		if stripped > 0 {
+		if len(stripped) > 0 {
 			log.Infof("[%s] Cooldown: stripped %d version(s) from %s metadata (%d days, %d eligible remain)",
-				ctx.RequestID, stripped, packageName, cooldownDays, remaining)
+				ctx.RequestID, len(stripped), packageName, cooldownDays, remaining)
 
-			recordCooldownStats(h.statsCollector, packagev1.Ecosystem_ECOSYSTEM_PYPI, packageName, pinnedVersion, dates, remaining, cooldownDays)
+			recordCooldownStats(h.statsCollector, packagev1.Ecosystem_ECOSYSTEM_PYPI, packageName, pinnedVersion, dates, stripped, remaining, cooldownDays)
 
 			headers.Set("Cache-Control", "no-store")
 			return statusCode, headers, strippedBody, nil
@@ -146,9 +148,9 @@ func (h *pypiCooldownHandler) parsePEP691Files(body []byte) (map[string]time.Tim
 }
 
 // stripCooldownFiles removes all file entries for versions within the cooldown window
-// from a PEP 691 JSON body. Returns the modified body, number of versions stripped,
-// and number of versions remaining.
-func (h *pypiCooldownHandler) stripCooldownFiles(body []byte, dates map[string]time.Time, cooldownDays int, exemptVersions map[string]bool) ([]byte, int, int) {
+// from a PEP 691 JSON body. Returns the modified body, the stripped versions, and the
+// count of versions remaining.
+func (h *pypiCooldownHandler) stripCooldownFiles(body []byte, dates map[string]time.Time, cooldownDays int, exemptVersions map[string]bool) ([]byte, []string, int) {
 	tooNew := make(map[string]bool)
 	for version, uploadDate := range dates {
 		// Version-pinned skip entries are never stripped, even inside the window.
@@ -163,24 +165,24 @@ func (h *pypiCooldownHandler) stripCooldownFiles(body []byte, dates map[string]t
 	remaining := len(dates) - len(tooNew)
 
 	if len(tooNew) == 0 {
-		return body, 0, remaining
+		return body, nil, remaining
 	}
 
 	var resp map[string]json.RawMessage
 	if err := json.Unmarshal(body, &resp); err != nil {
 		log.Warnf("Cooldown: failed to unmarshal PEP 691 body for stripping: %v", err)
-		return body, 0, remaining
+		return body, nil, remaining
 	}
 
 	rawFiles, ok := resp["files"]
 	if !ok {
-		return body, 0, remaining
+		return body, nil, remaining
 	}
 
 	var files []json.RawMessage
 	if err := json.Unmarshal(rawFiles, &files); err != nil {
 		log.Warnf("Cooldown: failed to unmarshal files array: %v", err)
-		return body, 0, remaining
+		return body, nil, remaining
 	}
 
 	filtered := make([]json.RawMessage, 0, len(files))
@@ -209,17 +211,17 @@ func (h *pypiCooldownHandler) stripCooldownFiles(body []byte, dates map[string]t
 	updatedFiles, err := json.Marshal(filtered)
 	if err != nil {
 		log.Warnf("Cooldown: failed to marshal filtered files array: %v", err)
-		return body, 0, remaining
+		return body, nil, remaining
 	}
 	resp["files"] = updatedFiles
 
 	result, err := json.Marshal(resp)
 	if err != nil {
 		log.Warnf("Cooldown: failed to marshal final PEP 691 response: %v", err)
-		return body, 0, remaining
+		return body, nil, remaining
 	}
 
-	return result, len(tooNew), remaining
+	return result, slices.Collect(maps.Keys(tooNew)), remaining
 }
 
 // parsePEP691UploadTime parses the ISO 8601 upload-time field from PEP 691 responses.

--- a/proxy/interceptors/pypi_cooldown_test.go
+++ b/proxy/interceptors/pypi_cooldown_test.go
@@ -181,7 +181,7 @@ func TestStripCooldownFiles_MixedVersions(t *testing.T) {
 	require.NoError(t, err)
 
 	newBody, stripped, remaining := handler.stripCooldownFiles(body, dates, 5, nil)
-	assert.Equal(t, 1, stripped)
+	assert.ElementsMatch(t, []string{"2.0.0"}, stripped)
 	assert.Equal(t, 1, remaining)
 
 	var result struct {
@@ -214,7 +214,7 @@ func TestStripCooldownFiles_AllVersionsTooNew(t *testing.T) {
 	require.NoError(t, err)
 
 	newBody, stripped, remaining := handler.stripCooldownFiles(body, dates, 5, nil)
-	assert.Equal(t, 2, stripped)
+	assert.ElementsMatch(t, []string{"1.0.0", "2.0.0"}, stripped)
 	assert.Equal(t, 0, remaining)
 
 	var result struct {
@@ -239,7 +239,7 @@ func TestStripCooldownFiles_NoVersionsTooNew(t *testing.T) {
 	require.NoError(t, err)
 
 	newBody, stripped, remaining := handler.stripCooldownFiles(body, dates, 5, nil)
-	assert.Equal(t, 0, stripped)
+	assert.Empty(t, stripped)
 	assert.Equal(t, 2, remaining)
 	assert.Equal(t, body, newBody)
 }
@@ -257,7 +257,7 @@ func TestStripCooldownFiles_SingleVersionInCooldown(t *testing.T) {
 	require.NoError(t, err)
 
 	_, stripped, remaining := handler.stripCooldownFiles(body, dates, 5, nil)
-	assert.Equal(t, 1, stripped)
+	assert.ElementsMatch(t, []string{"1.0.0"}, stripped)
 	assert.Equal(t, 0, remaining)
 }
 
@@ -288,7 +288,7 @@ func TestStripCooldownFiles_MultipleFilesPerVersion_AllStripped(t *testing.T) {
 	require.NoError(t, err)
 
 	newBody, stripped, remaining := handler.stripCooldownFiles(body, dates, 5, nil)
-	assert.Equal(t, 1, stripped) // 1 version stripped
+	assert.ElementsMatch(t, []string{"1.0.0"}, stripped)
 	assert.Equal(t, 0, remaining)
 
 	var result struct {
@@ -304,7 +304,7 @@ func TestStripCooldownFiles_MalformedJSON(t *testing.T) {
 	dates := map[string]time.Time{"1.0.0": time.Now().Add(-1 * time.Hour)}
 
 	newBody, stripped, _ := handler.stripCooldownFiles(body, dates, 5, nil)
-	assert.Equal(t, 0, stripped)
+	assert.Empty(t, stripped)
 	assert.Equal(t, body, newBody)
 }
 
@@ -339,7 +339,7 @@ func TestStripCooldownFiles_UnparseableFilename_KeepFile(t *testing.T) {
 		"1.0.0": now.Add(-1 * 24 * time.Hour),
 	}
 	newBody, stripped, _ := handler.stripCooldownFiles(body, forcedDates, 5, nil)
-	assert.Equal(t, 1, stripped) // version is "stripped" from the date map perspective
+	assert.ElementsMatch(t, []string{"1.0.0"}, stripped) // stripped from the date map perspective
 
 	var result struct {
 		Files []json.RawMessage `json:"files"`

--- a/proxy/interceptors/stats.go
+++ b/proxy/interceptors/stats.go
@@ -1,6 +1,7 @@
 package interceptors
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -27,6 +28,11 @@ type AnalysisStatsCollector struct {
 	blockedPackages   []*analyzer.PackageVersionAnalysisResult
 	confirmedPackages []*analyzer.PackageVersionAnalysisResult
 	cooldownBlocks    []models.CooldownBlock
+
+	// cooldownWithheld is keyed by package name, then version, holding days
+	// left. Metadata for one package can be fetched several times during an
+	// install, so recording must deduplicate rather than append.
+	cooldownWithheld map[string]map[string]int
 }
 
 // NewAnalysisStatsCollector creates a new stats collector
@@ -148,5 +154,51 @@ func (c *AnalysisStatsCollector) GetCooldownBlocks() []models.CooldownBlock {
 
 	result := make([]models.CooldownBlock, len(c.cooldownBlocks))
 	copy(result, c.cooldownBlocks)
+	return result
+}
+
+// RecordCooldownWithheld records versions stripped from a package's metadata
+// while eligible versions remained. Withheld versions are not blocks: they do
+// not count toward analyzed or blocked totals.
+func (c *AnalysisStatsCollector) RecordCooldownWithheld(name string, versions []models.CooldownWithheldVersion) {
+	if len(versions) == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cooldownWithheld == nil {
+		c.cooldownWithheld = make(map[string]map[string]int)
+	}
+	if c.cooldownWithheld[name] == nil {
+		c.cooldownWithheld[name] = make(map[string]int)
+	}
+	for _, v := range versions {
+		c.cooldownWithheld[name][v.Version] = v.DaysLeft
+	}
+}
+
+// GetCooldownWithheld returns the withheld records sorted by package name and
+// version for stable rendering.
+func (c *AnalysisStatsCollector) GetCooldownWithheld() []models.CooldownWithheld {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	result := make([]models.CooldownWithheld, 0, len(c.cooldownWithheld))
+	for name, versions := range c.cooldownWithheld {
+		entry := models.CooldownWithheld{Name: name}
+		for version, daysLeft := range versions {
+			entry.Versions = append(entry.Versions, models.CooldownWithheldVersion{
+				Version:  version,
+				DaysLeft: daysLeft,
+			})
+		}
+		sort.Slice(entry.Versions, func(i, j int) bool {
+			return entry.Versions[i].Version < entry.Versions[j].Version
+		})
+		result = append(result, entry)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
 	return result
 }

--- a/test/proxye2e/harness.go
+++ b/test/proxye2e/harness.go
@@ -196,6 +196,10 @@ func (h *Harness) BlockedPackages() []*analyzer.PackageVersionAnalysisResult {
 
 func (h *Harness) CooldownBlocks() []models.CooldownBlock { return h.stats.GetCooldownBlocks() }
 
+func (h *Harness) CooldownWithheld() []models.CooldownWithheld {
+	return h.stats.GetCooldownWithheld()
+}
+
 func (h *Harness) recordDial(addr string) {
 	h.dialMu.Lock()
 	defer h.dialMu.Unlock()

--- a/test/proxye2e/proxye2e_test.go
+++ b/test/proxye2e/proxye2e_test.go
@@ -133,6 +133,107 @@ func TestProxyFlow_Npm(t *testing.T) {
 					}
 				}
 				assert.True(t, found, "pinned in-window version should be recorded as a cooldown block")
+				assert.Empty(t, h.CooldownWithheld(), "a definite block must not also be recorded as withheld")
+			},
+		},
+		{
+			Name:   "cooldown records withheld versions when the resolver falls back",
+			Config: cooldownEnabled(7),
+			Setup: func(h *Harness) {
+				h.Registry.AddNpm(NpmPackage{Name: "left-pad", DistTagLatest: "2.0.0", Versions: []NpmVersion{
+					{Version: "1.0.0", PublishedAt: old()},
+					{Version: "2.0.0", PublishedAt: recent()},
+				}})
+				h.Analyzer.SetNpm("left-pad", "1.0.0", Clean())
+			},
+			Exec: func(h *Harness) ExecResult { return h.Npm().Install("left-pad", "") },
+			Assert: func(t *testing.T, h *Harness, res ExecResult) {
+				assert.False(t, res.Blocked())
+				assert.True(t, h.Registry.DownloadedTarball("left-pad", "1.0.0"), "resolver must fall back to the repaired latest")
+				assert.Equal(t, 0, h.Stats().CooldownBlockedCount, "a successful fallback is not a block")
+
+				withheld := h.CooldownWithheld()
+				assert.Len(t, withheld, 1)
+				assert.Equal(t, "left-pad", withheld[0].Name)
+				assert.Len(t, withheld[0].Versions, 1)
+				assert.Equal(t, "2.0.0", withheld[0].Versions[0].Version)
+				assert.Positive(t, withheld[0].Versions[0].DaysLeft)
+			},
+		},
+		{
+			// Models a transitive exact pin (e.g. posthog-node requiring exactly
+			// @posthog/core@1.47.0): the version is not CLI-pinned, eligible
+			// versions remain, but resolution still fails. PMG cannot record a
+			// block here; the withheld record is what the failure report shows.
+			Name:   "cooldown withheld exact transitive pin fails without a block record",
+			Config: cooldownEnabled(7),
+			Setup: func(h *Harness) {
+				h.Registry.AddNpm(NpmPackage{Name: "core", DistTagLatest: "2.0.0", Versions: []NpmVersion{
+					{Version: "1.0.0", PublishedAt: old()},
+					{Version: "2.0.0", PublishedAt: recent()},
+				}})
+			},
+			Exec: func(h *Harness) ExecResult { return h.Npm().Install("core", "2.0.0") },
+			Assert: func(t *testing.T, h *Harness, res ExecResult) {
+				assert.False(t, h.Registry.DownloadedTarball("core", "2.0.0"), "stripped version must not resolve")
+				assert.Equal(t, 0, h.Stats().CooldownBlockedCount)
+				assert.Empty(t, h.CooldownBlocks())
+
+				withheld := h.CooldownWithheld()
+				assert.Len(t, withheld, 1)
+				assert.Equal(t, "core", withheld[0].Name)
+				assert.Len(t, withheld[0].Versions, 1)
+				assert.Equal(t, "2.0.0", withheld[0].Versions[0].Version)
+			},
+		},
+		{
+			Name:   "cooldown all-in-window block is not duplicated as withheld",
+			Config: cooldownEnabled(7),
+			Setup: func(h *Harness) {
+				h.Registry.AddNpm(NpmPackage{Name: "left-pad", DistTagLatest: "1.0.1", Versions: []NpmVersion{
+					{Version: "1.0.0", PublishedAt: recent()},
+					{Version: "1.0.1", PublishedAt: recent()},
+				}})
+			},
+			Exec: func(h *Harness) ExecResult { return h.Npm().Install("left-pad", "") },
+			Assert: func(t *testing.T, h *Harness, res ExecResult) {
+				assert.GreaterOrEqual(t, h.Stats().CooldownBlockedCount, 1, "all versions in window is a definite block")
+				assert.Empty(t, h.CooldownWithheld())
+				assert.False(t, h.Registry.DownloadedTarball("left-pad", "1.0.0"))
+				assert.False(t, h.Registry.DownloadedTarball("left-pad", "1.0.1"))
+			},
+		},
+		{
+			// Regression: a pinned version that survives stripping via the skip
+			// list must not be reported as a cooldown block. Only the other
+			// stripped versions are recorded, as withheld.
+			Name: "cooldown skip-listed pinned version installs without a block record",
+			Config: func(rc *config.RuntimeConfig) {
+				rc.Config.DependencyCooldown = config.DependencyCooldownConfig{
+					Enabled: true, Days: 7,
+					Skip: []config.TrustedPackage{{Purl: "pkg:npm/left-pad@2.0.0"}},
+				}
+			},
+			PinnedVersions: map[string]string{"left-pad": "2.0.0"},
+			Setup: func(h *Harness) {
+				h.Registry.AddNpm(NpmPackage{Name: "left-pad", DistTagLatest: "2.1.0", Versions: []NpmVersion{
+					{Version: "1.0.0", PublishedAt: old()},
+					{Version: "2.0.0", PublishedAt: recent()},
+					{Version: "2.1.0", PublishedAt: recent()},
+				}})
+				h.Analyzer.SetNpm("left-pad", "2.0.0", Clean())
+			},
+			Exec: func(h *Harness) ExecResult { return h.Npm().Install("left-pad", "2.0.0") },
+			Assert: func(t *testing.T, h *Harness, res ExecResult) {
+				assert.False(t, res.Blocked())
+				assert.True(t, h.Registry.DownloadedTarball("left-pad", "2.0.0"), "skip-listed pinned version must install")
+				assert.Equal(t, 0, h.Stats().CooldownBlockedCount, "surviving pinned version must not be recorded as blocked")
+				assert.Empty(t, h.CooldownBlocks())
+
+				withheld := h.CooldownWithheld()
+				assert.Len(t, withheld, 1)
+				assert.Len(t, withheld[0].Versions, 1)
+				assert.Equal(t, "2.1.0", withheld[0].Versions[0].Version)
 			},
 		},
 		{
@@ -356,6 +457,28 @@ func TestProxyFlow_Pypi(t *testing.T) {
 				simple := h.Pypi().FetchSimple("Flask_Thing")
 				assert.False(t, simple.HasVersion("Flask_Thing", "2.0.0"), "in-window version must be stripped")
 				assert.True(t, simple.HasVersion("Flask_Thing", "1.0.0"), "out-of-window version must survive")
+			},
+		},
+		{
+			Name:   "cooldown records withheld versions while eligible remain",
+			Config: cooldownEnabled(7),
+			Setup: func(h *Harness) {
+				h.Registry.AddPypi(PypiPackage{Name: "requests", Versions: []PypiVersion{
+					{Version: "1.0.0", PublishedAt: old()},
+					{Version: "2.0.0", PublishedAt: recent()},
+				}})
+			},
+			Exec: func(h *Harness) ExecResult { return h.Pypi().Install("requests", "2.0.0") },
+			Assert: func(t *testing.T, h *Harness, res ExecResult) {
+				assert.Equal(t, 0, h.Stats().CooldownBlockedCount, "eligible versions remain, not a block")
+				assert.Empty(t, h.CooldownBlocks())
+
+				withheld := h.CooldownWithheld()
+				assert.Len(t, withheld, 1)
+				assert.Equal(t, "requests", withheld[0].Name)
+				assert.Len(t, withheld[0].Versions, 1)
+				assert.Equal(t, "2.0.0", withheld[0].Versions[0].Version)
+				assert.Positive(t, withheld[0].Versions[0].DaysLeft)
 			},
 		},
 	})


### PR DESCRIPTION
## Problem

Dependency cooldown output only appears for two definite blocks: all versions of a package in the window, or a CLI-pinned version stripped. When cooldown strips versions but eligible versions remain, PMG records nothing. That is correct when the resolver falls back. It is confusing when resolution fails because a lockfile entry or a dependency requires exactly a stripped version. The user then sees only the package manager error:

```
ERR_PNPM_NO_MATCHING_VERSION No matching version found for @posthog/core@1.47.0
...
pmg: pnpm exited with code 1
```

Nothing tells the user that cooldown caused this.

## Change

- Record stripped versions as withheld hints in the stats collector when eligible versions remain. Withheld records are not blocks: they do not count toward analyzed or blocked totals, and they do not emit audit events.
- On a failed install (outcome error), print the withheld versions after the package manager error, capped at 3 versions per package. Beyond 3 packages the hint collapses to a capped package-name list (a single AWS SDK client can put 24 packages in the window); --verbose keeps the full per-version listing. PMG cannot know the resolver failed because of the strip, so the output is phrased as a likely cause.
- Verbose mode always lists withheld versions. Silent mode and successful installs stay unchanged.
- Document when each form of cooldown output appears in `docs/dependency-cooldown.md`.

New output after a failed install:

```
⊘ Dependency cooldown withheld versions of 24 packages during resolution
    @aws-sdk/checksums, @aws-sdk/client-s3, @aws-sdk/core,
    @aws-sdk/credential-provider-env, @aws-sdk/credential-provider-http, and 19
    more
  If the install failed because a version was not found, this is the likely cause. Run with --verbose to list all withheld versions.

↳ pmg: npm exited with code 1
```

## Bug fix

`recordCooldownStats` reported a CLI-pinned version as a cooldown block whenever it was inside the window, even when it survived stripping through `dependency_cooldown.skip` or `trusted_packages` and installed fine. The pinned block now requires membership in the stripped set. Covered by the new `cooldown skip-listed pinned version installs without a block record` E2E case.

## Coverage

Unit tests cover the record decision table, collector dedup across repeated metadata fetches, and all report render paths. E2E cases cover: fallback success records withheld only, transitive exact pin failure records withheld with no block, pinned block does not duplicate as withheld, all-in-window block records no withheld, skip-listed pinned survivor, and the PyPI variant. Verified against the real npm registry with @posthog/core: manifest exact pin fails with the hint, range dep falls back silently to 1.47.0, CLI pin shows the existing block output with no duplicate hint, and an unrelated 404 failure shows no hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Output

<img width="2016" height="578" alt="image" src="https://github.com/user-attachments/assets/38c4fd2e-0b49-4318-ad0a-99a3c8bf61fe" />

