### PR TITLE
Support fallback package managers in protection checks

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -60,10 +60,15 @@ func resolveProtectionBinary(tc ProtectionTestCase) (string, bool) {
 func RunProtectionCheck(tc ProtectionTestCase, pmgBinary string) CheckResult {
 	binary, found := resolveProtectionBinary(tc)
 	if !found {
-		return CheckResult{
-			Status:  StatusWarn,
-			Message: fmt.Sprintf("%s not available — skipping protection test for %s", strings.Join(tc.binaries(), "/"), tc.Package),
+		if !tc.NeedsVenv {
+			return CheckResult{
+				Status:  StatusWarn,
+				Message: fmt.Sprintf("%s not available — skipping protection test for %s", strings.Join(tc.binaries(), "/"), tc.Package),
+			}
 		}
+		// Venv-based tests supply their own binary: python3 -m venv bootstraps
+		// pip into the venv, whose bin dir is prepended to PATH for the pmg run.
+		binary = tc.PackageManager
 	}
 
 	tmpDir, err := os.MkdirTemp("", "pmg-doctor-*")

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -14,9 +14,13 @@ import (
 
 type ProtectionTestCase struct {
 	PackageManager string
-	Package        string
-	InstallArgs    []string
-	NeedsVenv      bool
+	// Fallbacks are alternate binaries to run the test through when the primary
+	// is absent (e.g. Homebrew and Debian ship pip3 without a bare pip). Each
+	// entry must also be a pmg subcommand.
+	Fallbacks   []string
+	Package     string
+	InstallArgs []string
+	NeedsVenv   bool
 }
 
 func ProtectionTestCases() []ProtectionTestCase {
@@ -24,25 +28,41 @@ func ProtectionTestCases() []ProtectionTestCase {
 		{
 			PackageManager: "npm",
 			Package:        "safedep-test-pkg@0.1.3",
-			InstallArgs:    []string{"npm", "install", "--no-cache", "--prefer-online", "safedep-test-pkg@0.1.3"},
+			InstallArgs:    []string{"install", "--no-cache", "--prefer-online", "safedep-test-pkg@0.1.3"},
 		},
 		{
 			PackageManager: "pip",
+			Fallbacks:      []string{"pip3"},
 			Package:        "safedep-test-pkg==0.0.4",
-			InstallArgs:    []string{"pip", "install", "--no-cache-dir", "safedep-test-pkg==0.0.4"},
+			InstallArgs:    []string{"install", "--no-cache-dir", "safedep-test-pkg==0.0.4"},
 			NeedsVenv:      true,
 		},
 	}
 }
 
+func (tc ProtectionTestCase) binaries() []string {
+	return append([]string{tc.PackageManager}, tc.Fallbacks...)
+}
+
+// resolveProtectionBinary picks the first candidate with a real binary,
+// resolved the same way the runner does — PATH with PMG shim dirs stripped.
+// A plain exec.LookPath would find the PMG shim on PATH and report the
+// manager as available even when the real binary is absent.
+func resolveProtectionBinary(tc ProtectionTestCase) (string, bool) {
+	for _, name := range tc.binaries() {
+		if _, err := shim.ResolveRealBinary(name); err == nil {
+			return name, true
+		}
+	}
+	return "", false
+}
+
 func RunProtectionCheck(tc ProtectionTestCase, pmgBinary string) CheckResult {
-	// Resolve the real package manager the same way the runner does — PATH with
-	// PMG shim dirs stripped. A plain exec.LookPath would find the PMG shim on
-	// PATH and report the manager as available even when the real binary is absent
-	if _, err := shim.ResolveRealBinary(tc.PackageManager); err != nil {
+	binary, found := resolveProtectionBinary(tc)
+	if !found {
 		return CheckResult{
 			Status:  StatusWarn,
-			Message: fmt.Sprintf("%s not available — skipping protection test for %s", tc.PackageManager, tc.Package),
+			Message: fmt.Sprintf("%s not available — skipping protection test for %s", strings.Join(tc.binaries(), "/"), tc.Package),
 		}
 	}
 
@@ -73,12 +93,12 @@ func RunProtectionCheck(tc ProtectionTestCase, pmgBinary string) CheckResult {
 		env = prependPath(env, venvBin)
 	}
 
-	cmd := exec.Command(pmgBinary, tc.InstallArgs...)
+	cmd := exec.Command(pmgBinary, append([]string{binary}, tc.InstallArgs...)...)
 	cmd.Dir = tmpDir
 	cmd.Env = env
 
 	output, runErr := cmd.CombinedOutput()
-	return evaluateProtectionResult(tc.PackageManager, tc.Package, string(output), runErr)
+	return evaluateProtectionResult(binary, tc.Package, string(output), runErr)
 }
 
 func setupVenv(baseDir string) (string, error) {

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -93,7 +93,8 @@ func RunProtectionCheck(tc ProtectionTestCase, pmgBinary string) CheckResult {
 		env = prependPath(env, venvBin)
 	}
 
-	cmd := exec.Command(pmgBinary, append([]string{binary}, tc.InstallArgs...)...)
+	args := append([]string{binary}, tc.InstallArgs...)
+	cmd := exec.Command(pmgBinary, args...)
 	cmd.Dir = tmpDir
 	cmd.Env = env
 

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -142,6 +142,38 @@ func TestRunProtectionCheckReportsAllCandidatesWhenNoneAvailable(t *testing.T) {
 	assert.Contains(t, result.Message, "pip/pip3 not available")
 }
 
+func TestRunProtectionCheckUsesVenvPipWhenNoSystemPip(t *testing.T) {
+	realPython, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	binDir := t.TempDir()
+	require.NoError(t, os.Symlink(realPython, filepath.Join(binDir, "python3")))
+
+	argvFile := filepath.Join(t.TempDir(), "argv.txt")
+	pmgStub := filepath.Join(binDir, "pmg-stub")
+	stub := fmt.Sprintf("#!/bin/sh\necho \"$@\" > %s\necho '%s'\nexit 1\n", argvFile, ui.MalwareBlockedHeadline)
+	require.NoError(t, os.WriteFile(pmgStub, []byte(stub), 0o755))
+
+	t.Setenv("PATH", binDir)
+
+	var pipCase ProtectionTestCase
+	for _, tc := range ProtectionTestCases() {
+		if tc.PackageManager == "pip" {
+			pipCase = tc
+		}
+	}
+	require.True(t, pipCase.NeedsVenv)
+
+	result := RunProtectionCheck(pipCase, pmgStub)
+	assert.Equal(t, StatusPass, result.Status)
+
+	argv, err := os.ReadFile(argvFile)
+	require.NoError(t, err)
+	assert.Equal(t, "pip install --no-cache-dir safedep-test-pkg==0.0.4", strings.TrimSpace(string(argv)))
+}
+
 func TestProtectionTestCases(t *testing.T) {
 	cases := ProtectionTestCases()
 	require.GreaterOrEqual(t, len(cases), 2)

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -75,12 +75,71 @@ func TestRunProtectionCheckSkipsWhenOnlyShimOnPath(t *testing.T) {
 	tc := ProtectionTestCase{
 		PackageManager: "npm",
 		Package:        "safedep-test-pkg@0.1.3",
-		InstallArgs:    []string{"npm", "install", "safedep-test-pkg@0.1.3"},
+		InstallArgs:    []string{"install", "safedep-test-pkg@0.1.3"},
 	}
 
 	result := RunProtectionCheck(tc, filepath.Join(tmp, "nonexistent-pmg"))
 	assert.Equal(t, StatusWarn, result.Status)
 	assert.Contains(t, result.Message, "not available")
+}
+
+func TestResolveProtectionBinary(t *testing.T) {
+	tests := []struct {
+		name       string
+		available  []string
+		tc         ProtectionTestCase
+		wantBinary string
+		wantFound  bool
+	}{
+		{
+			name:       "primary preferred when both available",
+			available:  []string{"pip", "pip3"},
+			tc:         ProtectionTestCase{PackageManager: "pip", Fallbacks: []string{"pip3"}},
+			wantBinary: "pip",
+			wantFound:  true,
+		},
+		{
+			name:       "falls back to pip3 when pip is absent",
+			available:  []string{"pip3"},
+			tc:         ProtectionTestCase{PackageManager: "pip", Fallbacks: []string{"pip3"}},
+			wantBinary: "pip3",
+			wantFound:  true,
+		},
+		{
+			name:      "none available",
+			tc:        ProtectionTestCase{PackageManager: "pip", Fallbacks: []string{"pip3"}},
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			for _, name := range tt.available {
+				require.NoError(t, os.WriteFile(filepath.Join(binDir, name), []byte("#!/bin/sh\n"), 0o755))
+			}
+			t.Setenv("PATH", binDir)
+
+			binary, found := resolveProtectionBinary(tt.tc)
+			assert.Equal(t, tt.wantFound, found)
+			assert.Equal(t, tt.wantBinary, binary)
+		})
+	}
+}
+
+func TestRunProtectionCheckReportsAllCandidatesWhenNoneAvailable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	tc := ProtectionTestCase{
+		PackageManager: "pip",
+		Fallbacks:      []string{"pip3"},
+		Package:        "safedep-test-pkg==0.0.4",
+		InstallArgs:    []string{"install", "safedep-test-pkg==0.0.4"},
+	}
+
+	result := RunProtectionCheck(tc, "pmg")
+	assert.Equal(t, StatusWarn, result.Status)
+	assert.Contains(t, result.Message, "pip/pip3 not available")
 }
 
 func TestProtectionTestCases(t *testing.T) {
@@ -93,12 +152,14 @@ func TestProtectionTestCases(t *testing.T) {
 		if tc.PackageManager == "npm" {
 			hasNpm = true
 			assert.False(t, tc.NeedsVenv)
+			assert.Empty(t, tc.Fallbacks)
 			assert.Contains(t, tc.InstallArgs, "--no-cache")
 			assert.Contains(t, tc.InstallArgs, "--prefer-online")
 		}
 		if tc.PackageManager == "pip" {
 			hasPip = true
 			assert.True(t, tc.NeedsVenv)
+			assert.Equal(t, []string{"pip3"}, tc.Fallbacks)
 			assert.Contains(t, tc.InstallArgs, "--no-cache-dir")
 		}
 	}


### PR DESCRIPTION
Add support for fallback package manager binaries (e.g., `pip3` when `pip` is unavailable) in protection checks.

## Summary
This change enables the protection check system to gracefully handle cases where a primary package manager binary is unavailable but a fallback alternative exists. This is particularly useful for distributions like Debian and Homebrew that ship `pip3` without a bare `pip` binary.

## Key Changes
- Added `Fallbacks` field to `ProtectionTestCase` to specify alternate binaries for each package manager
- Extracted `resolveProtectionBinary()` function to resolve the first available binary from primary + fallbacks, using the same real binary resolution logic as the runner (stripping PMG shim dirs from PATH)
- Updated `RunProtectionCheck()` to use the resolved binary and report all candidates in error messages (e.g., "pip/pip3 not available")
- Removed package manager names from `InstallArgs` in test cases — these are now passed as the first argument to the pmg subcommand
- Updated test cases: npm and pip now have `InstallArgs` without the manager name prefix; pip includes `pip3` as a fallback
- Added comprehensive test coverage for binary resolution and fallback behavior

## Implementation Details
- The `resolveProtectionBinary()` function uses `shim.ResolveRealBinary()` to find binaries the same way the runner does, ensuring consistency and preventing false positives from PMG shims
- Error messages now show all candidate binaries (primary + fallbacks) joined with "/" for clarity
- The resolved binary is passed to the pmg subcommand, allowing it to execute the correct package manager

https://claude.ai/code/session_0116TxwVFYVbzTRGQv1vRUox