### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,11 +298,11 @@ If PMG saved you from a bad package, [star this repo](https://github.com/safedep
 
 ## Star History
 
-<a href="https://star-history.com/#safedep/pmg&Date">
+<a href="https://star-history.dera.page/#safedep/pmg&type=date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=safedep/pmg&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=safedep/pmg&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=safedep/pmg&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=safedep/pmg&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=safedep/pmg&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=safedep/pmg&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying stargazer API is restricted. This updates the chart and its wrapping link to use star-history.dera.page, an alternative that relies on a different data source and requires no API token, so the chart renders again.