### PR TITLE
feat(proxy): identify opaque artifact downloads via registry metadata discovery

### DIFF
--- a/docs/proxy-mode.md
+++ b/docs/proxy-mode.md
@@ -106,7 +106,11 @@ A request on a configured host whose path matches no endpoint passes through unc
 
 ### How PMG identifies a package
 
-PMG reads a package name and version directly from the request URL: the npm tarball path shape, or the PyPI distribution filename. When the URL carries no identity, PMG fails open: it allows the download without analysis and never blocks on a guess. This covers opaque download URLs such as `.../download/opaque?id=42` and any path shape PMG does not recognize. Support to identify these downloads from registry metadata is planned.
+PMG prefers to read a package name and version directly from the request URL. It reads the npm tarball path shape, or the PyPI distribution filename. This covers most registries and needs no extra state.
+
+Some registries use opaque download URLs that carry no name or version, for example `.../download/opaque?id=42`. For a URL like this, PMG remembers the name and version that a metadata response advertised for it. PMG reuses that mapping when the download request arrives. The mapping is scoped to one registry. It expires after 15 minutes. It holds at most 10,000 entries.
+
+A URL that PMG can already identify from its own shape always wins. Registry metadata can never override an identity PMG derived from the URL itself. A path shape PMG cannot identify from the URL or the metadata index still fails open. PMG allows that download without analysis and never blocks on a guess.
 
 ### npm registry requirements
 

--- a/proxy/interceptors/artifact_index.go
+++ b/proxy/interceptors/artifact_index.go
@@ -1,0 +1,303 @@
+package interceptors
+
+import (
+	"container/list"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/safedep/dry/log"
+	"github.com/safedep/pmg/internal/registryurl"
+	"github.com/safedep/pmg/proxy"
+)
+
+const (
+	defaultArtifactIndexLimit = 10_000
+	defaultArtifactIndexTTL   = 15 * time.Minute
+)
+
+type artifactIdentity struct {
+	Name    string
+	Version string
+}
+
+type artifactIndexKey struct {
+	registry string
+	url      string
+}
+
+type artifactIndexEntry struct {
+	key       artifactIndexKey
+	identity  artifactIdentity
+	expiresAt time.Time
+}
+
+type artifactIndex struct {
+	mu      sync.Mutex
+	entries map[artifactIndexKey]*list.Element
+	order   *list.List
+	limit   int
+	ttl     time.Duration
+	now     func() time.Time
+}
+
+func newArtifactIndex() *artifactIndex {
+	return newArtifactIndexWithOptions(defaultArtifactIndexLimit, defaultArtifactIndexTTL, time.Now)
+}
+
+func newArtifactIndexWithOptions(limit int, ttl time.Duration, now func() time.Time) *artifactIndex {
+	return &artifactIndex{
+		entries: make(map[artifactIndexKey]*list.Element),
+		order:   list.New(),
+		limit:   limit,
+		ttl:     ttl,
+		now:     now,
+	}
+}
+
+func (i *artifactIndex) Add(registry string, base *url.URL, ref string, identity artifactIdentity) error {
+	if i == nil || i.limit <= 0 || i.ttl <= 0 || i.now == nil {
+		return fmt.Errorf("artifact index is not usable")
+	}
+	if registry == "" {
+		return fmt.Errorf("registry name is required")
+	}
+	if identity.Name == "" || identity.Version == "" {
+		return fmt.Errorf("artifact package name and version are required")
+	}
+	if base == nil || !usableArtifactURL(base) {
+		return fmt.Errorf("metadata base URL is invalid")
+	}
+	if strings.TrimSpace(ref) == "" {
+		return fmt.Errorf("artifact URL reference is required")
+	}
+
+	parsedRef, err := url.Parse(ref)
+	if err != nil {
+		return fmt.Errorf("artifact URL reference is invalid")
+	}
+	resolved := base.ResolveReference(parsedRef)
+	if !usableArtifactURL(resolved) {
+		return fmt.Errorf("resolved artifact URL is invalid")
+	}
+	resolved.Fragment = ""
+	resolved.RawFragment = ""
+
+	normalizedURL, ok := artifactURLKey(resolved)
+	if !ok {
+		return fmt.Errorf("resolved artifact URL is invalid")
+	}
+	key := artifactIndexKey{registry: registry, url: normalizedURL}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	now := i.now()
+	i.pruneExpired(now)
+	if existing, ok := i.entries[key]; ok {
+		i.remove(existing)
+	} else if len(i.entries) >= i.limit {
+		i.remove(i.order.Front())
+	}
+
+	entry := &artifactIndexEntry{
+		key:       key,
+		identity:  identity,
+		expiresAt: now.Add(i.ttl),
+	}
+	element := i.order.PushBack(entry)
+	i.entries[key] = element
+	return nil
+}
+
+func (i *artifactIndex) Get(registry string, requestURL *url.URL) (artifactIdentity, bool) {
+	if i == nil || registry == "" || requestURL == nil || i.now == nil {
+		return artifactIdentity{}, false
+	}
+	normalizedURL, ok := artifactURLKey(requestURL)
+	if !ok {
+		return artifactIdentity{}, false
+	}
+	key := artifactIndexKey{registry: registry, url: normalizedURL}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	element, ok := i.entries[key]
+	if !ok {
+		return artifactIdentity{}, false
+	}
+	entry := element.Value.(*artifactIndexEntry)
+	now := i.now()
+	if !now.Before(entry.expiresAt) {
+		i.remove(element)
+		return artifactIdentity{}, false
+	}
+	return entry.identity, true
+}
+
+func (i *artifactIndex) pruneExpired(now time.Time) {
+	for element := i.order.Front(); element != nil; {
+		entry := element.Value.(*artifactIndexEntry)
+		if now.Before(entry.expiresAt) {
+			return
+		}
+		next := element.Next()
+		i.remove(element)
+		element = next
+	}
+}
+
+func (i *artifactIndex) remove(element *list.Element) {
+	if element == nil {
+		return
+	}
+	entry := element.Value.(*artifactIndexEntry)
+	delete(i.entries, entry.key)
+	i.order.Remove(element)
+}
+
+func usableArtifactURL(u *url.URL) bool {
+	if u == nil || !u.IsAbs() || u.Opaque != "" || u.User != nil || u.Host == "" || u.Hostname() == "" ||
+		strings.HasSuffix(u.Host, ":") {
+		return false
+	}
+	scheme := registryurl.NormalizeScheme(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return false
+	}
+	port, validPort := artifactURLPort(u.Host)
+	if !validPort {
+		return false
+	}
+	_, validPort = registryurl.EffectivePort(scheme, port)
+	return validPort
+}
+
+func artifactURLKey(u *url.URL) (string, bool) {
+	if !usableArtifactURL(u) {
+		return "", false
+	}
+
+	scheme := registryurl.NormalizeScheme(u.Scheme)
+	hostname := registryurl.NormalizeHostname(u.Hostname())
+	rawPort, valid := artifactURLPort(u.Host)
+	if !valid {
+		return "", false
+	}
+	port, valid := registryurl.EffectivePort(scheme, rawPort)
+	if !valid {
+		return "", false
+	}
+	defaultPort, _ := registryurl.EffectivePort(scheme, "")
+
+	host := hostname
+	if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	if port != defaultPort {
+		host = net.JoinHostPort(hostname, port)
+	}
+
+	path := registryurl.NormalizeEscapedPath(u.EscapedPath())
+	if path == "" {
+		path = "/"
+	}
+	normalized := scheme + "://" + host + path
+	if u.RawQuery != "" || u.ForceQuery {
+		normalized += "?" + u.RawQuery
+	}
+	return normalized, true
+}
+
+func artifactURLPort(host string) (string, bool) {
+	if strings.HasPrefix(host, "[") {
+		closingBracket := strings.LastIndex(host, "]")
+		if closingBracket < 0 {
+			return "", false
+		}
+		remainder := host[closingBracket+1:]
+		switch {
+		case remainder == "":
+			return "", true
+		case !strings.HasPrefix(remainder, ":") || len(remainder) == 1:
+			return "", false
+		default:
+			return remainder[1:], !strings.Contains(remainder[1:], ":")
+		}
+	}
+
+	switch strings.Count(host, ":") {
+	case 0:
+		return "", true
+	case 1:
+		_, port, _ := strings.Cut(host, ":")
+		return port, port != ""
+	default:
+		return "", false
+	}
+}
+
+// artifactDiscoveryModifier returns a response modifier that indexes
+// artifacts a parse function extracts from a metadata response, so a later
+// request to a non-standard URL still resolves to its package identity.
+// Every ecosystem wraps this; only the parse function differs.
+//
+// A URL canonical parsing would already resolve is never indexed, since
+// canonical parsing is authoritative and indexing it would be redundant.
+// The response itself is never modified, and a parse failure is logged
+// without URLs, references, or the body, since those may carry signed
+// download tokens.
+func artifactDiscoveryModifier(
+	ctx *proxy.RequestContext,
+	artifacts *artifactIndex,
+	registries registrySet,
+	registryName string,
+	metadataURL *url.URL,
+	parse func(headers http.Header, body []byte) ([]advertisedArtifact, error),
+) proxy.ResponseModifierFunc {
+	return func(statusCode int, headers http.Header, body []byte) (int, http.Header, []byte, error) {
+		// Only exactly 200 triggers discovery, stricter than "any 2xx
+		// succeeds": every targeted registry response uses 200 on success.
+		if statusCode != http.StatusOK {
+			return statusCode, headers, body, nil
+		}
+
+		discovered, err := parse(headers, body)
+		if err != nil {
+			log.Warnf("[%s] Failed to parse metadata for artifact discovery", ctx.RequestID)
+			return statusCode, headers, body, nil
+		}
+
+		for _, artifact := range discovered {
+			if registryURLHasCanonicalIdentity(registries, artifact.URL) {
+				continue
+			}
+			if err := artifacts.Add(registryName, metadataURL, artifact.URL.String(), artifact.Identity); err != nil {
+				log.Warnf("[%s] Failed to index artifact: %v", ctx.RequestID, err)
+			}
+		}
+
+		return statusCode, headers, body, nil
+	}
+}
+
+func chainResponseModifiers(modifiers ...proxy.ResponseModifierFunc) proxy.ResponseModifierFunc {
+	return func(statusCode int, headers http.Header, body []byte) (int, http.Header, []byte, error) {
+		var err error
+		for _, modifier := range modifiers {
+			if modifier == nil {
+				continue
+			}
+			statusCode, headers, body, err = modifier(statusCode, headers, body)
+			if err != nil {
+				return statusCode, headers, body, err
+			}
+		}
+		return statusCode, headers, body, nil
+	}
+}

