### PR TITLE
feat: Add machine-readable JSON output to setup info and doctor

### DIFF
--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -37,6 +37,8 @@ const (
 	checkSystemBinary       = "system-binary"
 
 	aliasesInstalledMessage = "Shell aliases installed"
+
+	categoryProtection = "Protection"
 )
 
 func NewDoctorCommand() *cobra.Command {
@@ -72,7 +74,7 @@ func executeDoctorChecks(out io.Writer, jsonOut bool) error {
 	allResults := append(coreResults, protectionResults...)
 
 	if jsonOut {
-		if err := writeStatusJSON(out, buildDoctorReport(allResults)); err != nil {
+		if err := writeStatusJSON(out, buildDoctorReport(cfg, allResults)); err != nil {
 			return err
 		}
 	} else {
@@ -456,7 +458,7 @@ func runProtectionChecks(coreResults []doctor.CheckResult) []doctor.CheckResult 
 		for _, tc := range doctor.ProtectionTestCases() {
 			results = append(results, doctor.CheckResult{
 				Name:     fmt.Sprintf("protection-%s", tc.PackageManager),
-				Category: "Protection",
+				Category: categoryProtection,
 				Status:   doctor.StatusFail,
 				Message:  "Aliases and shims not active",
 			})
@@ -472,7 +474,7 @@ func runProtectionChecks(coreResults []doctor.CheckResult) []doctor.CheckResult 
 	var results []doctor.CheckResult
 	for _, tc := range doctor.ProtectionTestCases() {
 		result := doctor.RunProtectionCheck(tc, pmgBinary)
-		result.Category = "Protection"
+		result.Category = categoryProtection
 		result.Name = fmt.Sprintf("protection-%s", tc.PackageManager)
 		results = append(results, result)
 	}

--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,19 +40,23 @@ const (
 )
 
 func NewDoctorCommand() *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+
+	cmd := &cobra.Command{
 		Use:          "doctor",
 		Short:        "Validate PMG installation and protection",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Print(ui.GeneratePMGBanner(version.Version, version.Commit))
-			err := executeDoctorChecks()
+			err := executeDoctorChecks(cmd.OutOrStdout(), jsonOut)
 			if _, ok := err.(*doctorFailError); ok {
 				cmd.SilenceErrors = true
 			}
 			return err
 		},
 	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit diagnostics as JSON")
+	return cmd
 }
 
 type doctorFailError struct{}
@@ -59,14 +64,21 @@ type doctorFailError struct{}
 func (e *doctorFailError) Error() string { return "" }
 func (e *doctorFailError) ExitCode() int { return 1 }
 
-func executeDoctorChecks() error {
+func executeDoctorChecks(out io.Writer, jsonOut bool) error {
 	cfg := config.Get()
 
 	coreResults := runCoreChecks(cfg)
 	protectionResults := runProtectionChecks(coreResults)
 	allResults := append(coreResults, protectionResults...)
 
-	printResults(allResults)
+	if jsonOut {
+		if err := writeStatusJSON(out, buildDoctorReport(allResults)); err != nil {
+			return err
+		}
+	} else {
+		fmt.Print(ui.GeneratePMGBanner(version.Version, version.Commit))
+		printResults(allResults)
+	}
 
 	if doctor.HasFailures(allResults) {
 		return &doctorFailError{}
@@ -602,17 +614,7 @@ func fixHint(name string) string {
 }
 
 func printSummaryLine(results []doctor.CheckResult) {
-	passCount, warnCount, failCount := 0, 0, 0
-	for _, r := range results {
-		switch r.Status {
-		case doctor.StatusPass:
-			passCount++
-		case doctor.StatusWarn:
-			warnCount++
-		case doctor.StatusFail:
-			failCount++
-		}
-	}
+	passCount, warnCount, failCount := countStatuses(results)
 
 	summary := fmt.Sprintf("%d passed", passCount)
 	if warnCount > 0 {

--- a/cmd/setup/info.go
+++ b/cmd/setup/info.go
@@ -23,10 +23,16 @@ import (
 )
 
 func NewInfoCommand() *cobra.Command {
+	var jsonOut bool
+
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Show information about PMG setup and configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if jsonOut {
+				return writeStatusJSON(cmd.OutOrStdout(), collectInfoReport(config.Get()))
+			}
+
 			err := executeSetupInfo()
 			if err != nil {
 				ui.ErrorExit(fmt.Errorf("failed to execute setup info: %w", err))
@@ -36,6 +42,7 @@ func NewInfoCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit setup and protection status as JSON")
 	return cmd
 }
 

--- a/cmd/setup/status.go
+++ b/cmd/setup/status.go
@@ -1,0 +1,280 @@
+package setup
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/internal/alias"
+	"github.com/safedep/pmg/internal/doctor"
+	"github.com/safedep/pmg/internal/proxyserver"
+	"github.com/safedep/pmg/internal/version"
+	"github.com/safedep/pmg/proxy/certmanager"
+	"github.com/safedep/pmg/truststore"
+)
+
+// statusSchemaVersion versions the JSON contract emitted by
+// `pmg setup info --json` and `pmg setup doctor --json` so consumers (the
+// Omarchy plugin, CI gates) can pin behaviour across PMG releases.
+const statusSchemaVersion = 1
+
+type health string
+
+const (
+	healthProtected   health = "protected"
+	healthDegraded    health = "degraded"
+	healthUnprotected health = "unprotected"
+)
+
+// statusCheck is the JSON projection of a doctor.CheckResult.
+type statusCheck struct {
+	Name     string `json:"name"`
+	Category string `json:"category"`
+	Status   string `json:"status"` // pass | warn | fail
+	Message  string `json:"message,omitempty"`
+	Fix      string `json:"fix,omitempty"`
+}
+
+type shellIntegration struct {
+	Shell       string `json:"shell"`
+	Aliases     bool   `json:"aliases"`
+	ShimsInPath bool   `json:"shims_in_path"`
+}
+
+type cooldownInfo struct {
+	Enabled bool `json:"enabled"`
+	Days    int  `json:"days"`
+}
+
+type sandboxInfo struct {
+	Enabled bool   `json:"enabled"`
+	Driver  string `json:"driver"`
+	Ready   bool   `json:"ready"`
+}
+
+type caInfo struct {
+	Trusted bool   `json:"trusted"`
+	Scope   string `json:"scope"` // none | user | system
+	Expires string `json:"expires,omitempty"`
+}
+
+type proxyInfo struct {
+	Running bool   `json:"running"`
+	Addr    string `json:"addr,omitempty"`
+	PID     int    `json:"pid,omitempty"`
+}
+
+type protectionLayers struct {
+	ThreatIntel bool         `json:"threat_intel"`
+	Cooldown    cooldownInfo `json:"cooldown"`
+	Sandbox     sandboxInfo  `json:"sandbox"`
+	CA          caInfo       `json:"ca"`
+	Proxy       proxyInfo    `json:"proxy"`
+}
+
+// infoReport is the machine-readable protection status emitted by
+// `pmg setup info --json`. It is derived only from the cheap core checks and
+// config, so it is safe to poll (no interception probes are executed).
+type infoReport struct {
+	SchemaVersion int              `json:"schema_version"`
+	Version       string           `json:"version"`
+	Health        health           `json:"health"`
+	Protected     bool             `json:"protected"`
+	Shell         shellIntegration `json:"shell_integration"`
+	Layers        protectionLayers `json:"layers"`
+	Checks        []statusCheck    `json:"checks"`
+}
+
+type doctorSummary struct {
+	Passed   int `json:"passed"`
+	Warnings int `json:"warnings"`
+	Failed   int `json:"failed"`
+}
+
+// doctorReport is emitted by `pmg setup doctor --json`. Unlike infoReport it
+// includes the authoritative interception probes, so it is the report a CI gate
+// should trust.
+type doctorReport struct {
+	SchemaVersion int           `json:"schema_version"`
+	Version       string        `json:"version"`
+	Health        health        `json:"health"`
+	Protected     bool          `json:"protected"`
+	Summary       doctorSummary `json:"summary"`
+	Checks        []statusCheck `json:"checks"`
+}
+
+func collectInfoReport(cfg *config.RuntimeConfig) infoReport {
+	core := runCoreChecks(cfg)
+	h, protected := deriveStatus(core)
+
+	return infoReport{
+		SchemaVersion: statusSchemaVersion,
+		Version:       version.Version,
+		Health:        h,
+		Protected:     protected,
+		Shell:         collectShellIntegration(core),
+		Layers:        collectLayers(cfg),
+		Checks:        toStatusChecks(core),
+	}
+}
+
+func buildDoctorReport(results []doctor.CheckResult) doctorReport {
+	h, protected := deriveStatus(results)
+	passed, warnings, failed := countStatuses(results)
+
+	return doctorReport{
+		SchemaVersion: statusSchemaVersion,
+		Version:       version.Version,
+		Health:        h,
+		Protected:     protected,
+		Summary:       doctorSummary{Passed: passed, Warnings: warnings, Failed: failed},
+		Checks:        toStatusChecks(results),
+	}
+}
+
+// deriveStatus rolls a set of checks into a single verdict. Protected is the
+// security-critical signal: are installs actually intercepted (via aliases or
+// shims on PATH). Health layers on the rest: any non-passing check downgrades an
+// intercepting install to "degraded" without claiming it is unprotected.
+func deriveStatus(results []doctor.CheckResult) (health, bool) {
+	if !isInterceptionActive(results) {
+		return healthUnprotected, false
+	}
+	for _, r := range results {
+		if r.Status != doctor.StatusPass {
+			return healthDegraded, true
+		}
+	}
+	return healthProtected, true
+}
+
+func collectShellIntegration(core []doctor.CheckResult) shellIntegration {
+	shell, err := alias.DetectShell()
+	if err != nil {
+		shell = "unknown"
+	}
+
+	si := shellIntegration{Shell: shell}
+	if c, ok := findCheck(core, checkShellAliases); ok {
+		si.Aliases = c.ImpliesInterception
+	}
+	if c, ok := findCheck(core, checkShimInPath); ok {
+		si.ShimsInPath = c.Status == doctor.StatusPass
+	}
+	return si
+}
+
+func collectLayers(cfg *config.RuntimeConfig) protectionLayers {
+	driver := resolveSandboxDriverName()
+
+	layers := protectionLayers{
+		ThreatIntel: true,
+		Cooldown: cooldownInfo{
+			Enabled: cfg.Config.DependencyCooldown.Enabled,
+			Days:    cfg.Config.DependencyCooldown.Days,
+		},
+		Sandbox: sandboxInfo{
+			Enabled: cfg.Config.Sandbox.Enabled,
+			Driver:  driver,
+			Ready:   driver != "unavailable",
+		},
+		CA:    collectCAInfo(cfg),
+		Proxy: collectProxyInfo(cfg),
+	}
+	return layers
+}
+
+func collectCAInfo(cfg *config.RuntimeConfig) caInfo {
+	st, _ := certmanager.InspectCA(cfg.ConfigDir())
+	st.UserTrusted, st.SystemTrusted, _ = truststore.Status(certmanager.CACommonName)
+
+	scope := "none"
+	if st.SystemTrusted {
+		scope = "system"
+	} else if st.UserTrusted {
+		scope = "user"
+	}
+
+	ca := caInfo{Trusted: st.Trusted(), Scope: scope}
+	if st.CertPresent {
+		ca.Expires = st.NotAfter.Format(time.RFC3339)
+	}
+	return ca
+}
+
+func collectProxyInfo(cfg *config.RuntimeConfig) proxyInfo {
+	st := proxyserver.GetStatus(proxyserver.ResolveStatePath("", cfg.CacheDir()))
+	if !st.Found || !st.Running {
+		return proxyInfo{}
+	}
+	return proxyInfo{Running: true, Addr: st.Addr, PID: st.PID}
+}
+
+func toStatusChecks(results []doctor.CheckResult) []statusCheck {
+	checks := make([]statusCheck, 0, len(results))
+	for _, r := range results {
+		checks = append(checks, statusCheck{
+			Name:     r.Name,
+			Category: r.Category,
+			Status:   statusString(r.Status),
+			Message:  r.Message,
+			Fix:      fixFor(r),
+		})
+	}
+	return checks
+}
+
+// fixFor returns the actionable fix for a non-passing check, preferring a
+// result-specific override over the static hint. Passing checks have no fix.
+func fixFor(r doctor.CheckResult) string {
+	if r.Status == doctor.StatusPass {
+		return ""
+	}
+	if r.Fix != "" {
+		return r.Fix
+	}
+	return checkFixes[r.Name]
+}
+
+func statusString(s doctor.CheckStatus) string {
+	switch s {
+	case doctor.StatusPass:
+		return "pass"
+	case doctor.StatusWarn:
+		return "warn"
+	case doctor.StatusFail:
+		return "fail"
+	default:
+		return "unknown"
+	}
+}
+
+func countStatuses(results []doctor.CheckResult) (passed, warnings, failed int) {
+	for _, r := range results {
+		switch r.Status {
+		case doctor.StatusPass:
+			passed++
+		case doctor.StatusWarn:
+			warnings++
+		case doctor.StatusFail:
+			failed++
+		}
+	}
+	return passed, warnings, failed
+}
+
+func findCheck(results []doctor.CheckResult, name string) (doctor.CheckResult, bool) {
+	for _, r := range results {
+		if r.Name == name {
+			return r, true
+		}
+	}
+	return doctor.CheckResult{}, false
+}
+
+func writeStatusJSON(out io.Writer, v any) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/cmd/setup/status.go
+++ b/cmd/setup/status.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/config"
 	"github.com/safedep/pmg/internal/alias"
 	"github.com/safedep/pmg/internal/doctor"
@@ -73,10 +74,10 @@ type protectionLayers struct {
 	Proxy       proxyInfo    `json:"proxy"`
 }
 
-// infoReport is the machine-readable protection status emitted by
-// `pmg setup info --json`. It is derived only from the cheap core checks and
-// config, so it is safe to poll (no interception probes are executed).
-type infoReport struct {
+// statusReport is the machine-readable protection status shared by
+// `pmg setup info --json` and `pmg setup doctor --json`: a health/protected
+// verdict, the enabled layers, and the checks it was derived from.
+type statusReport struct {
 	SchemaVersion int              `json:"schema_version"`
 	Version       string           `json:"version"`
 	Health        health           `json:"health"`
@@ -92,53 +93,53 @@ type doctorSummary struct {
 	Failed   int `json:"failed"`
 }
 
-// doctorReport is emitted by `pmg setup doctor --json`. Unlike infoReport it
-// includes the authoritative interception probes, so it is the report a CI gate
+// doctorReport is emitted by `pmg setup doctor --json`: the full status report
+// (with the authoritative interception probes in Checks) plus a pass/warn/fail
+// summary. It is a superset of the info report and is the surface a CI gate
 // should trust.
 type doctorReport struct {
-	SchemaVersion int           `json:"schema_version"`
-	Version       string        `json:"version"`
-	Health        health        `json:"health"`
-	Protected     bool          `json:"protected"`
-	Summary       doctorSummary `json:"summary"`
-	Checks        []statusCheck `json:"checks"`
+	statusReport
+	Summary doctorSummary `json:"summary"`
 }
 
-func collectInfoReport(cfg *config.RuntimeConfig) infoReport {
-	core := runCoreChecks(cfg)
-	h, protected := deriveStatus(core)
+// buildStatusReport rolls a set of checks and the current config into the shared
+// status report. The caller chooses which checks to pass: the cheap core checks
+// for `setup info`, or core plus the authoritative probes for `setup doctor`.
+func buildStatusReport(cfg *config.RuntimeConfig, checks []doctor.CheckResult) statusReport {
+	h, protected := deriveStatus(checks)
 
-	return infoReport{
+	return statusReport{
 		SchemaVersion: statusSchemaVersion,
 		Version:       version.Version,
 		Health:        h,
 		Protected:     protected,
-		Shell:         collectShellIntegration(core),
+		Shell:         collectShellIntegration(checks),
 		Layers:        collectLayers(cfg),
-		Checks:        toStatusChecks(core),
+		Checks:        toStatusChecks(checks),
 	}
 }
 
-func buildDoctorReport(results []doctor.CheckResult) doctorReport {
-	h, protected := deriveStatus(results)
+func collectInfoReport(cfg *config.RuntimeConfig) statusReport {
+	return buildStatusReport(cfg, runCoreChecks(cfg))
+}
+
+func buildDoctorReport(cfg *config.RuntimeConfig, results []doctor.CheckResult) doctorReport {
 	passed, warnings, failed := countStatuses(results)
 
 	return doctorReport{
-		SchemaVersion: statusSchemaVersion,
-		Version:       version.Version,
-		Health:        h,
-		Protected:     protected,
-		Summary:       doctorSummary{Passed: passed, Warnings: warnings, Failed: failed},
-		Checks:        toStatusChecks(results),
+		statusReport: buildStatusReport(cfg, results),
+		Summary:      doctorSummary{Passed: passed, Warnings: warnings, Failed: failed},
 	}
 }
 
 // deriveStatus rolls a set of checks into a single verdict. Protected is the
-// security-critical signal: are installs actually intercepted (via aliases or
-// shims on PATH). Health layers on the rest: any non-passing check downgrades an
-// intercepting install to "degraded" without claiming it is unprotected.
+// security-critical signal: are installs actually intercepted. A failing
+// authoritative protection probe (present only in the doctor report) proves
+// interception is bypassed and forces "unprotected", overriding the presence of
+// aliases or shims. Otherwise any non-passing check downgrades an intercepting
+// install to "degraded" without claiming it is unprotected.
 func deriveStatus(results []doctor.CheckResult) (health, bool) {
-	if !isInterceptionActive(results) {
+	if hasFailingProtectionCheck(results) || !isInterceptionActive(results) {
 		return healthUnprotected, false
 	}
 	for _, r := range results {
@@ -147,6 +148,15 @@ func deriveStatus(results []doctor.CheckResult) (health, bool) {
 		}
 	}
 	return healthProtected, true
+}
+
+func hasFailingProtectionCheck(results []doctor.CheckResult) bool {
+	for _, r := range results {
+		if r.Category == categoryProtection && r.Status == doctor.StatusFail {
+			return true
+		}
+	}
+	return false
 }
 
 func collectShellIntegration(core []doctor.CheckResult) shellIntegration {
@@ -186,7 +196,15 @@ func collectLayers(cfg *config.RuntimeConfig) protectionLayers {
 }
 
 func collectCAInfo(cfg *config.RuntimeConfig) caInfo {
-	st, _ := certmanager.InspectCA(cfg.ConfigDir())
+	// A present-but-unreadable/malformed cert makes the on-disk metadata
+	// (expiry, trust) untrustworthy; the ca-cert check already reports the
+	// failure, so here we report the layer as untrusted rather than encode
+	// contradictory data.
+	st, err := certmanager.InspectCA(cfg.ConfigDir())
+	if err != nil {
+		log.Debugf("CA inspection failed; reporting CA layer as untrusted: %v", err)
+		return caInfo{Scope: "none"}
+	}
 	st.UserTrusted, st.SystemTrusted, _ = truststore.Status(certmanager.CACommonName)
 
 	scope := "none"
@@ -197,7 +215,7 @@ func collectCAInfo(cfg *config.RuntimeConfig) caInfo {
 	}
 
 	ca := caInfo{Trusted: st.Trusted(), Scope: scope}
-	if st.CertPresent {
+	if st.CertPresent && !st.NotAfter.IsZero() {
 		ca.Expires = st.NotAfter.Format(time.RFC3339)
 	}
 	return ca

--- a/cmd/setup/status.go
+++ b/cmd/setup/status.go
@@ -15,9 +15,7 @@ import (
 	"github.com/safedep/pmg/truststore"
 )
 
-// statusSchemaVersion versions the JSON contract emitted by
-// `pmg setup info --json` and `pmg setup doctor --json` so consumers (the
-// Omarchy plugin, CI gates) can pin behaviour across PMG releases.
+// Bump when the JSON contract changes so consumers (plugins, CI gates) can pin it.
 const statusSchemaVersion = 1
 
 type health string
@@ -28,7 +26,6 @@ const (
 	healthUnprotected health = "unprotected"
 )
 
-// statusCheck is the JSON projection of a doctor.CheckResult.
 type statusCheck struct {
 	Name     string `json:"name"`
 	Category string `json:"category"`
@@ -74,9 +71,6 @@ type protectionLayers struct {
 	Proxy       proxyInfo    `json:"proxy"`
 }
 
-// statusReport is the machine-readable protection status shared by
-// `pmg setup info --json` and `pmg setup doctor --json`: a health/protected
-// verdict, the enabled layers, and the checks it was derived from.
 type statusReport struct {
 	SchemaVersion int              `json:"schema_version"`
 	Version       string           `json:"version"`
@@ -93,20 +87,13 @@ type doctorSummary struct {
 	Failed   int `json:"failed"`
 }
 
-// doctorReport is emitted by `pmg setup doctor --json`: the full status report
-// (with the authoritative interception probes in Checks) plus a pass/warn/fail
-// summary. It is a superset of the info report and is the surface a CI gate
-// should trust.
 type doctorReport struct {
 	statusReport
 	Summary doctorSummary `json:"summary"`
 }
 
-// buildStatusReport rolls a set of checks and the current config into the shared
-// status report. The caller chooses which checks to pass: the cheap core checks
-// for `setup info`, or core plus the authoritative probes for `setup doctor`.
 func buildStatusReport(cfg *config.RuntimeConfig, checks []doctor.CheckResult) statusReport {
-	h, protected := deriveStatus(checks)
+	h, protected := deriveStatus(checks, cfg.InsecureInstallation)
 
 	return statusReport{
 		SchemaVersion: statusSchemaVersion,
@@ -132,14 +119,12 @@ func buildDoctorReport(cfg *config.RuntimeConfig, results []doctor.CheckResult) 
 	}
 }
 
-// deriveStatus rolls a set of checks into a single verdict. Protected is the
-// security-critical signal: are installs actually intercepted. A failing
-// authoritative protection probe (present only in the doctor report) proves
-// interception is bypassed and forces "unprotected", overriding the presence of
-// aliases or shims. Otherwise any non-passing check downgrades an intercepting
-// install to "degraded" without claiming it is unprotected.
-func deriveStatus(results []doctor.CheckResult) (health, bool) {
-	if hasFailingProtectionCheck(results) || !isInterceptionActive(results) {
+// Insecure installation allows every package without analysis, and a failing
+// protection probe proves interception is bypassed: either forces "unprotected"
+// even when aliases or shims are active. Otherwise a non-passing check is only
+// "degraded", never "unprotected".
+func deriveStatus(results []doctor.CheckResult, insecure bool) (health, bool) {
+	if insecure || hasFailingProtectionCheck(results) || !isInterceptionActive(results) {
 		return healthUnprotected, false
 	}
 	for _, r := range results {
@@ -179,7 +164,8 @@ func collectLayers(cfg *config.RuntimeConfig) protectionLayers {
 	driver := resolveSandboxDriverName()
 
 	layers := protectionLayers{
-		ThreatIntel: true,
+		// Insecure installation short-circuits analysis, so threat intel never runs.
+		ThreatIntel: !cfg.InsecureInstallation,
 		Cooldown: cooldownInfo{
 			Enabled: cfg.Config.DependencyCooldown.Enabled,
 			Days:    cfg.Config.DependencyCooldown.Days,
@@ -196,10 +182,8 @@ func collectLayers(cfg *config.RuntimeConfig) protectionLayers {
 }
 
 func collectCAInfo(cfg *config.RuntimeConfig) caInfo {
-	// A present-but-unreadable/malformed cert makes the on-disk metadata
-	// (expiry, trust) untrustworthy; the ca-cert check already reports the
-	// failure, so here we report the layer as untrusted rather than encode
-	// contradictory data.
+	// An unreadable cert makes on-disk expiry/trust untrustworthy; report the
+	// layer as untrusted rather than encode contradictory data.
 	st, err := certmanager.InspectCA(cfg.ConfigDir())
 	if err != nil {
 		log.Debugf("CA inspection failed; reporting CA layer as untrusted: %v", err)
@@ -243,8 +227,6 @@ func toStatusChecks(results []doctor.CheckResult) []statusCheck {
 	return checks
 }
 
-// fixFor returns the actionable fix for a non-passing check, preferring a
-// result-specific override over the static hint. Passing checks have no fix.
 func fixFor(r doctor.CheckResult) string {
 	if r.Status == doctor.StatusPass {
 		return ""

--- a/cmd/setup/status_test.go
+++ b/cmd/setup/status_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/safedep/pmg/config"
 	"github.com/safedep/pmg/internal/doctor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +56,15 @@ func TestDeriveStatus(t *testing.T) {
 			},
 			wantHealth:    healthDegraded,
 			wantProtected: true,
+		},
+		{
+			name: "failing protection probe overrides active interception",
+			results: []doctor.CheckResult{
+				{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
+				{Name: "protection-pip", Category: categoryProtection, Status: doctor.StatusFail},
+			},
+			wantHealth:    healthUnprotected,
+			wantProtected: false,
 		},
 	}
 
@@ -112,17 +122,42 @@ func TestCountStatuses(t *testing.T) {
 }
 
 func TestBuildDoctorReport(t *testing.T) {
-	results := []doctor.CheckResult{
-		{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
-		{Name: checkCA, Status: doctor.StatusWarn, Message: "expiring"},
-	}
+	cfg := &config.RuntimeConfig{}
 
-	report := buildDoctorReport(results)
-	assert.Equal(t, statusSchemaVersion, report.SchemaVersion)
-	assert.Equal(t, healthDegraded, report.Health)
-	assert.True(t, report.Protected)
-	assert.Equal(t, doctorSummary{Passed: 1, Warnings: 1, Failed: 0}, report.Summary)
-	assert.Len(t, report.Checks, 2)
+	t.Run("degraded superset carries layers, shell, and summary", func(t *testing.T) {
+		results := []doctor.CheckResult{
+			{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
+			{Name: checkCA, Status: doctor.StatusWarn, Message: "expiring"},
+		}
+
+		report := buildDoctorReport(cfg, results)
+		assert.Equal(t, statusSchemaVersion, report.SchemaVersion)
+		assert.Equal(t, healthDegraded, report.Health)
+		assert.True(t, report.Protected)
+		assert.Equal(t, doctorSummary{Passed: 1, Warnings: 1, Failed: 0}, report.Summary)
+		assert.Len(t, report.Checks, 2)
+
+		// The doctor report is a superset of the info report: layers and shell
+		// integration must be present alongside the summary.
+		var buf bytes.Buffer
+		require.NoError(t, writeStatusJSON(&buf, report))
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+		assert.Contains(t, decoded, "layers")
+		assert.Contains(t, decoded, "shell_integration")
+		assert.Contains(t, decoded, "summary")
+	})
+
+	t.Run("failing protection probe forces unprotected despite active shims", func(t *testing.T) {
+		results := []doctor.CheckResult{
+			{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
+			{Name: "protection-npm", Category: categoryProtection, Status: doctor.StatusFail, Message: "installed"},
+		}
+
+		report := buildDoctorReport(cfg, results)
+		assert.Equal(t, healthUnprotected, report.Health)
+		assert.False(t, report.Protected)
+	})
 }
 
 func TestCollectShellIntegration(t *testing.T) {
@@ -163,7 +198,7 @@ func TestFindCheck(t *testing.T) {
 }
 
 func TestWriteStatusJSONSchema(t *testing.T) {
-	report := infoReport{
+	report := statusReport{
 		SchemaVersion: statusSchemaVersion,
 		Version:       "v1.2.3",
 		Health:        healthProtected,

--- a/cmd/setup/status_test.go
+++ b/cmd/setup/status_test.go
@@ -15,12 +15,23 @@ func TestDeriveStatus(t *testing.T) {
 	tests := []struct {
 		name          string
 		results       []doctor.CheckResult
+		insecure      bool
 		wantHealth    health
 		wantProtected bool
 	}{
 		{
 			name:          "no interception is unprotected",
 			results:       []doctor.CheckResult{{Name: checkShimInPath, Status: doctor.StatusFail}},
+			wantHealth:    healthUnprotected,
+			wantProtected: false,
+		},
+		{
+			name: "insecure installation forces unprotected despite active interception",
+			results: []doctor.CheckResult{
+				{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
+				{Name: checkSandbox, Status: doctor.StatusPass},
+			},
+			insecure:      true,
 			wantHealth:    healthUnprotected,
 			wantProtected: false,
 		},
@@ -70,7 +81,7 @@ func TestDeriveStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotHealth, gotProtected := deriveStatus(tt.results)
+			gotHealth, gotProtected := deriveStatus(tt.results, tt.insecure)
 			assert.Equal(t, tt.wantHealth, gotHealth)
 			assert.Equal(t, tt.wantProtected, gotProtected)
 		})
@@ -94,11 +105,9 @@ func TestToStatusChecks(t *testing.T) {
 	checks := toStatusChecks(results)
 	require.Len(t, checks, 3)
 
-	// Passing checks carry no fix.
 	assert.Equal(t, "pass", checks[0].Status)
 	assert.Empty(t, checks[0].Fix)
 
-	// Non-passing checks fall back to the static fix hint.
 	assert.Equal(t, "fail", checks[1].Status)
 	assert.Equal(t, checkFixes[checkShellAliases], checks[1].Fix)
 	assert.NotEmpty(t, checks[1].Fix)
@@ -157,6 +166,18 @@ func TestBuildDoctorReport(t *testing.T) {
 		report := buildDoctorReport(cfg, results)
 		assert.Equal(t, healthUnprotected, report.Health)
 		assert.False(t, report.Protected)
+	})
+
+	t.Run("insecure installation reports unprotected with threat intel off", func(t *testing.T) {
+		insecure := &config.RuntimeConfig{InsecureInstallation: true}
+		results := []doctor.CheckResult{
+			{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
+		}
+
+		report := buildDoctorReport(insecure, results)
+		assert.Equal(t, healthUnprotected, report.Health)
+		assert.False(t, report.Protected)
+		assert.False(t, report.Layers.ThreatIntel)
 	})
 }
 

--- a/cmd/setup/status_test.go
+++ b/cmd/setup/status_test.go
@@ -1,0 +1,184 @@
+package setup
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/safedep/pmg/internal/doctor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		results       []doctor.CheckResult
+		wantHealth    health
+		wantProtected bool
+	}{
+		{
+			name:          "no interception is unprotected",
+			results:       []doctor.CheckResult{{Name: checkShimInPath, Status: doctor.StatusFail}},
+			wantHealth:    healthUnprotected,
+			wantProtected: false,
+		},
+		{
+			name:          "empty results is unprotected",
+			results:       nil,
+			wantHealth:    healthUnprotected,
+			wantProtected: false,
+		},
+		{
+			name: "intercepting and all pass is protected",
+			results: []doctor.CheckResult{
+				{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
+				{Name: checkSandbox, Status: doctor.StatusPass},
+			},
+			wantHealth:    healthProtected,
+			wantProtected: true,
+		},
+		{
+			name: "intercepting with a warn is degraded",
+			results: []doctor.CheckResult{
+				{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
+				{Name: checkCA, Status: doctor.StatusWarn},
+			},
+			wantHealth:    healthDegraded,
+			wantProtected: true,
+		},
+		{
+			name: "intercepting via aliases with a fail elsewhere is degraded not unprotected",
+			results: []doctor.CheckResult{
+				{Name: checkShellAliases, Status: doctor.StatusPass, ImpliesInterception: true},
+				{Name: checkShimInPath, Status: doctor.StatusFail},
+			},
+			wantHealth:    healthDegraded,
+			wantProtected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHealth, gotProtected := deriveStatus(tt.results)
+			assert.Equal(t, tt.wantHealth, gotHealth)
+			assert.Equal(t, tt.wantProtected, gotProtected)
+		})
+	}
+}
+
+func TestStatusString(t *testing.T) {
+	assert.Equal(t, "pass", statusString(doctor.StatusPass))
+	assert.Equal(t, "warn", statusString(doctor.StatusWarn))
+	assert.Equal(t, "fail", statusString(doctor.StatusFail))
+	assert.Equal(t, "unknown", statusString(doctor.CheckStatus(99)))
+}
+
+func TestToStatusChecks(t *testing.T) {
+	results := []doctor.CheckResult{
+		{Name: checkConfigFile, Category: "Configuration", Status: doctor.StatusPass, Message: "found"},
+		{Name: checkShellAliases, Category: "Shell Integration", Status: doctor.StatusFail, Message: "missing"},
+		{Name: checkSystemBinary, Category: "Security", Status: doctor.StatusFail, Message: "unsafe", Fix: "custom fix"},
+	}
+
+	checks := toStatusChecks(results)
+	require.Len(t, checks, 3)
+
+	// Passing checks carry no fix.
+	assert.Equal(t, "pass", checks[0].Status)
+	assert.Empty(t, checks[0].Fix)
+
+	// Non-passing checks fall back to the static fix hint.
+	assert.Equal(t, "fail", checks[1].Status)
+	assert.Equal(t, checkFixes[checkShellAliases], checks[1].Fix)
+	assert.NotEmpty(t, checks[1].Fix)
+
+	// A result-specific fix overrides the static hint.
+	assert.Equal(t, "custom fix", checks[2].Fix)
+}
+
+func TestCountStatuses(t *testing.T) {
+	results := []doctor.CheckResult{
+		{Status: doctor.StatusPass},
+		{Status: doctor.StatusPass},
+		{Status: doctor.StatusWarn},
+		{Status: doctor.StatusFail},
+	}
+
+	passed, warnings, failed := countStatuses(results)
+	assert.Equal(t, 2, passed)
+	assert.Equal(t, 1, warnings)
+	assert.Equal(t, 1, failed)
+}
+
+func TestBuildDoctorReport(t *testing.T) {
+	results := []doctor.CheckResult{
+		{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
+		{Name: checkCA, Status: doctor.StatusWarn, Message: "expiring"},
+	}
+
+	report := buildDoctorReport(results)
+	assert.Equal(t, statusSchemaVersion, report.SchemaVersion)
+	assert.Equal(t, healthDegraded, report.Health)
+	assert.True(t, report.Protected)
+	assert.Equal(t, doctorSummary{Passed: 1, Warnings: 1, Failed: 0}, report.Summary)
+	assert.Len(t, report.Checks, 2)
+}
+
+func TestCollectShellIntegration(t *testing.T) {
+	t.Run("aliases and shims active", func(t *testing.T) {
+		core := []doctor.CheckResult{
+			{Name: checkShellAliases, Status: doctor.StatusPass, ImpliesInterception: true},
+			{Name: checkShimInPath, Status: doctor.StatusPass, ImpliesInterception: true},
+		}
+		si := collectShellIntegration(core)
+		assert.True(t, si.Aliases)
+		assert.True(t, si.ShimsInPath)
+		assert.NotEmpty(t, si.Shell)
+	})
+
+	t.Run("system install: aliases not interception, shim path failing", func(t *testing.T) {
+		core := []doctor.CheckResult{
+			{Name: checkShellAliases, Status: doctor.StatusPass, Message: "No aliases (system install)"},
+			{Name: checkShimInPath, Status: doctor.StatusFail},
+		}
+		si := collectShellIntegration(core)
+		assert.False(t, si.Aliases)
+		assert.False(t, si.ShimsInPath)
+	})
+}
+
+func TestFindCheck(t *testing.T) {
+	results := []doctor.CheckResult{
+		{Name: checkConfigFile, Status: doctor.StatusPass},
+		{Name: checkSandbox, Status: doctor.StatusWarn},
+	}
+
+	c, ok := findCheck(results, checkSandbox)
+	require.True(t, ok)
+	assert.Equal(t, doctor.StatusWarn, c.Status)
+
+	_, ok = findCheck(results, checkCA)
+	assert.False(t, ok)
+}
+
+func TestWriteStatusJSONSchema(t *testing.T) {
+	report := infoReport{
+		SchemaVersion: statusSchemaVersion,
+		Version:       "v1.2.3",
+		Health:        healthProtected,
+		Protected:     true,
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writeStatusJSON(&buf, report))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.EqualValues(t, statusSchemaVersion, decoded["schema_version"])
+	assert.Equal(t, "protected", decoded["health"])
+	assert.Equal(t, true, decoded["protected"])
+	// Layers and shell_integration are always present, even at zero value.
+	assert.Contains(t, decoded, "layers")
+	assert.Contains(t, decoded, "shell_integration")
+}


### PR DESCRIPTION
## What

Adds `--json` to `pmg setup info` and `pmg setup doctor`, backed by a shared status model in a new `cmd/setup/status.go`.

- **`pmg setup info --json`** — rolls up protection **health** and enabled **layers** (threat intel, cooldown, sandbox driver, MITM CA, persistent proxy) from the *cheap* core checks. No interception probes are executed, so it is safe to poll.
- **`pmg setup doctor --json`** — the same shape plus the authoritative npm/pip interception probes and a pass/warn/fail summary. This is the report a CI gate should trust.
- The existing **human output of both commands is unchanged** (the `info` text renderer and the `doctor` table are untouched; only the summary-count helper was factored out and reused).

## Why

PMG has no machine-readable "am I protected?" surface today — status is spread across `setup info`, `setup doctor`, and `proxy status`, all text-only. A stable, versioned (`schema_version`) JSON contract enables:

- **CI health gates** — `pmg setup info --json | jq -e .protected` (or `--json | jq -e '.health == "protected"'` for strict), and `setup doctor --json` for the authoritative probe-backed gate.
- **Fleet / provisioning verification** and **agent/tool integrations**.
- Cleaner, parseable bug reports.

## Status model

`protected` (bool) is the security-critical signal: are installs actually intercepted (aliases or shims on PATH). `health` layers on the rest — `unprotected` (no interception), `degraded` (intercepting but a check warns/fails), `protected` (all green).

Example (`setup info --json`):

```json
{
  "schema_version": 1,
  "version": "v0.25.1",
  "health": "degraded",
  "protected": true,
  "shell_integration": { "shell": "fish", "aliases": true, "shims_in_path": true },
  "layers": {
    "threat_intel": true,
    "cooldown": { "enabled": true, "days": 5 },
    "sandbox": { "enabled": true, "driver": "landlock", "ready": true },
    "ca": { "trusted": false, "scope": "none" },
    "proxy": { "running": false }
  },
  "checks": [ { "name": "ca-cert", "category": "Security", "status": "warn", "message": "...", "fix": "pmg setup cert install" } ]
}
```

## Testing

- New `cmd/setup/status_test.go`: table-driven tests for `deriveStatus`, `toStatusChecks` (status mapping + fix precedence), `countStatuses`, `buildDoctorReport`, `collectShellIntegration`, `findCheck`, and the JSON schema shape.
- `go build ./...`, `go test ./cmd/setup/`, `go vet`, and `golangci-lint run ./cmd/setup/...` all clean.
- Manually verified `setup info --json`, `setup doctor --json` (probes run and exit codes preserved), and that the plain-text output of both commands is unchanged.

## Notes

First of a small initiative: this machine-readable status is a standalone PMG feature (CI/fleet/agents). A separate Omarchy desktop plugin will be its first external consumer, in its own repo — no plugin code lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)