--- a/proxy/interceptors/artifact_index_test.go
+++ b/proxy/interceptors/artifact_index_test.go
@@ -1,0 +1,397 @@
+package interceptors
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/safedep/pmg/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArtifactIndexResolvesAndNormalizesURLs(t *testing.T) {
+	clock := newArtifactIndexTestClock()
+	index := newArtifactIndexWithOptions(10, time.Minute, clock.Now)
+	base := mustParseArtifactURL(t, "https://Registry.Example:443/npm/pkg?metadata=1")
+
+	tests := []struct {
+		name    string
+		ref     string
+		lookup  string
+		present bool
+	}{
+		{name: "relative", ref: "../files/pkg.tgz", lookup: "https://registry.example/files/pkg.tgz", present: true},
+		{name: "absolute origin normalization", ref: "HTTPS://REGISTRY.EXAMPLE:443/files/other.tgz", lookup: "https://registry.example/files/other.tgz", present: true},
+		{name: "fragment removed", ref: "../files/fragment.tgz#sha256=abc", lookup: "https://registry.example/files/fragment.tgz", present: true},
+		{name: "escaped slash preserved and escape case normalized", ref: "../files/a%2fb.tgz", lookup: "https://registry.example/files/a%2Fb.tgz", present: true},
+		{name: "escaped slash is not decoded", ref: "../files/encoded%2Fslash.tgz", lookup: "https://registry.example/files/encoded/slash.tgz", present: false},
+		{name: "query preserved", ref: "../files/signed.tgz?token=A%2fb&part=1", lookup: "https://registry.example/files/signed.tgz?token=A%2fb&part=1", present: true},
+		{name: "query difference", ref: "../files/query.tgz?token=one", lookup: "https://registry.example/files/query.tgz?token=two", present: false},
+		{name: "nondefault port preserved", ref: "https://registry.example:8443/files/port.tgz", lookup: "https://REGISTRY.EXAMPLE:8443/files/port.tgz", present: true},
+		{name: "IPv6 default port normalized", ref: "https://[2001:db8::1]:443/files/ipv6.tgz", lookup: "https://[2001:DB8::1]/files/ipv6.tgz", present: true},
+	}
+
+	for indexNumber, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			identity := artifactIdentity{Name: fmt.Sprintf("pkg-%d", indexNumber), Version: "1.0.0"}
+			require.NoError(t, index.Add("npm", base, test.ref, identity))
+
+			actual, ok := index.Get("npm", mustParseArtifactURL(t, test.lookup))
+			assert.Equal(t, test.present, ok)
+			if test.present {
+				assert.Equal(t, identity, actual)
+			}
+		})
+	}
+}
+
+func TestArtifactIndexKeepsRegistriesIsolated(t *testing.T) {
+	index := newArtifactIndexWithOptions(10, time.Minute, time.Now)
+	base := mustParseArtifactURL(t, "https://registry.example/npm/pkg")
+	artifact := mustParseArtifactURL(t, "https://cdn.example/pkg.tgz")
+	identity := artifactIdentity{Name: "pkg", Version: "1.0.0"}
+
+	require.NoError(t, index.Add("registry-a", base, artifact.String(), identity))
+
+	actual, ok := index.Get("registry-a", artifact)
+	assert.True(t, ok)
+	assert.Equal(t, identity, actual)
+	_, ok = index.Get("registry-b", artifact)
+	assert.False(t, ok)
+}
+
+func TestArtifactIndexExpiresEntries(t *testing.T) {
+	clock := newArtifactIndexTestClock()
+	index := newArtifactIndexWithOptions(10, 15*time.Minute, clock.Now)
+	base := mustParseArtifactURL(t, "https://registry.example/pkg")
+	artifact := mustParseArtifactURL(t, "https://registry.example/pkg.tgz")
+
+	require.NoError(t, index.Add("npm", base, artifact.String(), artifactIdentity{Name: "pkg", Version: "1"}))
+	clock.Advance(15*time.Minute - time.Nanosecond)
+	_, ok := index.Get("npm", artifact)
+	assert.True(t, ok)
+	clock.Advance(time.Nanosecond)
+	_, ok = index.Get("npm", artifact)
+	assert.False(t, ok)
+}
+
+func TestArtifactIndexPrunesExpiredBeforeEvictingLiveEntries(t *testing.T) {
+	clock := newArtifactIndexTestClock()
+	index := newArtifactIndexWithOptions(2, time.Minute, clock.Now)
+	base := mustParseArtifactURL(t, "https://registry.example/metadata")
+	first := mustParseArtifactURL(t, "https://registry.example/first.tgz")
+	second := mustParseArtifactURL(t, "https://registry.example/second.tgz")
+	third := mustParseArtifactURL(t, "https://registry.example/third.tgz")
+
+	require.NoError(t, index.Add("npm", base, first.String(), artifactIdentity{Name: "first", Version: "1"}))
+	clock.Advance(30 * time.Second)
+	require.NoError(t, index.Add("npm", base, second.String(), artifactIdentity{Name: "second", Version: "1"}))
+	clock.Advance(31 * time.Second)
+	require.NoError(t, index.Add("npm", base, third.String(), artifactIdentity{Name: "third", Version: "1"}))
+
+	_, ok := index.Get("npm", first)
+	assert.False(t, ok)
+	_, ok = index.Get("npm", second)
+	assert.True(t, ok)
+	_, ok = index.Get("npm", third)
+	assert.True(t, ok)
+}
+
+func TestArtifactIndexEvictsOldestWithStableTieBreaking(t *testing.T) {
+	clock := newArtifactIndexTestClock()
+	index := newArtifactIndexWithOptions(2, time.Hour, clock.Now)
+	base := mustParseArtifactURL(t, "https://registry.example/metadata")
+	first := mustParseArtifactURL(t, "https://registry.example/first.tgz")
+	second := mustParseArtifactURL(t, "https://registry.example/second.tgz")
+	third := mustParseArtifactURL(t, "https://registry.example/third.tgz")
+
+	require.NoError(t, index.Add("npm", base, first.String(), artifactIdentity{Name: "first", Version: "1"}))
+	require.NoError(t, index.Add("npm", base, second.String(), artifactIdentity{Name: "second", Version: "1"}))
+	require.NoError(t, index.Add("npm", base, third.String(), artifactIdentity{Name: "third", Version: "1"}))
+
+	_, ok := index.Get("npm", first)
+	assert.False(t, ok)
+	_, ok = index.Get("npm", second)
+	assert.True(t, ok)
+	_, ok = index.Get("npm", third)
+	assert.True(t, ok)
+}
+
+func TestArtifactIndexDuplicateUpdateRefreshesValueAndAge(t *testing.T) {
+	clock := newArtifactIndexTestClock()
+	index := newArtifactIndexWithOptions(2, time.Hour, clock.Now)
+	base := mustParseArtifactURL(t, "https://registry.example/metadata")
+	first := mustParseArtifactURL(t, "https://registry.example/first.tgz")
+	second := mustParseArtifactURL(t, "https://registry.example/second.tgz")
+	third := mustParseArtifactURL(t, "https://registry.example/third.tgz")
+
+	require.NoError(t, index.Add("npm", base, first.String(), artifactIdentity{Name: "first", Version: "1"}))
+	require.NoError(t, index.Add("npm", base, second.String(), artifactIdentity{Name: "second", Version: "1"}))
+	require.NoError(t, index.Add("npm", base, first.String(), artifactIdentity{Name: "first", Version: "2"}))
+	require.NoError(t, index.Add("npm", base, third.String(), artifactIdentity{Name: "third", Version: "1"}))
+
+	actual, ok := index.Get("npm", first)
+	assert.True(t, ok)
+	assert.Equal(t, artifactIdentity{Name: "first", Version: "2"}, actual)
+	_, ok = index.Get("npm", second)
+	assert.False(t, ok)
+}
+
+func TestArtifactIndexMaintainsInsertionAndRefreshOrder(t *testing.T) {
+	clock := newArtifactIndexTestClock()
+	index := newArtifactIndexWithOptions(3, time.Hour, clock.Now)
+	base := mustParseArtifactURL(t, "https://registry.example/metadata")
+
+	require.NoError(t, index.Add("npm", base, "first.tgz", artifactIdentity{Name: "first", Version: "1"}))
+	require.NoError(t, index.Add("npm", base, "second.tgz", artifactIdentity{Name: "second", Version: "1"}))
+	require.NoError(t, index.Add("npm", base, "first.tgz", artifactIdentity{Name: "first", Version: "2"}))
+
+	require.Len(t, index.entries, 2)
+	require.Equal(t, 2, index.order.Len())
+	assert.Equal(t, artifactIdentity{Name: "second", Version: "1"}, index.order.Front().Value.(*artifactIndexEntry).identity)
+	assert.Equal(t, artifactIdentity{Name: "first", Version: "2"}, index.order.Back().Value.(*artifactIndexEntry).identity)
+}
+
+func TestArtifactIndexPrunesExpiredEntriesAfterRefreshedEntriesMoveBack(t *testing.T) {
+	clock := newArtifactIndexTestClock()
+	index := newArtifactIndexWithOptions(2, time.Minute, clock.Now)
+	base := mustParseArtifactURL(t, "https://registry.example/metadata")
+	first := mustParseArtifactURL(t, "https://registry.example/first.tgz")
+	second := mustParseArtifactURL(t, "https://registry.example/second.tgz")
+	third := mustParseArtifactURL(t, "https://registry.example/third.tgz")
+
+	require.NoError(t, index.Add("npm", base, first.String(), artifactIdentity{Name: "first", Version: "1"}))
+	clock.Advance(30 * time.Second)
+	require.NoError(t, index.Add("npm", base, second.String(), artifactIdentity{Name: "second", Version: "1"}))
+	clock.Advance(10 * time.Second)
+	require.NoError(t, index.Add("npm", base, first.String(), artifactIdentity{Name: "first", Version: "2"}))
+	clock.Advance(51 * time.Second)
+	require.NoError(t, index.Add("npm", base, third.String(), artifactIdentity{Name: "third", Version: "1"}))
+
+	refreshed, ok := index.Get("npm", first)
+	assert.True(t, ok)
+	assert.Equal(t, artifactIdentity{Name: "first", Version: "2"}, refreshed)
+	_, ok = index.Get("npm", second)
+	assert.False(t, ok)
+	_, ok = index.Get("npm", third)
+	assert.True(t, ok)
+	assert.Len(t, index.entries, 2)
+	assert.Equal(t, 2, index.order.Len())
+}
+
+func TestArtifactIndexRejectsInvalidInputs(t *testing.T) {
+	index := newArtifactIndexWithOptions(10, time.Minute, time.Now)
+	validBase := mustParseArtifactURL(t, "https://registry.example/pkg")
+	identity := artifactIdentity{Name: "pkg", Version: "1"}
+
+	tests := []struct {
+		name     string
+		registry string
+		base     *url.URL
+		ref      string
+		identity artifactIdentity
+	}{
+		{name: "empty registry", base: validBase, ref: "pkg.tgz", identity: identity},
+		{name: "nil base", registry: "npm", ref: "pkg.tgz", identity: identity},
+		{name: "relative base", registry: "npm", base: mustParseArtifactURL(t, "/pkg"), ref: "pkg.tgz", identity: identity},
+		{name: "unsupported base scheme", registry: "npm", base: mustParseArtifactURL(t, "file:///pkg"), ref: "pkg.tgz", identity: identity},
+		{name: "base credentials", registry: "npm", base: mustParseArtifactURL(t, "https://user:secret@registry.example/pkg"), ref: "pkg.tgz", identity: identity},
+		{name: "invalid base port", registry: "npm", base: &url.URL{Scheme: "https", Host: "registry.example:invalid", Path: "/pkg"}, ref: "pkg.tgz", identity: identity},
+		{name: "empty ref", registry: "npm", base: validBase, identity: identity},
+		{name: "malformed ref", registry: "npm", base: validBase, ref: "%zz", identity: identity},
+		{name: "unsupported resolved scheme", registry: "npm", base: validBase, ref: "file:///pkg.tgz", identity: identity},
+		{name: "resolved credentials", registry: "npm", base: validBase, ref: "https://user:secret@registry.example/pkg.tgz", identity: identity},
+		{name: "empty package name", registry: "npm", base: validBase, ref: "pkg.tgz", identity: artifactIdentity{Version: "1"}},
+		{name: "empty version", registry: "npm", base: validBase, ref: "pkg.tgz", identity: artifactIdentity{Name: "pkg"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Error(t, index.Add(test.registry, test.base, test.ref, test.identity))
+		})
+	}
+
+	_, ok := index.Get("npm", nil)
+	assert.False(t, ok)
+	_, ok = index.Get("", validBase)
+	assert.False(t, ok)
+}
+
+func TestArtifactIndexErrorsDoNotExposeURLSecrets(t *testing.T) {
+	index := newArtifactIndexWithOptions(10, time.Minute, time.Now)
+	identity := artifactIdentity{Name: "pkg", Version: "1"}
+	validBase := mustParseArtifactURL(t, "https://registry.example/metadata")
+
+	tests := []struct {
+		name    string
+		base    *url.URL
+		ref     string
+		secrets []string
+	}{
+		{
+			name: "credential-bearing base",
+			base: mustParseArtifactURL(t, "https://base-user:base-password@registry.example/metadata?token=base-secret"),
+			ref:  "artifact.tgz",
+			secrets: []string{
+				"base-user",
+				"base-password",
+				"base-secret",
+				"registry.example",
+			},
+		},
+		{
+			name: "malformed reference",
+			base: validBase,
+			ref:  "%zz?token=reference-secret",
+			secrets: []string{
+				"%zz",
+				"reference-secret",
+				"registry.example",
+			},
+		},
+		{
+			name: "credential-bearing reference",
+			base: validBase,
+			ref:  "https://ref-user:ref-password@artifacts.example/pkg.tgz?token=artifact-secret",
+			secrets: []string{
+				"ref-user",
+				"ref-password",
+				"artifact-secret",
+				"artifacts.example",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := index.Add("npm", test.base, test.ref, identity)
+			require.Error(t, err)
+			for _, secret := range test.secrets {
+				assert.NotContains(t, err.Error(), secret)
+			}
+		})
+	}
+}
+
+func TestArtifactIndexConcurrentAccess(t *testing.T) {
+	index := newArtifactIndexWithOptions(100, time.Minute, time.Now)
+	base := mustParseArtifactURL(t, "https://registry.example/metadata")
+	var workers sync.WaitGroup
+	errs := make(chan error, 2_000)
+
+	for worker := 0; worker < 20; worker++ {
+		worker := worker
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for iteration := 0; iteration < 100; iteration++ {
+				ref := fmt.Sprintf("../files/%d-%d.tgz?token=%d", worker, iteration%10, iteration)
+				identity := artifactIdentity{Name: fmt.Sprintf("pkg-%d", worker), Version: fmt.Sprint(iteration)}
+				if err := index.Add("npm", base, ref, identity); err != nil {
+					errs <- err
+				}
+				resolved, err := base.Parse(ref)
+				if err != nil {
+					errs <- err
+					continue
+				}
+				index.Get("npm", resolved)
+			}
+		}()
+	}
+
+	workers.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestNewArtifactIndexUsesProductionDefaults(t *testing.T) {
+	index := newArtifactIndex()
+
+	assert.Equal(t, 10_000, index.limit)
+	assert.Equal(t, 15*time.Minute, index.ttl)
+	require.NotNil(t, index.now)
+}
+
+func TestChainResponseModifiersRunsInOrder(t *testing.T) {
+	var calls []string
+	first := func(status int, headers http.Header, body []byte) (int, http.Header, []byte, error) {
+		calls = append(calls, "first")
+		assert.Equal(t, 200, status)
+		assert.Equal(t, []byte("upstream"), body)
+		headers.Set("X-First", "set")
+		return 201, headers, append(body, []byte("-first")...), nil
+	}
+	second := func(status int, headers http.Header, body []byte) (int, http.Header, []byte, error) {
+		calls = append(calls, "second")
+		assert.Equal(t, 201, status)
+		assert.Equal(t, "set", headers.Get("X-First"))
+		assert.Equal(t, []byte("upstream-first"), body)
+		return 202, headers, append(body, []byte("-second")...), nil
+	}
+
+	modifier := chainResponseModifiers(first, second)
+	status, headers, body, err := modifier(200, http.Header{}, []byte("upstream"))
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"first", "second"}, calls)
+	assert.Equal(t, 202, status)
+	assert.Equal(t, "set", headers.Get("X-First"))
+	assert.Equal(t, []byte("upstream-first-second"), body)
+}
+
+func TestChainResponseModifiersStopsOnError(t *testing.T) {
+	expectedErr := errors.New("modifier failed")
+	called := false
+	first := func(status int, headers http.Header, body []byte) (int, http.Header, []byte, error) {
+		return 201, headers, []byte("first"), expectedErr
+	}
+	second := func(status int, headers http.Header, body []byte) (int, http.Header, []byte, error) {
+		called = true
+		return status, headers, body, nil
+	}
+
+	status, _, body, err := chainResponseModifiers(first, nil, second)(200, http.Header{}, []byte("upstream"))
+
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, 201, status)
+	assert.Equal(t, []byte("first"), body)
+	assert.False(t, called)
+}
+
+type artifactIndexTestClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newArtifactIndexTestClock() *artifactIndexTestClock {
+	return &artifactIndexTestClock{now: time.Date(2026, time.August, 18, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *artifactIndexTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *artifactIndexTestClock) Advance(duration time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(duration)
+}
+
+func mustParseArtifactURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return parsed
+}
+
+var _ proxy.ResponseModifierFunc = chainResponseModifiers()

--- a/proxy/interceptors/base_registry.go
+++ b/proxy/interceptors/base_registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
@@ -320,7 +321,14 @@ func (m *registryRequestMatcher) ShouldIntercept(ctx *proxy.RequestContext) bool
 // registry read-path flow.
 type registryRequestHandler interface {
 	handleArtifact(ctx *proxy.RequestContext, name, version string) (*proxy.InterceptorResponse, error)
-	handleMetadataRequest(ctx *proxy.RequestContext, pkgInfo packageInfo) (*proxy.InterceptorResponse, error)
+	handleMetadataRequest(ctx *proxy.RequestContext, endpoint *registryEndpoint, pkgInfo packageInfo, requestURL *url.URL) (*proxy.InterceptorResponse, error)
+}
+
+// artifactDiscoverer is the optional half of registryRequestHandler. npm and
+// pypi implement it to resolve opaque download URLs from a registry-scoped
+// index that metadata responses populate. Cargo does not implement it.
+type artifactDiscoverer interface {
+	resolveIndexedArtifact(registryName string, requestURL *url.URL) (artifactIdentity, bool)
 }
 
 // handleRegistryRequest is the shared registry request flow: match the
@@ -356,10 +364,25 @@ func handleRegistryRequest(
 		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
 	}
 
+	requestURL := registryAbsoluteRequestURL(ctx)
+
 	pkgInfo, parseErr := endpoint.Parser.ParseURL(match.RelativePath)
 
 	if parseErr == nil && packageInfoHasCompleteIdentity(pkgInfo) {
+		// Canonical parsing is authoritative and must never be overridden by
+		// metadata discovery, or a compromised registry could get a
+		// malicious artifact analyzed under a different, safe identity.
 		return handler.handleArtifact(ctx, pkgInfo.GetName(), pkgInfo.GetVersion())
+	}
+
+	// Canonical parsing failed or the path carries no complete identity.
+	// Fall back to the registry-scoped artifact index for ecosystems that
+	// support discovery. Built-in registries have an empty name and never
+	// index, so they never match here.
+	if discoverer, ok := handler.(artifactDiscoverer); ok {
+		if identity, ok := discoverer.resolveIndexedArtifact(endpoint.Name, requestURL); ok {
+			return handler.handleArtifact(ctx, identity.Name, identity.Version)
+		}
 	}
 
 	if parseErr != nil {
@@ -368,12 +391,12 @@ func handleRegistryRequest(
 	}
 
 	if !pkgInfo.IsFileDownload() {
-		return handler.handleMetadataRequest(ctx, pkgInfo)
+		return handler.handleMetadataRequest(ctx, endpoint, pkgInfo, requestURL)
 	}
 
-	// A file-download parse without a complete identity: nothing reliable
-	// to analyze against. URLs that carry no identity at all (opaque
-	// download URLs some registries serve) land here too and are allowed
-	// without analysis.
+	// A file-download parse without a complete identity, and no index match:
+	// nothing reliable to analyze against. URLs that carry no identity at all
+	// (opaque download URLs some registries serve) land here too and are
+	// allowed without analysis.
 	return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
 }

--- a/proxy/interceptors/cargo_registry.go
+++ b/proxy/interceptors/cargo_registry.go
@@ -1,6 +1,8 @@
 package interceptors
 
 import (
+	"net/url"
+
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/analyzer"
@@ -67,10 +69,14 @@ func (i *CargoRegistryInterceptor) HandleRequest(ctx *proxy.RequestContext) (*pr
 }
 
 // handleMetadataRequest applies dependency cooldown to a sparse-index
-// request. The registry config.json passes through untouched.
+// request. The registry config.json passes through untouched. Cargo has no
+// custom registries and no artifact discovery, so it ignores endpoint and
+// requestURL.
 func (i *CargoRegistryInterceptor) handleMetadataRequest(
 	ctx *proxy.RequestContext,
+	_ *registryEndpoint,
 	pkgInfo packageInfo,
+	_ *url.URL,
 ) (*proxy.InterceptorResponse, error) {
 	info, ok := pkgInfo.(*cargoCrateInfo)
 	if !ok || info.requestType != cargoRequestIndex {

--- a/proxy/interceptors/npm_metadata.go
+++ b/proxy/interceptors/npm_metadata.go
@@ -1,0 +1,111 @@
+package interceptors
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"unicode"
+
+	"github.com/safedep/dry/log"
+	"github.com/safedep/pmg/proxy"
+)
+
+// advertisedArtifact is a package artifact URL discovered from registry
+// metadata, together with the package identity it was advertised for.
+type advertisedArtifact struct {
+	URL      *url.URL
+	Identity artifactIdentity
+}
+
+// parseNpmMetadataArtifacts extracts tarball URLs from an npm packument's
+// "versions" map, supporting both full and abbreviated (install-v1) shapes.
+// A malformed or inconsistent entry is skipped rather than failing the
+// whole packument.
+func parseNpmMetadataArtifacts(base *url.URL, body []byte) ([]advertisedArtifact, error) {
+	if base == nil {
+		return nil, fmt.Errorf("metadata base URL is required")
+	}
+
+	var packument struct {
+		Name     string                     `json:"name"`
+		Versions map[string]json.RawMessage `json:"versions"`
+	}
+	if err := json.Unmarshal(body, &packument); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal npm packument")
+	}
+
+	artifacts := make([]advertisedArtifact, 0, len(packument.Versions))
+	for key, raw := range packument.Versions {
+		var entry struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+			Dist    struct {
+				Tarball string `json:"tarball"`
+			} `json:"dist"`
+		}
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			log.Debugf("Skipping npm packument version entry with an unparseable shape")
+			continue
+		}
+
+		// "versions" is keyed by the entry's own version string. A mismatch
+		// means the entry's identity cannot be trusted.
+		if entry.Version != "" && key != entry.Version {
+			continue
+		}
+
+		name := entry.Name
+		switch {
+		case !identityFieldValid(name):
+			// No usable name of its own: fall back to the packument's name.
+			name = packument.Name
+		case identityFieldValid(packument.Name) && name != packument.Name:
+			// A valid name that disagrees with the packument's name is
+			// inconsistent, like the mismatched version key above.
+			continue
+		}
+		if !identityFieldValid(name) || !identityFieldValid(entry.Version) || entry.Dist.Tarball == "" {
+			continue
+		}
+
+		ref, err := url.Parse(entry.Dist.Tarball)
+		if err != nil {
+			log.Debugf("Skipping npm packument version with an unparseable tarball reference")
+			continue
+		}
+
+		artifacts = append(artifacts, advertisedArtifact{
+			URL:      base.ResolveReference(ref),
+			Identity: artifactIdentity{Name: name, Version: entry.Version},
+		})
+	}
+
+	return artifacts, nil
+}
+
+// identityFieldValid reports whether s is non-empty once trimmed and free of
+// control characters. Shared by every ecosystem's metadata discovery.
+func identityFieldValid(s string) bool {
+	if strings.TrimSpace(s) == "" {
+		return false
+	}
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// npmMetadataDiscoveryModifier indexes tarball URLs advertised by a
+// packument response so a later request to a non-standard URL still
+// resolves to its package identity. See artifactDiscoveryModifier for the
+// shared discovery contract.
+func npmMetadataDiscoveryModifier(ctx *proxy.RequestContext, artifacts *artifactIndex, registries registrySet, registryName string, metadataURL *url.URL) proxy.ResponseModifierFunc {
+	return artifactDiscoveryModifier(ctx, artifacts, registries, registryName, metadataURL,
+		func(_ http.Header, body []byte) ([]advertisedArtifact, error) {
+			return parseNpmMetadataArtifacts(metadataURL, body)
+		})
+}

--- a/proxy/interceptors/npm_metadata_test.go
+++ b/proxy/interceptors/npm_metadata_test.go
@@ -1,0 +1,237 @@
+package interceptors
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNpmMetadataArtifacts(t *testing.T) {
+	base, err := url.Parse("https://packages.test/npm/demo")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		body           string
+		wantURLs       []string
+		wantIdentities []artifactIdentity
+	}{
+		{
+			name:           "opaque relative tarball resolves against the metadata URL",
+			body:           `{"name":"demo","versions":{"1.2.3":{"name":"demo","version":"1.2.3","dist":{"tarball":"../../download/opaque?id=42"}}}}`,
+			wantURLs:       []string{"https://packages.test/download/opaque?id=42"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "signed query string is preserved exactly",
+			body:           `{"name":"demo","versions":{"1.2.3":{"name":"demo","version":"1.2.3","dist":{"tarball":"https://cdn.test/demo-1.2.3.tgz?sig=abc123&exp=999"}}}}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3.tgz?sig=abc123&exp=999"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "absolute tarball is preserved",
+			body:           `{"name":"demo","versions":{"1.0.0":{"name":"demo","version":"1.0.0","dist":{"tarball":"https://cdn.test/demo/demo-1.0.0.tgz"}}}}`,
+			wantURLs:       []string{"https://cdn.test/demo/demo-1.0.0.tgz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.0.0"}},
+		},
+		{
+			name:           "scoped package name is preserved",
+			body:           `{"name":"@scope/demo","versions":{"2.0.0":{"name":"@scope/demo","version":"2.0.0","dist":{"tarball":"./-/scope-demo-2.0.0.tgz"}}}}`,
+			wantURLs:       []string{"https://packages.test/npm/-/scope-demo-2.0.0.tgz"},
+			wantIdentities: []artifactIdentity{{Name: "@scope/demo", Version: "2.0.0"}},
+		},
+		{
+			name:           "abbreviated install-v1 packument shape is supported",
+			body:           `{"name":"demo","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"name":"demo","version":"1.0.0","dist":{"tarball":"https://packages.test/npm/demo/-/demo-1.0.0.tgz","shasum":"abc"},"engines":{"node":">=18"}}}}`,
+			wantURLs:       []string{"https://packages.test/npm/demo/-/demo-1.0.0.tgz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.0.0"}},
+		},
+		{
+			name:           "version missing its own name falls back to the packument name",
+			body:           `{"name":"demo","versions":{"1.0.0":{"version":"1.0.0","dist":{"tarball":"https://cdn.test/demo-1.0.0.tgz"}}}}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.0.0.tgz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.0.0"}},
+		},
+		{
+			name:           "version missing a tarball is skipped",
+			body:           `{"name":"demo","versions":{"1.0.0":{"name":"demo","version":"1.0.0"}}}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "version with no usable identity is skipped",
+			body:           `{"versions":{"1.0.0":{"version":"1.0.0","dist":{"tarball":"https://cdn.test/x.tgz"}}}}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "whitespace-only version is skipped",
+			body:           `{"name":"demo","versions":{"   ":{"name":"demo","version":"   ","dist":{"tarball":"https://cdn.test/x.tgz"}}}}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "version key inconsistent with the entry's own version is skipped",
+			body:           `{"name":"demo","versions":{"1.0.0":{"name":"demo","version":"9.9.9","dist":{"tarball":"https://cdn.test/x.tgz"}}}}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "version entry name differing from the packument name is skipped",
+			body:           `{"name":"demo","versions":{"1.0.0":{"name":"other","version":"1.0.0","dist":{"tarball":"https://cdn.test/x.tgz"}}}}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "malformed individual entry is skipped, valid entries still parsed",
+			body:           `{"name":"demo","versions":{"bad":"not-an-object","1.0.0":{"name":"demo","version":"1.0.0","dist":{"tarball":"https://cdn.test/demo-1.0.0.tgz"}}}}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.0.0.tgz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.0.0"}},
+		},
+		{
+			name:           "unrelated fields are ignored",
+			body:           `{"name":"demo","readme":"# Demo","time":{"created":"2020-01-01T00:00:00.000Z"},"versions":{"1.0.0":{"name":"demo","version":"1.0.0","dist":{"tarball":"https://cdn.test/demo-1.0.0.tgz","integrity":"sha512-x"},"maintainers":[{"name":"me"}]}}}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.0.0.tgz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.0.0"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			artifacts, err := parseNpmMetadataArtifacts(base, []byte(tt.body))
+			require.NoError(t, err)
+			require.Len(t, artifacts, len(tt.wantURLs))
+
+			gotURLs := make([]string, len(artifacts))
+			gotIdentities := make([]artifactIdentity, len(artifacts))
+			for i, artifact := range artifacts {
+				gotURLs[i] = artifact.URL.String()
+				gotIdentities[i] = artifact.Identity
+			}
+			assert.ElementsMatch(t, tt.wantURLs, gotURLs)
+			assert.ElementsMatch(t, tt.wantIdentities, gotIdentities)
+		})
+	}
+}
+
+func TestNpmMetadataArtifacts_RequiresBase(t *testing.T) {
+	_, err := parseNpmMetadataArtifacts(nil, []byte(`{}`))
+	assert.Error(t, err)
+}
+
+func TestNpmMetadataArtifacts_MalformedJSONErrors(t *testing.T) {
+	base, err := url.Parse("https://packages.test/npm/demo")
+	require.NoError(t, err)
+
+	_, err = parseNpmMetadataArtifacts(base, []byte("not json"))
+	assert.Error(t, err)
+}
+
+var controlByte = string(rune(7))
+
+func TestNpmMetadataArtifacts_ControlCharacterInVersionNameFallsBack(t *testing.T) {
+	base, err := url.Parse("https://packages.test/npm/demo")
+	require.NoError(t, err)
+
+	body, err := json.Marshal(map[string]any{
+		"name": "demo",
+		"versions": map[string]any{
+			"1.0.0": map[string]any{
+				"name":    "de" + controlByte + "mo",
+				"version": "1.0.0",
+				"dist":    map[string]any{"tarball": "https://cdn.test/demo-1.0.0.tgz"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	artifacts, err := parseNpmMetadataArtifacts(base, body)
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, artifactIdentity{Name: "demo", Version: "1.0.0"}, artifacts[0].Identity)
+}
+
+func TestNpmMetadataArtifacts_ControlCharacterInPackumentNameCannotFallBack(t *testing.T) {
+	base, err := url.Parse("https://packages.test/npm/demo")
+	require.NoError(t, err)
+
+	body, err := json.Marshal(map[string]any{
+		"name": "de" + controlByte + "mo",
+		"versions": map[string]any{
+			"1.0.0": map[string]any{
+				"version": "1.0.0",
+				"dist":    map[string]any{"tarball": "https://cdn.test/demo-1.0.0.tgz"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	artifacts, err := parseNpmMetadataArtifacts(base, body)
+	require.NoError(t, err)
+	assert.Empty(t, artifacts)
+}
+
+func TestNpmMetadataDiscoveryModifier_NeverRewritesTheResponse(t *testing.T) {
+	base, err := url.Parse("https://packages.test/npm/demo")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		status int
+		body   []byte
+	}{
+		{name: "non-2xx status is left untouched", status: http.StatusNotFound, body: []byte(`{"error":"not found"}`)},
+		{name: "server error status is left untouched", status: http.StatusInternalServerError, body: []byte(`internal error`)},
+		{name: "empty body on a 200 is left untouched", status: http.StatusOK, body: []byte{}},
+		{name: "malformed JSON body on a 200 is left untouched", status: http.StatusOK, body: []byte("not json")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			index := newArtifactIndex()
+			ctx := makeTestRequestContext("https://packages.test/npm/demo")
+			modifier := npmMetadataDiscoveryModifier(ctx, index, registrySet{}, "custom-npm", base)
+
+			headers := http.Header{"X-Test": []string{"value"}}
+			wantHeaders := headers.Clone()
+			wantBody := make([]byte, len(tt.body))
+			copy(wantBody, tt.body)
+
+			gotStatus, gotHeaders, gotBody, err := modifier(tt.status, headers, tt.body)
+			require.NoError(t, err)
+			assert.Equal(t, tt.status, gotStatus)
+			assert.Equal(t, wantHeaders, gotHeaders)
+			assert.Equal(t, wantBody, gotBody)
+
+			_, ok := index.Get("custom-npm", base)
+			assert.False(t, ok, "a rejected or unparseable response must add no index mappings")
+		})
+	}
+}
+
+func TestNpmMetadataDiscoveryModifier_SkipsCanonicallyResolvableArtifacts(t *testing.T) {
+	registries := newTestCustomRegistrySetFor(t, packagev1.Ecosystem_ECOSYSTEM_NPM, "https://packages.test/npm")
+	index := newArtifactIndex()
+	base := mustParseURL("https://packages.test/npm/demo")
+	ctx := makeTestRequestContext("https://packages.test/npm/demo")
+	modifier := npmMetadataDiscoveryModifier(ctx, index, registries, "custom-npm", base)
+
+	body := []byte(`{"name":"demo","versions":{
+		"1.0.0":{"name":"demo","version":"1.0.0","dist":{"tarball":"https://packages.test/npm/demo/-/demo-1.0.0.tgz"}},
+		"2.0.0":{"name":"demo","version":"2.0.0","dist":{"tarball":"https://packages.test/npm/opaque-blob?id=7"}}
+	}}`)
+	_, _, _, err := modifier(http.StatusOK, http.Header{}, body)
+	require.NoError(t, err)
+
+	_, ok := index.Get("custom-npm", mustParseURL("https://packages.test/npm/demo/-/demo-1.0.0.tgz"))
+	assert.False(t, ok, "a canonically parseable tarball URL must not be indexed")
+
+	identity, ok := index.Get("custom-npm", mustParseURL("https://packages.test/npm/opaque-blob?id=7"))
+	assert.True(t, ok, "a non-canonical tarball URL must still be indexed")
+	assert.Equal(t, artifactIdentity{Name: "demo", Version: "2.0.0"}, identity)
+}

--- a/proxy/interceptors/npm_registry.go
+++ b/proxy/interceptors/npm_registry.go
@@ -1,6 +1,8 @@
 package interceptors
 
 import (
+	"net/url"
+
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/analyzer"
@@ -21,6 +23,7 @@ type NpmRegistryInterceptor struct {
 	baseRegistryInterceptor
 	registryRequestMatcher
 	cooldownHandler *npmCooldownHandler
+	artifacts       *artifactIndex
 }
 
 var _ proxy.Interceptor = (*NpmRegistryInterceptor)(nil)
@@ -45,6 +48,7 @@ func newNpmRegistryInterceptor(
 		},
 		registryRequestMatcher: registryRequestMatcher{registries: registries},
 		cooldownHandler:        newNpmCooldownHandler(statsCollector),
+		artifacts:              newArtifactIndex(),
 	}
 }
 
@@ -59,19 +63,55 @@ func (i *NpmRegistryInterceptor) HandleRequest(ctx *proxy.RequestContext) (*prox
 	return handleRegistryRequest(ctx, i.registries, "NPM", i)
 }
 
-// handleMetadataRequest applies dependency cooldown to a metadata request.
+// resolveIndexedArtifact resolves an opaque download URL to an identity a
+// prior metadata response advertised for the same registry.
+func (i *NpmRegistryInterceptor) resolveIndexedArtifact(registryName string, requestURL *url.URL) (artifactIdentity, bool) {
+	return i.artifacts.Get(registryName, requestURL)
+}
+
+// handleMetadataRequest applies cooldown, artifact discovery, or both to a
+// metadata request. Discovery runs before cooldown so it always sees the
+// upstream packument.
 func (i *NpmRegistryInterceptor) handleMetadataRequest(
 	ctx *proxy.RequestContext,
+	endpoint *registryEndpoint,
 	pkgInfo packageInfo,
+	requestURL *url.URL,
 ) (*proxy.InterceptorResponse, error) {
 	depCooldownConfig := pmgconfig.Get().Config.DependencyCooldown
-	if !depCooldownConfig.Enabled ||
-		pmgconfig.IsTrustedPackageAllVersions(packagev1.Ecosystem_ECOSYSTEM_NPM, pkgInfo.GetName()) {
-		log.Debugf("[%s] Skipping analysis for metadata request: %s", ctx.RequestID, pkgInfo.GetName())
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+	trustedAllVersions := pmgconfig.IsTrustedPackageAllVersions(packagev1.Ecosystem_ECOSYSTEM_NPM, pkgInfo.GetName())
+
+	var cooldownModifier proxy.ResponseModifierFunc
+	if depCooldownConfig.Enabled && !trustedAllVersions {
+		cooldownResp, err := i.cooldownHandler.HandleMetadataRequest(ctx, pkgInfo.GetName(), depCooldownConfig.Days, i.execContext.PinnedVersions[pkgInfo.GetName()])
+		if err != nil {
+			return nil, err
+		}
+		if cooldownResp.Action == proxy.ActionModifyResponse {
+			cooldownModifier = cooldownResp.ResponseModifier
+		}
 	}
 
-	return i.cooldownHandler.HandleMetadataRequest(ctx, pkgInfo.GetName(), depCooldownConfig.Days, i.execContext.PinnedVersions[pkgInfo.GetName()])
+	// Built-in registries never populate the index, so discovery is a no-op
+	// for them. Cooldown alone (or nothing) applies.
+	if endpoint.Source != registrySourceCustom {
+		if cooldownModifier == nil {
+			log.Debugf("[%s] Skipping analysis for metadata request: %s", ctx.RequestID, pkgInfo.GetName())
+			return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+		}
+		return &proxy.InterceptorResponse{Action: proxy.ActionModifyResponse, ResponseModifier: cooldownModifier}, nil
+	}
+
+	// Discovery needs a parseable, always-fresh body even when cooldown does
+	// not run its own modifier, or the response could arrive compressed or
+	// as a bodyless 304.
+	forceUncompressedNonConditionalResponse(ctx.Headers)
+
+	discovery := npmMetadataDiscoveryModifier(ctx, i.artifacts, i.registries, endpoint.Name, requestURL)
+	return &proxy.InterceptorResponse{
+		Action:           proxy.ActionModifyResponse,
+		ResponseModifier: chainResponseModifiers(discovery, cooldownModifier),
+	}, nil
 }
 
 // handleArtifact runs the trust, analysis, and verdict pipeline for an

--- a/proxy/interceptors/npm_registry_test.go
+++ b/proxy/interceptors/npm_registry_test.go
@@ -3,6 +3,7 @@ package interceptors
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/safedep/pmg/analyzer"
@@ -111,42 +112,202 @@ func TestNpmRegistryInterceptor_Custom_TarballCanonicalFallback(t *testing.T) {
 	}
 }
 
-func TestNpmRegistryInterceptor_Custom_OpaqueArtifactIsAllowedWithoutAnalysis(t *testing.T) {
+func TestNpmRegistryInterceptor_Custom_OpaqueArtifactUsesMetadataIdentity(t *testing.T) {
 	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
 
-	// Opaque download URLs carry no name or version, so PMG cannot identify
-	// the package from the request alone. Until metadata-based artifact
-	// discovery lands, such downloads are allowed without analysis rather
-	// than guessed at.
 	mock := &mockAnalyzer{result: &analyzer.PackageVersionAnalysisResult{Action: analyzer.ActionBlock}}
 	interceptor := newTestNpmCustomInterceptor(t, mock, "https://packages.test/npm", "https://packages.test/download")
 
-	ctx := makeTestRequestContext("https://packages.test/download/opaque?id=42")
-	resp, err := interceptor.HandleRequest(ctx)
+	metadataCtx := makeTestRequestContext("https://packages.test/npm/demo")
+	metadataResp, err := interceptor.HandleRequest(metadataCtx)
 	require.NoError(t, err)
-	assert.Equal(t, proxy.ActionAllow, resp.Action)
-	assert.Zero(t, mock.callCount)
+	require.Equal(t, proxy.ActionModifyResponse, metadataResp.Action)
+	require.NotNil(t, metadataResp.ResponseModifier)
+
+	// The tarball path is opaque, so only the metadata-discovered identity
+	// lets it be classified correctly.
+	body := []byte(`{"name":"demo","versions":{"1.2.3":{"name":"demo","version":"1.2.3","dist":{"tarball":"../../download/opaque?id=42"}}}}`)
+	_, _, _, err = metadataResp.ResponseModifier(http.StatusOK, http.Header{}, body)
+	require.NoError(t, err)
+
+	artifactCtx := makeTestRequestContext("https://packages.test/download/opaque?id=42")
+	artifactResp, err := interceptor.HandleRequest(artifactCtx)
+	require.NoError(t, err)
+	assert.Equal(t, proxy.ActionBlock, artifactResp.Action)
+	assert.Equal(t, 1, mock.callCount)
+	require.NotNil(t, artifactResp.BlockContext)
+	assert.Equal(t, "demo", artifactResp.BlockContext.PackageName)
+	assert.Equal(t, "1.2.3", artifactResp.BlockContext.PackageVersion)
 }
 
-func TestNpmRegistryInterceptor_Custom_MetadataResponseIsNotModifiedWithoutCooldown(t *testing.T) {
+func TestNpmRegistryInterceptor_Custom_MetadataDiscoveryChainsBeforeCooldown(t *testing.T) {
+	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: true, Days: 5})
+
+	mock := &mockAnalyzer{}
+	interceptor := newTestNpmCustomInterceptor(t, mock, "https://packages.test/npm", "https://packages.test/download")
+
+	ctx := makeTestRequestContext("https://packages.test/npm/demo")
+	resp, err := interceptor.HandleRequest(ctx)
+	require.NoError(t, err)
+	require.Equal(t, proxy.ActionModifyResponse, resp.Action)
+	require.NotNil(t, resp.ResponseModifier)
+
+	// The only version is within the cooldown window, so the cooldown
+	// modifier strips it from the response. Discovery must still see it,
+	// since it runs on the upstream body before cooldown rewrites it.
+	tarballURL := "https://packages.test/download/opaque?id=99"
+	body := []byte(`{"name":"demo","time":{"created":"2020-01-01T00:00:00.000Z","modified":"2024-01-01T00:00:00.000Z","1.2.3":"` +
+		time.Now().Add(-1*24*time.Hour).Format(time.RFC3339) +
+		`"},"dist-tags":{"latest":"1.2.3"},"versions":{"1.2.3":{"name":"demo","version":"1.2.3","dist":{"tarball":"` + tarballURL + `"}}}}`)
+
+	_, _, newBody, err := resp.ResponseModifier(http.StatusOK, http.Header{}, body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(newBody), "1.2.3", "cooldown must strip the too-new version from the client-visible response")
+
+	identity, ok := interceptor.artifacts.Get("custom-npm", mustParseURL(tarballURL))
+	require.True(t, ok, "discovery must index the artifact before cooldown strips it from the response")
+	assert.Equal(t, artifactIdentity{Name: "demo", Version: "1.2.3"}, identity)
+}
+
+func TestNpmRegistryInterceptor_Custom_SignedQueryParticipatesInArtifactIdentity(t *testing.T) {
 	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
 
-	// With cooldown disabled a metadata response must pass through
-	// untouched: no response modifier, no header mutation.
+	mock := &mockAnalyzer{result: &analyzer.PackageVersionAnalysisResult{Action: analyzer.ActionBlock}}
+	interceptor := newTestNpmCustomInterceptor(t, mock, "https://packages.test/npm", "https://packages.test/download")
+
+	metadataCtx := makeTestRequestContext("https://packages.test/npm/demo")
+	metadataResp, err := interceptor.HandleRequest(metadataCtx)
+	require.NoError(t, err)
+	require.NotNil(t, metadataResp.ResponseModifier)
+
+	body := []byte(`{"name":"demo","versions":{"1.2.3":{"name":"demo","version":"1.2.3","dist":{"tarball":"../../download/opaque?sig=abc123&exp=999"}}}}`)
+	_, _, _, err = metadataResp.ResponseModifier(http.StatusOK, http.Header{}, body)
+	require.NoError(t, err)
+
+	signedCtx := makeTestRequestContext("https://packages.test/download/opaque?sig=abc123&exp=999")
+	resp, err := interceptor.HandleRequest(signedCtx)
+	require.NoError(t, err)
+	assert.Equal(t, proxy.ActionBlock, resp.Action, "the exact signed query must resolve through the artifact index")
+	assert.Equal(t, 1, mock.callCount)
+
+	// Same path, different query: the signed token is part of the artifact's
+	// identity, so this must miss the index, never reusing the verdict for
+	// the signed download.
+	unsignedCtx := makeTestRequestContext("https://packages.test/download/opaque")
+	resp, err = interceptor.HandleRequest(unsignedCtx)
+	require.NoError(t, err)
+	assert.Equal(t, proxy.ActionModifyResponse, resp.Action, "a query mismatch must not reuse the indexed artifact's verdict")
+	assert.Equal(t, 1, mock.callCount, "the query-mismatched request must not trigger analysis")
+}
+
+func newTestNpmMultiRegistryInterceptor(t *testing.T, mock *mockAnalyzer, registries ...config.ProxyRegistryConfig) *NpmRegistryInterceptor {
+	t.Helper()
+	return newNpmRegistryInterceptor(mock, NewInMemoryAnalysisCache(), NewAnalysisStatsCollector(),
+		make(chan *ConfirmationRequest, 1), InterceptorContext{},
+		newTestRegistrySetFor(t, packagev1.Ecosystem_ECOSYSTEM_NPM, registries))
+}
+
+func TestNpmRegistryInterceptor_Custom_ArtifactIndexIsolatedAcrossRegistries(t *testing.T) {
+	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
+
+	mock := &mockAnalyzer{}
+	interceptor := newTestNpmMultiRegistryInterceptor(t, mock,
+		config.ProxyRegistryConfig{
+			Name:      "registry-a",
+			Ecosystem: "npm",
+			Endpoints: []config.ProxyRegistryEndpointConfig{{URL: "https://packages.test/a"}},
+		},
+		config.ProxyRegistryConfig{
+			Name:      "registry-b",
+			Ecosystem: "npm",
+			Endpoints: []config.ProxyRegistryEndpointConfig{{URL: "https://packages.test/b"}},
+		},
+	)
+
+	metadataCtx := makeTestRequestContext("https://packages.test/a/demo")
+	metadataResp, err := interceptor.HandleRequest(metadataCtx)
+	require.NoError(t, err)
+	require.NotNil(t, metadataResp.ResponseModifier)
+
+	// Opaque, not a canonical npm tarball path, so it stays a candidate for
+	// indexing after the canonical-identity skip.
+	tarballURL := "https://packages.test/a/opaque-blob?id=1"
+	body := []byte(`{"name":"demo","versions":{"1.2.3":{"name":"demo","version":"1.2.3","dist":{"tarball":"` + tarballURL + `"}}}}`)
+	_, _, _, err = metadataResp.ResponseModifier(http.StatusOK, http.Header{}, body)
+	require.NoError(t, err)
+
+	identity, ok := interceptor.artifacts.Get("registry-a", mustParseURL(tarballURL))
+	require.True(t, ok, "discovery must index the artifact under the registry that served the metadata")
+	assert.Equal(t, artifactIdentity{Name: "demo", Version: "1.2.3"}, identity)
+
+	_, ok = interceptor.artifacts.Get("registry-b", mustParseURL(tarballURL))
+	assert.False(t, ok, "a mapping discovered for one registry must never be visible to another")
+}
+
+func TestNpmRegistryInterceptor_Custom_DiscoveredOffHostArtifactStaysUnintercepted(t *testing.T) {
+	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
+
+	mock := &mockAnalyzer{}
+	interceptor := newTestNpmCustomInterceptor(t, mock, "https://packages.test/npm")
+
+	metadataCtx := makeTestRequestContext("https://packages.test/npm/demo")
+	metadataResp, err := interceptor.HandleRequest(metadataCtx)
+	require.NoError(t, err)
+	require.NotNil(t, metadataResp.ResponseModifier)
+
+	// The registry advertises a tarball on an unconfigured host. Discovery
+	// may index it, but that must never expand which hosts get MITM'd.
+	body := []byte(`{"name":"demo","versions":{"1.2.3":{"name":"demo","version":"1.2.3","dist":{"tarball":"https://cdn.unconfigured.test/demo-1.2.3.tgz"}}}}`)
+	_, _, _, err = metadataResp.ResponseModifier(http.StatusOK, http.Header{}, body)
+	require.NoError(t, err)
+
+	offHostCtx := &proxy.RequestContext{Hostname: "cdn.unconfigured.test"}
+	assert.False(t, interceptor.ShouldMITM(offHostCtx), "discovery must not dynamically enroll a new MITM host")
+	assert.False(t, interceptor.ShouldIntercept(offHostCtx), "discovery must not dynamically enroll a new intercepted host")
+}
+
+func TestNpmRegistryInterceptor_Custom_MetadataDiscoveryNormalizesRequestHeaders(t *testing.T) {
+	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
+
 	mock := &mockAnalyzer{}
 	interceptor := newTestNpmCustomInterceptor(t, mock, "https://packages.test/npm")
 
 	ctx := makeTestRequestContext("https://packages.test/npm/demo")
 	ctx.Headers.Set("Accept-Encoding", "gzip")
 	ctx.Headers.Set("If-None-Match", `"etag-value"`)
+	ctx.Headers.Set("If-Modified-Since", "Wed, 01 Jan 2025 00:00:00 GMT")
 
+	// Cooldown is disabled, so its handler never runs to normalize headers
+	// itself. Discovery must still see a decompressible, always-fresh body.
 	resp, err := interceptor.HandleRequest(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, proxy.ActionAllow, resp.Action)
-	assert.Nil(t, resp.ResponseModifier)
-	assert.Equal(t, "gzip", ctx.Headers.Get("Accept-Encoding"))
-	assert.Equal(t, `"etag-value"`, ctx.Headers.Get("If-None-Match"))
-	assert.Zero(t, mock.callCount)
+	require.Equal(t, proxy.ActionModifyResponse, resp.Action)
+
+	assert.Equal(t, "identity", ctx.Headers.Get("Accept-Encoding"), "discovery must force an uncompressed response even with cooldown disabled")
+	assert.Empty(t, ctx.Headers.Get("If-None-Match"), "discovery must prevent a bodyless 304")
+	assert.Empty(t, ctx.Headers.Get("If-Modified-Since"), "discovery must prevent a bodyless 304")
+	assert.Empty(t, ctx.Headers.Get("Accept"), "discovery must not force an Accept override")
+}
+
+func TestNpmRegistryInterceptor_Custom_CanonicalIdentityWinsOverConflictingIndexEntry(t *testing.T) {
+	mock := &mockAnalyzer{result: &analyzer.PackageVersionAnalysisResult{Action: analyzer.ActionBlock}}
+	interceptor := newTestNpmCustomInterceptor(t, mock, "https://packages.test/npm")
+
+	tarballURL := mustParseURL("https://packages.test/npm/real-package/-/real-package-1.0.0.tgz")
+
+	// Simulate a stale or compromised index entry claiming this exact
+	// canonical tarball URL belongs to a different, unrelated package.
+	require.NoError(t, interceptor.artifacts.Add("custom-npm", tarballURL, tarballURL.String(),
+		artifactIdentity{Name: "attacker-package", Version: "9.9.9"}))
+
+	ctx := makeTestRequestContext(tarballURL.String())
+	resp, err := interceptor.HandleRequest(ctx)
+	require.NoError(t, err)
+
+	require.NotNil(t, resp.BlockContext)
+	assert.Equal(t, "real-package", resp.BlockContext.PackageName, "canonical parsing must win over a conflicting index entry")
+	assert.Equal(t, "1.0.0", resp.BlockContext.PackageVersion)
+	assert.Equal(t, 1, mock.callCount)
 }
 
 func TestNpmRegistryInterceptor_Custom_NonReadMethodPassesThroughUntouched(t *testing.T) {
@@ -172,14 +333,14 @@ func TestNpmRegistryInterceptor_Custom_NonReadMethodPassesThroughUntouched(t *te
 	assert.Zero(t, mock.callCount)
 }
 
-func TestNpmRegistryInterceptor_Custom_UnparseablePathAllows(t *testing.T) {
+func TestNpmRegistryInterceptor_Custom_UnparseablePathFallsBackToIndexThenAllows(t *testing.T) {
 	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
 
 	mock := &mockAnalyzer{}
 	interceptor := newTestNpmCustomInterceptor(t, mock, "https://packages.test/npm")
 
-	// Too many segments for the unscoped tarball convention: parsing fails,
-	// and the request is allowed rather than guessed at.
+	// Too many segments for the unscoped tarball convention: canonical
+	// parsing fails, and nothing was ever indexed for it.
 	ctx := makeTestRequestContext("https://packages.test/npm/pkg/1.0.0/extra/segments")
 	resp, err := interceptor.HandleRequest(ctx)
 	require.NoError(t, err)

--- a/proxy/interceptors/pypi_metadata.go
+++ b/proxy/interceptors/pypi_metadata.go
@@ -1,0 +1,179 @@
+package interceptors
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/safedep/dry/log"
+	"github.com/safedep/pmg/proxy"
+	"golang.org/x/net/html"
+)
+
+// pypiSimpleHTMLContentType is the PEP 691 HTML media type. Plain "text/html"
+// is also accepted, since that is what most real Simple API servers send.
+const pypiSimpleHTMLContentType = "application/vnd.pypi.simple.v1+html"
+
+// parsePypiSimpleArtifacts extracts artifact URLs from a Simple API index,
+// dispatching on Content-Type between PEP 691 JSON and PEP 503 HTML. Each
+// identity comes from the filename via parseFilename, never trusted
+// verbatim from the response.
+func parsePypiSimpleArtifacts(base *url.URL, contentType string, body []byte) ([]advertisedArtifact, error) {
+	if base == nil {
+		return nil, fmt.Errorf("metadata base URL is required")
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pypi simple response content type")
+	}
+
+	switch mediaType {
+	case pypiSimpleAPIContentType:
+		return parsePypiSimpleJSONArtifacts(base, body)
+	case "text/html", pypiSimpleHTMLContentType:
+		return parsePypiSimpleHTMLArtifacts(base, body)
+	default:
+		return nil, fmt.Errorf("unsupported pypi simple response content type")
+	}
+}
+
+// pypiSimpleJSONIndex is the subset of a PEP 691 Simple API JSON response
+// discovery needs. Every other field (meta, upload-time, hashes, yanked,
+// requires-python, ...) is ignored.
+type pypiSimpleJSONIndex struct {
+	Name  string            `json:"name"`
+	Files []json.RawMessage `json:"files"`
+}
+
+func parsePypiSimpleJSONArtifacts(base *url.URL, body []byte) ([]advertisedArtifact, error) {
+	var index pypiSimpleJSONIndex
+	if err := json.Unmarshal(body, &index); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal pypi simple JSON index")
+	}
+
+	canonicalName := denormalizePyPIPackageName(index.Name)
+
+	artifacts := make([]advertisedArtifact, 0, len(index.Files))
+	for _, raw := range index.Files {
+		var file struct {
+			Filename string `json:"filename"`
+			URL      string `json:"url"`
+		}
+		if err := json.Unmarshal(raw, &file); err != nil {
+			log.Debugf("Skipping pypi simple file entry with an unparseable shape")
+			continue
+		}
+		if !identityFieldValid(file.Filename) || !identityFieldValid(file.URL) {
+			continue
+		}
+
+		identity, ok := pypiArtifactIdentityFromFilename(canonicalName, file.Filename)
+		if !ok {
+			continue
+		}
+
+		ref, err := url.Parse(file.URL)
+		if err != nil {
+			log.Debugf("Skipping pypi simple file entry with an unparseable URL reference")
+			continue
+		}
+
+		artifacts = append(artifacts, advertisedArtifact{
+			URL:      base.ResolveReference(ref),
+			Identity: identity,
+		})
+	}
+	return artifacts, nil
+}
+
+func parsePypiSimpleHTMLArtifacts(base *url.URL, body []byte) ([]advertisedArtifact, error) {
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pypi simple HTML index")
+	}
+
+	var artifacts []advertisedArtifact
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			for _, attr := range n.Attr {
+				if attr.Key != "href" {
+					continue
+				}
+				if artifact, ok := pypiSimpleArtifactFromHref(base, attr.Val); ok {
+					artifacts = append(artifacts, artifact)
+				}
+				break
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	return artifacts, nil
+}
+
+// pypiSimpleArtifactFromHref derives an artifact's identity from a PEP 503
+// anchor's href filename, never from the anchor's presentational inner
+// text.
+func pypiSimpleArtifactFromHref(base *url.URL, href string) (advertisedArtifact, bool) {
+	href = strings.TrimSpace(href)
+	if href == "" {
+		return advertisedArtifact{}, false
+	}
+	ref, err := url.Parse(href)
+	if err != nil {
+		return advertisedArtifact{}, false
+	}
+	resolved := base.ResolveReference(ref)
+
+	identity, ok := pypiArtifactIdentityFromFilename("", lastPathSegment(resolved.Path))
+	if !ok {
+		return advertisedArtifact{}, false
+	}
+	return advertisedArtifact{URL: resolved, Identity: identity}, true
+}
+
+// pypiArtifactIdentityFromFilename parses a distribution filename into an
+// identity. When canonicalName is set, a filename claiming a different
+// project is rejected as inconsistent, mirroring npm's version-key check.
+func pypiArtifactIdentityFromFilename(canonicalName, filename string) (artifactIdentity, bool) {
+	info, err := parseFilename(filename)
+	if err != nil {
+		log.Debugf("Skipping pypi simple entry with an unparseable filename")
+		return artifactIdentity{}, false
+	}
+	if !identityFieldValid(info.GetName()) || !identityFieldValid(info.GetVersion()) {
+		return artifactIdentity{}, false
+	}
+	if canonicalName != "" && info.GetName() != canonicalName {
+		log.Debugf("Skipping pypi simple entry whose filename does not match the indexed project name")
+		return artifactIdentity{}, false
+	}
+	return artifactIdentity{Name: info.GetName(), Version: info.GetVersion()}, true
+}
+
+func lastPathSegment(path string) string {
+	path = strings.TrimSuffix(path, "/")
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[idx+1:]
+	}
+	return path
+}
+
+// pypiMetadataDiscoveryModifier indexes artifact URLs advertised by a
+// Simple API index response so a later request to a non-standard URL still
+// resolves to its package identity. See artifactDiscoveryModifier for the
+// shared discovery contract.
+func pypiMetadataDiscoveryModifier(ctx *proxy.RequestContext, artifacts *artifactIndex, registries registrySet, registryName string, metadataURL *url.URL) proxy.ResponseModifierFunc {
+	return artifactDiscoveryModifier(ctx, artifacts, registries, registryName, metadataURL,
+		func(headers http.Header, body []byte) ([]advertisedArtifact, error) {
+			return parsePypiSimpleArtifacts(metadataURL, headers.Get("Content-Type"), body)
+		})
+}

--- a/proxy/interceptors/pypi_metadata_test.go
+++ b/proxy/interceptors/pypi_metadata_test.go
@@ -1,0 +1,354 @@
+package interceptors
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePypiSimpleJSONArtifacts(t *testing.T) {
+	body := []byte(`{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"../../files/opaque/42#sha256=abc"}]}`)
+	base, err := url.Parse("https://packages.test/python/simple/demo/")
+	require.NoError(t, err)
+	artifacts, err := parsePypiSimpleArtifacts(base, pypiSimpleAPIContentType, body)
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, artifactIdentity{Name: "demo", Version: "1.2.3"}, artifacts[0].Identity)
+}
+
+func TestParsePypiSimpleArtifacts_JSON(t *testing.T) {
+	base, err := url.Parse("https://packages.test/simple/demo/")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		body           string
+		wantURLs       []string
+		wantIdentities []artifactIdentity
+	}{
+		{
+			name:           "relative url resolves against the metadata base",
+			body:           `{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"../../files/opaque/42"}]}`,
+			wantURLs:       []string{"https://packages.test/files/opaque/42"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "absolute url is preserved",
+			body:           `{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"https://cdn.test/demo-1.2.3-py3-none-any.whl"}]}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3-py3-none-any.whl"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "fragment on the url is retained at parse time",
+			body:           `{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"https://cdn.test/demo-1.2.3-py3-none-any.whl#sha256=abc"}]}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3-py3-none-any.whl#sha256=abc"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "signed query string is preserved exactly",
+			body:           `{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"https://cdn.test/demo-1.2.3-py3-none-any.whl?sig=abc123&exp=999"}]}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3-py3-none-any.whl?sig=abc123&exp=999"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "hyphenated normalized project name",
+			body:           `{"name":"Flask_RESTful","files":[{"filename":"Flask_RESTful-0.3.10.tar.gz","url":"https://cdn.test/Flask_RESTful-0.3.10.tar.gz"}]}`,
+			wantURLs:       []string{"https://cdn.test/Flask_RESTful-0.3.10.tar.gz"},
+			wantIdentities: []artifactIdentity{{Name: "flask-restful", Version: "0.3.10"}},
+		},
+		{
+			name: "multiple files for the same project",
+			body: `{"name":"demo","files":[
+				{"filename":"demo-1.2.3-py3-none-any.whl","url":"https://cdn.test/demo-1.2.3-py3-none-any.whl"},
+				{"filename":"demo-1.2.3.tar.gz","url":"https://cdn.test/demo-1.2.3.tar.gz"}
+			]}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3-py3-none-any.whl", "https://cdn.test/demo-1.2.3.tar.gz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}, {Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "missing filename is skipped",
+			body:           `{"name":"demo","files":[{"url":"https://cdn.test/demo-1.2.3-py3-none-any.whl"}]}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "missing url is skipped",
+			body:           `{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl"}]}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "unparseable filename is skipped",
+			body:           `{"name":"demo","files":[{"filename":"demo-1.2.3.egg","url":"https://cdn.test/demo-1.2.3.egg"}]}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "filename disagreeing with the project name is skipped",
+			body:           `{"name":"demo","files":[{"filename":"otherpkg-9.9.9.tar.gz","url":"https://cdn.test/otherpkg-9.9.9.tar.gz"}]}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name: "malformed individual entry is skipped, valid entries still parsed",
+			body: `{"name":"demo","files":[
+				"not-an-object",
+				{"filename":"demo-1.2.3.tar.gz","url":"https://cdn.test/demo-1.2.3.tar.gz"}
+			]}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3.tar.gz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "empty files list",
+			body:           `{"name":"demo","files":[]}`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "missing project name skips the crosscheck but still parses",
+			body:           `{"files":[{"filename":"demo-1.2.3.tar.gz","url":"https://cdn.test/demo-1.2.3.tar.gz"}]}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3.tar.gz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "unrelated fields are ignored",
+			body:           `{"name":"demo","meta":{"api-version":"1.0"},"files":[{"filename":"demo-1.2.3.tar.gz","url":"https://cdn.test/demo-1.2.3.tar.gz","upload-time":"2024-01-01T00:00:00Z","hashes":{"sha256":"abc"},"yanked":false}]}`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3.tar.gz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			artifacts, err := parsePypiSimpleArtifacts(base, pypiSimpleAPIContentType, []byte(tt.body))
+			require.NoError(t, err)
+			require.Len(t, artifacts, len(tt.wantURLs))
+
+			gotURLs := make([]string, len(artifacts))
+			gotIdentities := make([]artifactIdentity, len(artifacts))
+			for i, artifact := range artifacts {
+				gotURLs[i] = artifact.URL.String()
+				gotIdentities[i] = artifact.Identity
+			}
+			assert.ElementsMatch(t, tt.wantURLs, gotURLs)
+			assert.ElementsMatch(t, tt.wantIdentities, gotIdentities)
+		})
+	}
+}
+
+func TestParsePypiSimpleArtifacts_RequiresBase(t *testing.T) {
+	_, err := parsePypiSimpleArtifacts(nil, pypiSimpleAPIContentType, []byte(`{}`))
+	assert.Error(t, err)
+}
+
+func TestParsePypiSimpleArtifacts_MalformedJSONErrors(t *testing.T) {
+	base, err := url.Parse("https://packages.test/simple/demo/")
+	require.NoError(t, err)
+
+	_, err = parsePypiSimpleArtifacts(base, pypiSimpleAPIContentType, []byte("not json"))
+	assert.Error(t, err)
+}
+
+func TestParsePypiSimpleArtifacts_UnsupportedContentType(t *testing.T) {
+	base, err := url.Parse("https://packages.test/simple/demo/")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		contentType string
+	}{
+		{"legacy json api content type", "application/json"},
+		{"empty content type", ""},
+		{"garbage content type", "not a mime type;;;"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parsePypiSimpleArtifacts(base, tt.contentType, []byte(`{"name":"demo","files":[]}`))
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestParsePypiSimpleArtifacts_ContentTypeWithParameters(t *testing.T) {
+	base, err := url.Parse("https://packages.test/simple/demo/")
+	require.NoError(t, err)
+
+	jsonArtifacts, err := parsePypiSimpleArtifacts(base, pypiSimpleAPIContentType+"; charset=utf-8",
+		[]byte(`{"name":"demo","files":[{"filename":"demo-1.2.3.tar.gz","url":"https://cdn.test/demo-1.2.3.tar.gz"}]}`))
+	require.NoError(t, err)
+	require.Len(t, jsonArtifacts, 1)
+
+	htmlArtifacts, err := parsePypiSimpleArtifacts(base, "text/html; charset=utf-8",
+		[]byte(`<!DOCTYPE html><html><body><a href="demo-1.2.3.tar.gz">demo-1.2.3.tar.gz</a></body></html>`))
+	require.NoError(t, err)
+	require.Len(t, htmlArtifacts, 1)
+}
+
+func TestParsePypiSimpleArtifacts_HTML(t *testing.T) {
+	base, err := url.Parse("https://packages.test/simple/demo/")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		body           string
+		wantURLs       []string
+		wantIdentities []artifactIdentity
+	}{
+		{
+			name:           "relative href resolves against the metadata base",
+			body:           `<!DOCTYPE html><html><body><a href="../../files/demo-1.2.3-py3-none-any.whl">demo-1.2.3-py3-none-any.whl</a></body></html>`,
+			wantURLs:       []string{"https://packages.test/files/demo-1.2.3-py3-none-any.whl"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "absolute href is preserved",
+			body:           `<html><body><a href="https://cdn.test/demo-1.2.3.tar.gz">demo-1.2.3.tar.gz</a></body></html>`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3.tar.gz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "fragment on the href is retained at parse time",
+			body:           `<html><body><a href="https://cdn.test/demo-1.2.3.tar.gz#sha256=abc">demo-1.2.3.tar.gz</a></body></html>`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3.tar.gz#sha256=abc"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "identity is derived from the href path, not the anchor text",
+			body:           `<html><body><a href="https://cdn.test/demo-1.2.3.tar.gz">click here to download</a></body></html>`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3.tar.gz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "percent-encoded final path segment is decoded before parsing",
+			body:           `<html><body><a href="https://cdn.test/mylib-1.2.3%2Blocal.tar.gz">mylib-1.2.3+local.tar.gz</a></body></html>`,
+			wantURLs:       []string{"https://cdn.test/mylib-1.2.3%2Blocal.tar.gz"},
+			wantIdentities: []artifactIdentity{{Name: "mylib", Version: "1.2.3+local"}},
+		},
+		{
+			name:           "anchor without href is skipped",
+			body:           `<html><body><a>demo-1.2.3.tar.gz</a></body></html>`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name:           "unsupported extension is skipped",
+			body:           `<html><body><a href="https://cdn.test/demo-1.2.3.egg">demo-1.2.3.egg</a></body></html>`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+		{
+			name: "one bad anchor does not discard a good one",
+			body: `<html><body>
+				<a href="https://cdn.test/demo-1.2.3.egg">demo-1.2.3.egg</a>
+				<a href="https://cdn.test/demo-1.2.3.tar.gz">demo-1.2.3.tar.gz</a>
+			</body></html>`,
+			wantURLs:       []string{"https://cdn.test/demo-1.2.3.tar.gz"},
+			wantIdentities: []artifactIdentity{{Name: "demo", Version: "1.2.3"}},
+		},
+		{
+			name:           "no anchors at all",
+			body:           `<html><body><p>no packages here</p></body></html>`,
+			wantURLs:       nil,
+			wantIdentities: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			artifacts, err := parsePypiSimpleArtifacts(base, "text/html", []byte(tt.body))
+			require.NoError(t, err)
+			require.Len(t, artifacts, len(tt.wantURLs))
+
+			gotURLs := make([]string, len(artifacts))
+			gotIdentities := make([]artifactIdentity, len(artifacts))
+			for i, artifact := range artifacts {
+				gotURLs[i] = artifact.URL.String()
+				gotIdentities[i] = artifact.Identity
+			}
+			assert.ElementsMatch(t, tt.wantURLs, gotURLs)
+			assert.ElementsMatch(t, tt.wantIdentities, gotIdentities)
+		})
+	}
+}
+
+func TestParsePypiSimpleArtifacts_HTMLVendorContentType(t *testing.T) {
+	base, err := url.Parse("https://packages.test/simple/demo/")
+	require.NoError(t, err)
+
+	artifacts, err := parsePypiSimpleArtifacts(base, "application/vnd.pypi.simple.v1+html",
+		[]byte(`<html><body><a href="https://cdn.test/demo-1.2.3.tar.gz">demo-1.2.3.tar.gz</a></body></html>`))
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, artifactIdentity{Name: "demo", Version: "1.2.3"}, artifacts[0].Identity)
+}
+
+func TestPypiMetadataDiscoveryModifier_NeverRewritesTheResponse(t *testing.T) {
+	base, err := url.Parse("https://packages.test/simple/demo/")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		status      int
+		contentType string
+		body        []byte
+	}{
+		{name: "non-2xx status is left untouched", status: http.StatusNotFound, contentType: pypiSimpleAPIContentType, body: []byte(`{"error":"not found"}`)},
+		{name: "server error status is left untouched", status: http.StatusInternalServerError, contentType: pypiSimpleAPIContentType, body: []byte(`internal error`)},
+		{name: "empty body on a 200 is left untouched", status: http.StatusOK, contentType: pypiSimpleAPIContentType, body: []byte{}},
+		{name: "malformed JSON body on a 200 is left untouched", status: http.StatusOK, contentType: pypiSimpleAPIContentType, body: []byte("not json")},
+		{name: "unsupported content type on a 200 is left untouched", status: http.StatusOK, contentType: "application/json", body: []byte(`{"name":"demo"}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			index := newArtifactIndex()
+			ctx := makeTestRequestContext("https://packages.test/simple/demo/")
+			modifier := pypiMetadataDiscoveryModifier(ctx, index, registrySet{}, "custom-pypi", base)
+
+			headers := http.Header{}
+			headers.Set("Content-Type", tt.contentType)
+			headers.Set("X-Test", "value")
+			wantHeaders := headers.Clone()
+			wantBody := make([]byte, len(tt.body))
+			copy(wantBody, tt.body)
+
+			gotStatus, gotHeaders, gotBody, err := modifier(tt.status, headers, tt.body)
+			require.NoError(t, err)
+			assert.Equal(t, tt.status, gotStatus)
+			assert.Equal(t, wantHeaders, gotHeaders)
+			assert.Equal(t, wantBody, gotBody)
+
+			_, ok := index.Get("custom-pypi", base)
+			assert.False(t, ok, "a rejected or unparseable response must add no index mappings")
+		})
+	}
+}
+
+func TestPypiMetadataDiscoveryModifier_SkipsCanonicallyResolvableArtifacts(t *testing.T) {
+	registries := newTestCustomRegistrySetFor(t, packagev1.Ecosystem_ECOSYSTEM_PYPI, "https://packages.test/simple")
+	index := newArtifactIndex()
+	base := mustParseURL("https://packages.test/simple/demo/")
+	ctx := makeTestRequestContext("https://packages.test/simple/demo/")
+	modifier := pypiMetadataDiscoveryModifier(ctx, index, registries, "custom-pypi", base)
+
+	body := []byte(`{"name":"demo","files":[
+		{"filename":"demo-1.2.3-py3-none-any.whl","url":"https://packages.test/simple/demo/demo-1.2.3-py3-none-any.whl"},
+		{"filename":"demo-2.0.0-py3-none-any.whl","url":"https://packages.test/simple/opaque-blob?id=7"}
+	]}`)
+	headers := http.Header{}
+	headers.Set("Content-Type", pypiSimpleAPIContentType)
+	_, _, _, err := modifier(http.StatusOK, headers, body)
+	require.NoError(t, err)
+
+	_, ok := index.Get("custom-pypi", mustParseURL("https://packages.test/simple/demo/demo-1.2.3-py3-none-any.whl"))
+	assert.False(t, ok, "a canonically parseable artifact URL must not be indexed")
+
+	identity, ok := index.Get("custom-pypi", mustParseURL("https://packages.test/simple/opaque-blob?id=7"))
+	assert.True(t, ok, "a non-canonical artifact URL must still be indexed")
+	assert.Equal(t, artifactIdentity{Name: "demo", Version: "2.0.0"}, identity)
+}

--- a/proxy/interceptors/pypi_registry.go
+++ b/proxy/interceptors/pypi_registry.go
@@ -1,6 +1,8 @@
 package interceptors
 
 import (
+	"net/url"
+
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/analyzer"
@@ -21,6 +23,7 @@ type PypiRegistryInterceptor struct {
 	baseRegistryInterceptor
 	registryRequestMatcher
 	cooldownHandler *pypiCooldownHandler
+	artifacts       *artifactIndex
 }
 
 var _ proxy.Interceptor = (*PypiRegistryInterceptor)(nil)
@@ -52,6 +55,7 @@ func newPypiRegistryInterceptor(
 		},
 		registryRequestMatcher: registryRequestMatcher{registries: registries},
 		cooldownHandler:        newPypiCooldownHandler(statsCollector),
+		artifacts:              newArtifactIndex(),
 	}
 }
 
@@ -66,21 +70,60 @@ func (i *PypiRegistryInterceptor) HandleRequest(ctx *proxy.RequestContext) (*pro
 	return handleRegistryRequest(ctx, i.registries, "PyPI", i)
 }
 
-// handleMetadataRequest applies dependency cooldown to a metadata request.
-// Cooldown applies only to Simple API requests, since pip uses those, not
-// the JSON API, for version resolution.
+// resolveIndexedArtifact resolves an opaque download URL to an identity a
+// prior metadata response advertised for the same registry.
+func (i *PypiRegistryInterceptor) resolveIndexedArtifact(registryName string, requestURL *url.URL) (artifactIdentity, bool) {
+	return i.artifacts.Get(registryName, requestURL)
+}
+
+// handleMetadataRequest applies cooldown, artifact discovery, or both to a
+// metadata request. Discovery runs before cooldown so it always sees the
+// upstream index. Cooldown applies only to Simple API requests, since pip
+// uses those, not the JSON API, for version resolution.
 func (i *PypiRegistryInterceptor) handleMetadataRequest(
 	ctx *proxy.RequestContext,
+	endpoint *registryEndpoint,
 	pkgInfo packageInfo,
+	requestURL *url.URL,
 ) (*proxy.InterceptorResponse, error) {
 	depCooldownConfig := pmgconfig.Get().Config.DependencyCooldown
-	if !depCooldownConfig.Enabled || !pypiIsSimpleAPIMetadataRequest(pkgInfo) ||
-		pmgconfig.IsTrustedPackageAllVersions(packagev1.Ecosystem_ECOSYSTEM_PYPI, denormalizePyPIPackageName(pkgInfo.GetName())) {
-		log.Debugf("[%s] Skipping analysis for metadata request: %s", ctx.RequestID, pkgInfo.GetName())
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+	isSimpleAPIRequest := pypiIsSimpleAPIMetadataRequest(pkgInfo)
+
+	var cooldownModifier proxy.ResponseModifierFunc
+	if depCooldownConfig.Enabled && isSimpleAPIRequest {
+		canonicalName := denormalizePyPIPackageName(pkgInfo.GetName())
+		if !pmgconfig.IsTrustedPackageAllVersions(packagev1.Ecosystem_ECOSYSTEM_PYPI, canonicalName) {
+			cooldownResp, err := i.cooldownHandler.HandleMetadataRequest(ctx, pkgInfo.GetName(), depCooldownConfig.Days, i.execContext.PinnedVersions[pkgInfo.GetName()])
+			if err != nil {
+				return nil, err
+			}
+			if cooldownResp.Action == proxy.ActionModifyResponse {
+				cooldownModifier = cooldownResp.ResponseModifier
+			}
+		}
 	}
 
-	return i.cooldownHandler.HandleMetadataRequest(ctx, pkgInfo.GetName(), depCooldownConfig.Days, i.execContext.PinnedVersions[pkgInfo.GetName()])
+	// Discovery applies only to a Simple API request on a custom registry.
+	// The JSON API and built-in registries never populate the index, so
+	// cooldown alone (or nothing) applies to them.
+	if endpoint.Source != registrySourceCustom || !isSimpleAPIRequest {
+		if cooldownModifier == nil {
+			log.Debugf("[%s] Skipping analysis for metadata request: %s", ctx.RequestID, pkgInfo.GetName())
+			return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+		}
+		return &proxy.InterceptorResponse{Action: proxy.ActionModifyResponse, ResponseModifier: cooldownModifier}, nil
+	}
+
+	// Discovery needs a parseable, always-fresh body even when cooldown does
+	// not run its own modifier, or the response could arrive compressed or
+	// as a bodyless 304.
+	forceUncompressedNonConditionalResponse(ctx.Headers)
+
+	discovery := pypiMetadataDiscoveryModifier(ctx, i.artifacts, i.registries, endpoint.Name, requestURL)
+	return &proxy.InterceptorResponse{
+		Action:           proxy.ActionModifyResponse,
+		ResponseModifier: chainResponseModifiers(discovery, cooldownModifier),
+	}, nil
 }
 
 // pypiIsSimpleAPIMetadataRequest reports whether a metadata request is

--- a/proxy/interceptors/pypi_registry_test.go
+++ b/proxy/interceptors/pypi_registry_test.go
@@ -63,8 +63,8 @@ func TestPypiRegistryInterceptor_Custom_ProjectSegmentIndexRequestIsMetadata(t *
 	ctx := makeTestRequestContext("https://python.test/simple/demo/")
 	resp, err := interceptor.HandleRequest(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, proxy.ActionAllow, resp.Action)
-	assert.Nil(t, resp.ResponseModifier)
+	require.Equal(t, proxy.ActionModifyResponse, resp.Action)
+	require.NotNil(t, resp.ResponseModifier)
 	assert.Zero(t, mock.callCount)
 }
 
@@ -115,31 +115,46 @@ func TestPypiRegistryInterceptor_Custom_BareFilenameOnDownloadOnlyEndpointIsCano
 	assert.Equal(t, 1, mock.callCount)
 }
 
-func TestPypiRegistryInterceptor_Custom_OpaqueArtifactIsAllowedWithoutAnalysis(t *testing.T) {
+func TestPypiRegistryInterceptor_Custom_OpaqueArtifactUsesMetadataIdentityFromJSON(t *testing.T) {
 	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
 
-	// Opaque download URLs carry no name or version, so PMG cannot identify
-	// the package from the request alone. Until metadata-based artifact
-	// discovery lands, such downloads are allowed without analysis rather
-	// than guessed at.
 	mock := &mockAnalyzer{result: &analyzer.PackageVersionAnalysisResult{Action: analyzer.ActionBlock}}
 	interceptor := newTestPypiCustomInterceptor(t, mock, "https://python.test/simple", "https://python.test/files")
+
+	metadataCtx := makeTestRequestContext("https://python.test/simple/demo/")
+	metadataResp, err := interceptor.HandleRequest(metadataCtx)
+	require.NoError(t, err)
+	require.Equal(t, proxy.ActionModifyResponse, metadataResp.Action)
+	require.NotNil(t, metadataResp.ResponseModifier)
+
+	// The download reference is opaque, so only the metadata-discovered
+	// identity lets it be classified correctly.
+	body := []byte(`{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"../../files/opaque?id=42"}]}`)
+	headers := http.Header{}
+	headers.Set("Content-Type", pypiSimpleAPIContentType)
+	_, _, _, err = metadataResp.ResponseModifier(http.StatusOK, headers, body)
+	require.NoError(t, err)
 
 	artifactCtx := makeTestRequestContext("https://python.test/files/opaque?id=42")
 	artifactResp, err := interceptor.HandleRequest(artifactCtx)
 	require.NoError(t, err)
-	assert.Equal(t, proxy.ActionAllow, artifactResp.Action)
-	assert.Zero(t, mock.callCount)
+	assert.Equal(t, proxy.ActionBlock, artifactResp.Action)
+	assert.Equal(t, 1, mock.callCount)
+	require.NotNil(t, artifactResp.BlockContext)
+	assert.Equal(t, "demo", artifactResp.BlockContext.PackageName)
+	assert.Equal(t, "1.2.3", artifactResp.BlockContext.PackageVersion)
 }
 
-func TestPypiRegistryInterceptor_Custom_DeepHashDirectoryFilenameResolvesCanonically(t *testing.T) {
+func TestPypiRegistryInterceptor_Custom_DeepHashDirectoryFilenameResolvesWithColdIndex(t *testing.T) {
 	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
 
 	mock := &mockAnalyzer{result: &analyzer.PackageVersionAnalysisResult{Action: analyzer.ActionBlock}}
 	interceptor := newTestPypiCustomInterceptor(t, mock, "https://python.test/simple", "https://python.test/files")
 
 	// A hash-directory filename resolves canonically via the
-	// filename-at-any-depth check, with no prior metadata request.
+	// filename-at-any-depth check, with a cold artifact index (no prior
+	// metadata request). Regression guard: analysis must not depend on a
+	// prior warm index entry.
 	artifactCtx := makeTestRequestContext("https://python.test/files/ab/cd/demo-1.2.3-py3-none-any.whl")
 	artifactResp, err := interceptor.HandleRequest(artifactCtx)
 	require.NoError(t, err)
@@ -148,6 +163,9 @@ func TestPypiRegistryInterceptor_Custom_DeepHashDirectoryFilenameResolvesCanonic
 	require.NotNil(t, artifactResp.BlockContext)
 	assert.Equal(t, "demo", artifactResp.BlockContext.PackageName)
 	assert.Equal(t, "1.2.3", artifactResp.BlockContext.PackageVersion)
+
+	_, ok := interceptor.artifacts.Get("custom-pypi", mustParseURL("https://python.test/files/ab/cd/demo-1.2.3-py3-none-any.whl"))
+	assert.False(t, ok, "resolution must be canonical: the artifact index was never populated")
 }
 
 func TestPypiRegistryInterceptor_Custom_ProjectNamedSimpleIsNotShadowed(t *testing.T) {
@@ -203,8 +221,8 @@ func TestPypiRegistryInterceptor_Custom_ProjectNameShapedLikeFilenameIsMetadataN
 	ctx := makeTestRequestContext("https://python.test/simple/totally-fine-2.0.0.tar.gz/")
 	resp, err := interceptor.HandleRequest(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, proxy.ActionAllow, resp.Action)
-	assert.Nil(t, resp.ResponseModifier)
+	assert.Equal(t, proxy.ActionModifyResponse, resp.Action)
+	require.NotNil(t, resp.ResponseModifier)
 	assert.Zero(t, mock.callCount, "the analyzer must never be called under a fabricated filename-derived identity")
 }
 
@@ -228,14 +246,189 @@ func TestPypiRegistryInterceptor_Custom_NonReadMethodPassesThroughUntouched(t *t
 	assert.Zero(t, mock.callCount)
 }
 
-func TestPypiRegistryInterceptor_Custom_UnparseablePathAllows(t *testing.T) {
+func TestPypiRegistryInterceptor_Custom_MetadataDiscoveryChainsBeforeCooldown(t *testing.T) {
+	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: true, Days: 5})
+
+	mock := &mockAnalyzer{}
+	interceptor := newTestPypiCustomInterceptor(t, mock, "https://python.test/simple", "https://python.test/files")
+
+	ctx := makeTestRequestContext("https://python.test/simple/demo/")
+	ctx.Headers.Set("Accept", pypiSimpleAPIContentType)
+	resp, err := interceptor.HandleRequest(ctx)
+	require.NoError(t, err)
+	require.Equal(t, proxy.ActionModifyResponse, resp.Action)
+	require.NotNil(t, resp.ResponseModifier)
+
+	// The only version is within the cooldown window, so the cooldown
+	// modifier strips it from the response. Discovery must still see it,
+	// since it runs on the upstream body before cooldown rewrites it.
+	artifactURL := "https://python.test/files/opaque?id=99"
+	body := []byte(`{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"` + artifactURL + `","upload-time":"` +
+		time.Now().Add(-1*24*time.Hour).Format(time.RFC3339) + `"}]}`)
+	headers := http.Header{}
+	headers.Set("Content-Type", pypiSimpleAPIContentType)
+
+	_, _, newBody, err := resp.ResponseModifier(http.StatusOK, headers, body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(newBody), "1.2.3", "cooldown must strip the too-new version from the client-visible response")
+
+	identity, ok := interceptor.artifacts.Get("custom-pypi", mustParseURL(artifactURL))
+	require.True(t, ok, "discovery must index the artifact before cooldown strips it from the response")
+	assert.Equal(t, artifactIdentity{Name: "demo", Version: "1.2.3"}, identity)
+}
+
+func TestPypiRegistryInterceptor_Custom_SignedQueryParticipatesInArtifactIdentity(t *testing.T) {
+	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
+
+	mock := &mockAnalyzer{result: &analyzer.PackageVersionAnalysisResult{Action: analyzer.ActionBlock}}
+	interceptor := newTestPypiCustomInterceptor(t, mock, "https://python.test/simple", "https://python.test/files")
+
+	metadataCtx := makeTestRequestContext("https://python.test/simple/demo/")
+	metadataResp, err := interceptor.HandleRequest(metadataCtx)
+	require.NoError(t, err)
+	require.NotNil(t, metadataResp.ResponseModifier)
+
+	body := []byte(`{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"../../files/opaque?sig=abc123&exp=999"}]}`)
+	headers := http.Header{}
+	headers.Set("Content-Type", pypiSimpleAPIContentType)
+	_, _, _, err = metadataResp.ResponseModifier(http.StatusOK, headers, body)
+	require.NoError(t, err)
+
+	signedCtx := makeTestRequestContext("https://python.test/files/opaque?sig=abc123&exp=999")
+	resp, err := interceptor.HandleRequest(signedCtx)
+	require.NoError(t, err)
+	assert.Equal(t, proxy.ActionBlock, resp.Action, "the exact signed query must resolve through the artifact index")
+	assert.Equal(t, 1, mock.callCount)
+
+	// Same path, different query: the signed token is part of the artifact's
+	// identity, so this must miss the index and pass through, never reusing
+	// the verdict for the signed download.
+	unsignedCtx := makeTestRequestContext("https://python.test/files/opaque")
+	resp, err = interceptor.HandleRequest(unsignedCtx)
+	require.NoError(t, err)
+	assert.Equal(t, proxy.ActionAllow, resp.Action, "a query mismatch must not reuse the indexed artifact's verdict")
+	assert.Equal(t, 1, mock.callCount, "the query-mismatched request must not trigger analysis")
+}
+
+func newTestPypiMultiRegistryInterceptor(t *testing.T, mock *mockAnalyzer, registries ...config.ProxyRegistryConfig) *PypiRegistryInterceptor {
+	t.Helper()
+	return newPypiRegistryInterceptor(mock, NewInMemoryAnalysisCache(), NewAnalysisStatsCollector(),
+		make(chan *ConfirmationRequest, 1), InterceptorContext{},
+		newTestRegistrySetFor(t, packagev1.Ecosystem_ECOSYSTEM_PYPI, registries))
+}
+
+func TestPypiRegistryInterceptor_Custom_ArtifactIndexIsolatedAcrossRegistries(t *testing.T) {
+	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
+
+	mock := &mockAnalyzer{}
+	interceptor := newTestPypiMultiRegistryInterceptor(t, mock,
+		config.ProxyRegistryConfig{
+			Name:      "registry-a",
+			Ecosystem: "pypi",
+			Endpoints: []config.ProxyRegistryEndpointConfig{{URL: "https://python.test/a/simple"}},
+		},
+		config.ProxyRegistryConfig{
+			Name:      "registry-b",
+			Ecosystem: "pypi",
+			Endpoints: []config.ProxyRegistryEndpointConfig{{URL: "https://python.test/b/simple"}},
+		},
+	)
+
+	metadataCtx := makeTestRequestContext("https://python.test/a/simple/demo/")
+	metadataResp, err := interceptor.HandleRequest(metadataCtx)
+	require.NoError(t, err)
+	require.NotNil(t, metadataResp.ResponseModifier)
+
+	artifactURL := "https://python.test/a/simple/opaque?id=1"
+	body := []byte(`{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"` + artifactURL + `"}]}`)
+	headers := http.Header{}
+	headers.Set("Content-Type", pypiSimpleAPIContentType)
+	_, _, _, err = metadataResp.ResponseModifier(http.StatusOK, headers, body)
+	require.NoError(t, err)
+
+	identity, ok := interceptor.artifacts.Get("registry-a", mustParseURL(artifactURL))
+	require.True(t, ok, "discovery must index the artifact under the registry that served the metadata")
+	assert.Equal(t, artifactIdentity{Name: "demo", Version: "1.2.3"}, identity)
+
+	_, ok = interceptor.artifacts.Get("registry-b", mustParseURL(artifactURL))
+	assert.False(t, ok, "a mapping discovered for one registry must never be visible to another")
+}
+
+func TestPypiRegistryInterceptor_Custom_DiscoveredOffHostArtifactStaysUnintercepted(t *testing.T) {
 	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
 
 	mock := &mockAnalyzer{}
 	interceptor := newTestPypiCustomInterceptor(t, mock, "https://python.test/simple")
 
-	// Too many segments for the custom parser's supported shapes: parsing
-	// fails, and the request is allowed rather than guessed at.
+	metadataCtx := makeTestRequestContext("https://python.test/simple/demo/")
+	metadataResp, err := interceptor.HandleRequest(metadataCtx)
+	require.NoError(t, err)
+	require.NotNil(t, metadataResp.ResponseModifier)
+
+	// The registry advertises a file on an unconfigured host. Discovery may
+	// index it, but that must never expand which hosts get MITM'd.
+	body := []byte(`{"name":"demo","files":[{"filename":"demo-1.2.3-py3-none-any.whl","url":"https://cdn.unconfigured.test/demo-1.2.3-py3-none-any.whl"}]}`)
+	headers := http.Header{}
+	headers.Set("Content-Type", pypiSimpleAPIContentType)
+	_, _, _, err = metadataResp.ResponseModifier(http.StatusOK, headers, body)
+	require.NoError(t, err)
+
+	offHostCtx := &proxy.RequestContext{Hostname: "cdn.unconfigured.test"}
+	assert.False(t, interceptor.ShouldMITM(offHostCtx), "discovery must not dynamically enroll a new MITM host")
+	assert.False(t, interceptor.ShouldIntercept(offHostCtx), "discovery must not dynamically enroll a new intercepted host")
+}
+
+func TestPypiRegistryInterceptor_Custom_MetadataDiscoveryNormalizesRequestHeaders(t *testing.T) {
+	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
+
+	mock := &mockAnalyzer{}
+	interceptor := newTestPypiCustomInterceptor(t, mock, "https://python.test/simple")
+
+	ctx := makeTestRequestContext("https://python.test/simple/demo/")
+	ctx.Headers.Set("Accept-Encoding", "gzip")
+	ctx.Headers.Set("If-None-Match", `"etag-value"`)
+	ctx.Headers.Set("If-Modified-Since", "Wed, 01 Jan 2025 00:00:00 GMT")
+
+	// Cooldown is disabled, so its handler never runs to normalize headers
+	// itself. Discovery must still see a decompressible, always-fresh body.
+	resp, err := interceptor.HandleRequest(ctx)
+	require.NoError(t, err)
+	require.Equal(t, proxy.ActionModifyResponse, resp.Action)
+
+	assert.Equal(t, "identity", ctx.Headers.Get("Accept-Encoding"), "discovery must force an uncompressed response even with cooldown disabled")
+	assert.Empty(t, ctx.Headers.Get("If-None-Match"), "discovery must prevent a bodyless 304")
+	assert.Empty(t, ctx.Headers.Get("If-Modified-Since"), "discovery must prevent a bodyless 304")
+}
+
+func TestPypiRegistryInterceptor_Custom_CanonicalIdentityWinsOverConflictingIndexEntry(t *testing.T) {
+	mock := &mockAnalyzer{result: &analyzer.PackageVersionAnalysisResult{Action: analyzer.ActionBlock}}
+	interceptor := newTestPypiCustomInterceptor(t, mock, "https://python.test/simple")
+
+	artifactURL := mustParseURL("https://python.test/simple/real-package/real-package-1.0.0.tar.gz")
+
+	// Simulate a stale or compromised index entry claiming this exact
+	// canonical filename URL belongs to a different, unrelated package.
+	require.NoError(t, interceptor.artifacts.Add("custom-pypi", artifactURL, artifactURL.String(),
+		artifactIdentity{Name: "attacker-package", Version: "9.9.9"}))
+
+	ctx := makeTestRequestContext(artifactURL.String())
+	resp, err := interceptor.HandleRequest(ctx)
+	require.NoError(t, err)
+
+	require.NotNil(t, resp.BlockContext)
+	assert.Equal(t, "real-package", resp.BlockContext.PackageName, "canonical parsing must win over a conflicting index entry")
+	assert.Equal(t, "1.0.0", resp.BlockContext.PackageVersion)
+	assert.Equal(t, 1, mock.callCount)
+}
+
+func TestPypiRegistryInterceptor_Custom_UnparseablePathFallsBackToIndexThenAllows(t *testing.T) {
+	setCooldownConfig(t, config.DependencyCooldownConfig{Enabled: false})
+
+	mock := &mockAnalyzer{}
+	interceptor := newTestPypiCustomInterceptor(t, mock, "https://python.test/simple")
+
+	// Too many segments for the custom parser's supported shapes: canonical
+	// parsing fails, and nothing was ever indexed for it.
 	ctx := makeTestRequestContext("https://python.test/simple/pkg/1.0.0/extra/segments")
 	resp, err := interceptor.HandleRequest(ctx)
 	require.NoError(t, err)
@@ -255,7 +448,7 @@ func TestPypiRegistryInterceptor_Custom_RetainsExistingSimpleAndJSONShapesWhenBa
 	metadataCtx := makeTestRequestContext("https://python.test/python/simple/demo/")
 	metadataResp, err := interceptor.HandleRequest(metadataCtx)
 	require.NoError(t, err)
-	assert.Equal(t, proxy.ActionAllow, metadataResp.Action)
+	assert.Equal(t, proxy.ActionModifyResponse, metadataResp.Action)
 
 	jsonCtx := makeTestRequestContext("https://python.test/python/pypi/demo/json")
 	jsonResp, err := interceptor.HandleRequest(jsonCtx)

--- a/proxy/interceptors/registry_endpoint.go
+++ b/proxy/interceptors/registry_endpoint.go
@@ -175,6 +175,22 @@ func registryAbsoluteRequestURL(ctx *proxy.RequestContext) *url.URL {
 	return &u
 }
 
+// registryURLHasCanonicalIdentity reports whether canonical parsing already
+// resolves u to a complete identity. Discovery must skip indexing such a
+// URL: canonical parsing is authoritative, and a stale or compromised index
+// entry must never be able to override it.
+func registryURLHasCanonicalIdentity(registries registrySet, u *url.URL) bool {
+	match := registries.MatchURL(u)
+	if match == nil {
+		return false
+	}
+	pkgInfo, err := match.Endpoint.Parser.ParseURL(match.RelativePath)
+	if err != nil {
+		return false
+	}
+	return packageInfoHasCompleteIdentity(pkgInfo)
+}
+
 func relativePath(path, basePath string) string {
 	relative := strings.TrimPrefix(path, basePath)
 	if relative == "" {

--- a/test/proxye2e/proxye2e_test.go
+++ b/test/proxye2e/proxye2e_test.go
@@ -1289,11 +1289,7 @@ func TestProxyFlow_CustomNpm(t *testing.T) {
 			},
 		},
 		{
-			// Opaque download URLs carry no identity. Until metadata-based
-			// artifact discovery lands, they must pass through unanalyzed
-			// (fail-open), never blocked on a guess. This pins the v1 contract
-			// that discovery flips to a block.
-			Name:   "opaque npm artifact is allowed without analysis",
+			Name:   "opaque npm artifact resolved via metadata discovery is blocked",
 			Config: customRegistry("company-npm", "npm", npmBase, downloadBase),
 			Setup: func(h *Harness) {
 				h.Registry.AddCustomNpm(npmHost, "/npm/team")
@@ -1311,9 +1307,8 @@ func TestProxyFlow_CustomNpm(t *testing.T) {
 				return res
 			},
 			Assert: func(t *testing.T, h *Harness, res ExecResult) {
-				assert.False(t, res.Blocked(), "an opaque download must be allowed, not blocked on a guess")
-				assert.Equal(t, 0, h.Analyzer.AnalyzedCount("demo", "1.2.3"))
-				assert.True(t, h.Registry.Requested(npmHost, "/download/opaque"), "the download must pass through to the registry")
+				assert.True(t, res.Blocked(), "the opaque download must resolve via the discovered identity and be blocked")
+				assert.Equal(t, 1, h.Analyzer.AnalyzedCount("demo", "1.2.3"))
 			},
 		},
 		{
@@ -1393,11 +1388,9 @@ func TestProxyFlow_CustomPypi(t *testing.T) {
 		{
 			// The href sits at depth 1 under the "/simple"-ending base, so
 			// canonical parsing reads it as a metadata request, not a
-			// download: per PEP 503 a bare one-segment path there is always the
-			// project index page. Until metadata-based artifact discovery
-			// lands, such a download is allowed without analysis. This pins
-			// the v1 contract that discovery flips to a block.
-			Name:   "depth-1 artifact under a /simple base is allowed without analysis",
+			// download. This is the one shape where HTML discovery's index
+			// is actually consulted.
+			Name:   "custom pypi HTML flow blocks malware via discovery",
 			Config: customRegistry("company-pypi", "pypi", simpleBase),
 			Setup: func(h *Harness) {
 				h.Registry.AddCustomPypi(pypiHost, "/simple")
@@ -1413,16 +1406,33 @@ func TestProxyFlow_CustomPypi(t *testing.T) {
 				return res
 			},
 			Assert: func(t *testing.T, h *Harness, res ExecResult) {
-				assert.False(t, res.Blocked(), "an unidentifiable download must be allowed, not blocked on a guess")
-				assert.Equal(t, 0, h.Analyzer.AnalyzedCount("htmlpkg", "1.0.0"))
-				assert.True(t, h.Registry.Requested(pypiHost, "/simple/htmlpkg-1.0.0.tar.gz"),
-					"the download must pass through to the registry")
+				assert.True(t, res.Blocked(), "the depth-1 filename must resolve via the HTML-discovered identity and be blocked")
+				assert.Equal(t, 1, h.Analyzer.AnalyzedCount("htmlpkg", "1.0.0"))
 			},
 		},
 		{
-			// Same fail-open contract as the npm opaque case: no identity in
-			// the URL means no analysis until artifact discovery lands.
-			Name:   "opaque pypi artifact is allowed without analysis",
+			Name:   "custom pypi HTML flow allows a clean package via discovery",
+			Config: customRegistry("company-pypi", "pypi", simpleBase),
+			Setup: func(h *Harness) {
+				h.Registry.AddCustomPypi(pypiHost, "/simple")
+				h.Registry.AddPypi(PypiPackage{Name: "htmlclean", Versions: []PypiVersion{
+					{Version: "1.0.0", PublishedAt: old(), FileURL: simpleBase + "/htmlclean-1.0.0.tar.gz"},
+				}})
+				h.Analyzer.SetPypi("htmlclean", "1.0.0", Clean())
+			},
+			Exec: func(h *Harness) ExecResult {
+				res := ExecResult{}
+				res.add(h.get(simpleBase+"/htmlclean/", map[string]string{"Accept": pypiSimpleHTMLContentType}))
+				res.add(h.get(simpleBase+"/htmlclean-1.0.0.tar.gz", nil))
+				return res
+			},
+			Assert: func(t *testing.T, h *Harness, res ExecResult) {
+				assert.False(t, res.Blocked())
+				assert.Equal(t, 1, h.Analyzer.AnalyzedCount("htmlclean", "1.0.0"))
+			},
+		},
+		{
+			Name:   "opaque pypi artifact resolved via JSON metadata discovery is blocked",
 			Config: customRegistry("company-pypi", "pypi", simpleBase, filesBase),
 			Setup: func(h *Harness) {
 				h.Registry.AddCustomPypi(pypiHost, "/simple")
@@ -1434,10 +1444,8 @@ func TestProxyFlow_CustomPypi(t *testing.T) {
 			},
 			Exec: func(h *Harness) ExecResult { return h.Pypi().InstallFrom(simpleBase, "demo", "1.2.3") },
 			Assert: func(t *testing.T, h *Harness, res ExecResult) {
-				assert.False(t, res.Blocked(), "an opaque download must be allowed, not blocked on a guess")
-				assert.Equal(t, 0, h.Analyzer.AnalyzedCount("demo", "1.2.3"))
-				assert.True(t, h.Registry.Requested(pypiHost, "/files/opaque"),
-					"the download must pass through to the registry")
+				assert.True(t, res.Blocked())
+				assert.Equal(t, 1, h.Analyzer.AnalyzedCount("demo", "1.2.3"))
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Some registries serve artifacts from URLs that carry no name or version, for example `.../download/opaque?id=42`. Without this change such downloads fail open. PMG allows them without analysis. This PR closes that gap. PMG indexes the identity that metadata responses advertise for those URLs.

It parses the metadata that npm packuments and PyPI Simple indexes (PEP 691 JSON and PEP 503 HTML) serve. It reuses the advertised identity when the matching download arrives.

## Behavior

- Metadata responses are parsed as they pass through the proxy. Advertised artifact URLs populate a bounded index (15-minute TTL, 10,000 entries), scoped per configured registry.
- Canonical URL parsing stays authoritative and always wins. PMG consults the index only when the URL itself carries no complete identity. Registry metadata can never override a URL-derived identity. A canonically resolvable URL is never indexed.
- Discovery runs before dependency cooldown in the response-modifier chain. It sees the upstream body even when cooldown strips versions.
- Indexing never expands interception. Links and redirect targets on unconfigured hosts stay tunneled.
- The npm and pypi interceptors fall back to the registry-scoped index only after canonical parsing fails or yields an incomplete identity.

## Structure

One commit on top of `main`. The delta is only the discovery subsystem, ported onto the current interceptor structure after #408 and #422 landed. The v1 fail-open assertions (`opaque * artifact is allowed without analysis`) flip to blocked assertions here, so the behavior change is explicit.

## Tests

New unit coverage for the artifact index (TTL, LRU, eviction, URL normalization, per-registry isolation, secret redaction), npm packument and PyPI Simple parsing, the interceptor fallbacks, and canonical-over-index precedence. The proxy E2E cases flip from the fail-open contract to the blocking contract, plus a clean-package HTML discovery case.
