### PR TITLE
Post-merge hardening and cleanup for custom proxy registries (#408)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,16 @@ go test ./config/ -v -count=1  # Run specific package tests
   (which runs under `go test ./...`) fails if a script has no catalog entry. Do not add
   scaffolding — add a script and a catalog row. See `test/acceptance/README.md`.
 
+## Writing
+
+Write in ASD-STE100, Simplified Technical English. This applies to every word you write: code
+comments, user-facing messages (errors, warnings, doctor checks), commit messages, pull request
+titles and bodies, review comments, docs.
+
+- One sentence, one idea. Do not join clauses with a semicolon or a colon.
+- Use the active voice and name the actor.
+- Cut every word that does no work. Say it once.
+
 ## Code Style
 
 - Keep things short and simple

--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -30,6 +30,7 @@ const (
 	checkShimInPath         = "shim-in-path"
 	checkDependencyCooldown = "dependency-cooldown"
 	checkEventLogging       = "event-logging"
+	checkProxyRegistries    = "proxy-registries"
 	checkSandbox            = "sandbox"
 	checkProtectionNpm      = "protection-npm"
 	checkProtectionPip      = "protection-pip"
@@ -202,6 +203,13 @@ func runCoreChecks(cfg *config.RuntimeConfig) []doctor.CheckResult {
 					Status:  doctor.StatusWarn,
 					Message: "Dependency cooldown is disabled",
 				}
+			},
+		},
+		{
+			Name:     checkProxyRegistries,
+			Category: "Security",
+			Run: func() doctor.CheckResult {
+				return checkProxyRegistriesResult(config.LoadError(), cfg.Config.Proxy.Registries)
 			},
 		},
 		{
@@ -498,6 +506,7 @@ var checkDisplayNames = map[string]string{
 	checkShimInPath:         "Shim in PATH",
 	checkDependencyCooldown: "Dependency cooldown",
 	checkEventLogging:       "Event logging",
+	checkProxyRegistries:    "Custom registries",
 	checkSandbox:            "Sandbox",
 	checkProtectionNpm:      "npm protection",
 	checkProtectionPip:      "pip protection",
@@ -513,6 +522,7 @@ var checkFixes = map[string]string{
 	checkShimInPath:         "Restart shell or source profile",
 	checkSandbox:            "Set sandbox.enabled: true in config",
 	checkDependencyCooldown: "Set dependency_cooldown.enabled: true in config",
+	checkProxyRegistries:    "Fix the proxy.registries entries in the PMG configuration file",
 	checkEventLogging:       "Set skip_event_logging: false in config",
 	checkProtectionNpm:      "pmg setup install",
 	checkProtectionPip:      "pmg setup install",
@@ -606,6 +616,51 @@ func displayName(name string) string {
 		return dn
 	}
 	return name
+}
+
+// checkProxyRegistriesResult reports the state of proxy.registries. A load
+// error is a failure: installs and proxy start fail closed until the config
+// is repaired. Plain-HTTP endpoints get a warning, because that traffic is
+// readable and modifiable on the network path.
+func checkProxyRegistriesResult(loadErr error, registries []config.ProxyRegistryConfig) doctor.CheckResult {
+	if loadErr != nil {
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: "proxy.registries is invalid; installs and proxy start fail closed",
+		}
+	}
+	if len(registries) == 0 {
+		return doctor.CheckResult{
+			Status:  doctor.StatusPass,
+			Message: "No custom registries configured",
+		}
+	}
+
+	normalized, err := config.NormalizeProxyRegistries(registries)
+	if err != nil {
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: fmt.Sprintf("proxy.registries is invalid: %v", err),
+		}
+	}
+
+	var insecure []string
+	for _, endpoint := range normalized {
+		if endpoint.Scheme == "http" {
+			insecure = append(insecure, endpoint.URL)
+		}
+	}
+	if len(insecure) > 0 {
+		return doctor.CheckResult{
+			Status:  doctor.StatusWarn,
+			Message: fmt.Sprintf("%d custom registry endpoint(s) use plain HTTP: %s", len(insecure), strings.Join(insecure, ", ")),
+			Fix:     "Use https:// endpoint URLs where the registry supports TLS",
+		}
+	}
+	return doctor.CheckResult{
+		Status:  doctor.StatusPass,
+		Message: fmt.Sprintf("%d custom registry endpoint(s) configured", len(normalized)),
+	}
 }
 
 func fixHint(name string) string {

--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -620,14 +620,14 @@ func displayName(name string) string {
 }
 
 // checkProxyRegistriesResult reports the state of proxy.registries. A load
-// error is a failure: installs and proxy start fail closed until the config
-// is repaired. Plain-HTTP endpoints get a warning, because that traffic is
-// readable and modifiable on the network path.
+// error fails the check. Installs and proxy start fail closed until the
+// user repairs the config file. A plain-HTTP endpoint gets a warning.
+// Anyone on the network path can read and change that traffic.
 func checkProxyRegistriesResult(loadErr error, registries []config.ProxyRegistryConfig) doctor.CheckResult {
 	if loadErr != nil {
 		return doctor.CheckResult{
 			Status:  doctor.StatusFail,
-			Message: "proxy.registries is invalid; installs and proxy start fail closed",
+			Message: "proxy.registries is invalid. Installs and proxy start fail closed",
 		}
 	}
 	if len(registries) == 0 {
@@ -637,13 +637,13 @@ func checkProxyRegistriesResult(loadErr error, registries []config.ProxyRegistry
 		}
 	}
 
-	// Build the catalog that proxy startup builds, so the check fails on
-	// everything startup rejects (built-in host overlap, reserved Go hosts),
-	// not only on load-time validation.
+	// Build the same catalog that proxy startup builds. The check then
+	// fails on everything startup rejects (built-in host overlap, reserved
+	// Go hosts), not only on load-time validation errors.
 	if _, err := interceptors.NewRegistryCatalog(registries); err != nil {
 		return doctor.CheckResult{
 			Status:  doctor.StatusFail,
-			Message: fmt.Sprintf("%v; installs and proxy start fail closed", err),
+			Message: fmt.Sprintf("%v. Installs and proxy start fail closed", err),
 		}
 	}
 

--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/safedep/pmg/internal/ui"
 	"github.com/safedep/pmg/internal/version"
 	"github.com/safedep/pmg/proxy/certmanager"
+	"github.com/safedep/pmg/proxy/interceptors"
 	"github.com/safedep/pmg/sandbox/platform"
 	"github.com/safedep/pmg/truststore"
 	"github.com/spf13/cobra"
@@ -633,6 +634,16 @@ func checkProxyRegistriesResult(loadErr error, registries []config.ProxyRegistry
 		return doctor.CheckResult{
 			Status:  doctor.StatusPass,
 			Message: "No custom registries configured",
+		}
+	}
+
+	// Build the catalog that proxy startup builds, so the check fails on
+	// everything startup rejects (built-in host overlap, reserved Go hosts),
+	// not only on load-time validation.
+	if _, err := interceptors.NewRegistryCatalog(registries); err != nil {
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: fmt.Sprintf("%v; installs and proxy start fail closed", err),
 		}
 	}
 

--- a/cmd/setup/doctor_test.go
+++ b/cmd/setup/doctor_test.go
@@ -156,3 +156,56 @@ func TestCheckEventLogDirResult(t *testing.T) {
 		assert.Equal(t, expectedFix, result.Fix)
 	})
 }
+
+func TestCheckProxyRegistriesResult(t *testing.T) {
+	httpsRegistry := config.ProxyRegistryConfig{
+		Name:      "company-npm",
+		Ecosystem: config.ProxyRegistryEcosystemNpm,
+		Endpoints: []config.ProxyRegistryEndpointConfig{{URL: "https://packages.test/npm"}},
+	}
+	httpRegistry := config.ProxyRegistryConfig{
+		Name:      "plain-npm",
+		Ecosystem: config.ProxyRegistryEcosystemNpm,
+		Endpoints: []config.ProxyRegistryEndpointConfig{{URL: "http://plain.test/npm"}},
+	}
+
+	tests := []struct {
+		name        string
+		loadErr     error
+		registries  []config.ProxyRegistryConfig
+		wantStatus  doctor.CheckStatus
+		wantMessage string
+	}{
+		{
+			name:        "load error fails",
+			loadErr:     assert.AnError,
+			wantStatus:  doctor.StatusFail,
+			wantMessage: "fail closed",
+		},
+		{
+			name:        "no registries passes",
+			wantStatus:  doctor.StatusPass,
+			wantMessage: "No custom registries",
+		},
+		{
+			name:        "https endpoints pass",
+			registries:  []config.ProxyRegistryConfig{httpsRegistry},
+			wantStatus:  doctor.StatusPass,
+			wantMessage: "1 custom registry endpoint(s) configured",
+		},
+		{
+			name:        "plain http endpoint warns",
+			registries:  []config.ProxyRegistryConfig{httpsRegistry, httpRegistry},
+			wantStatus:  doctor.StatusWarn,
+			wantMessage: "http://plain.test/npm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkProxyRegistriesResult(tt.loadErr, tt.registries)
+			assert.Equal(t, tt.wantStatus, result.Status)
+			assert.Contains(t, result.Message, tt.wantMessage)
+		})
+	}
+}

--- a/cmd/setup/doctor_test.go
+++ b/cmd/setup/doctor_test.go
@@ -199,6 +199,26 @@ func TestCheckProxyRegistriesResult(t *testing.T) {
 			wantStatus:  doctor.StatusWarn,
 			wantMessage: "http://plain.test/npm",
 		},
+		{
+			name: "endpoint on a built-in host fails like proxy startup",
+			registries: []config.ProxyRegistryConfig{{
+				Name:      "shadow-npm",
+				Ecosystem: config.ProxyRegistryEcosystemNpm,
+				Endpoints: []config.ProxyRegistryEndpointConfig{{URL: "https://registry.npmjs.org/npm-virtual"}},
+			}},
+			wantStatus:  doctor.StatusFail,
+			wantMessage: "covered by the built-in",
+		},
+		{
+			name: "endpoint on a reserved go host fails like proxy startup",
+			registries: []config.ProxyRegistryConfig{{
+				Name:      "go-shadow",
+				Ecosystem: config.ProxyRegistryEcosystemNpm,
+				Endpoints: []config.ProxyRegistryEndpointConfig{{URL: "https://sum.golang.org/npm"}},
+			}},
+			wantStatus:  doctor.StatusFail,
+			wantMessage: "reserved for PMG's built-in Go module handling",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/setup/status.go
+++ b/cmd/setup/status.go
@@ -354,7 +354,7 @@ func collectProxyInfo(cfg *config.RuntimeConfig) proxyInfo {
 	// Custom registries are surfaced even when the daemon is not running:
 	// interception works per-command too.
 	for _, r := range cfg.Config.Proxy.Registries {
-		info.Registries = append(info.Registries, registryInfo{Name: r.Name, Ecosystem: r.Ecosystem})
+		info.Registries = append(info.Registries, registryInfo{Name: r.Name, Ecosystem: string(r.Ecosystem)})
 	}
 	return info
 }

--- a/config/config_template_test.go
+++ b/config/config_template_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -47,12 +48,7 @@ func TestTemplateMatchesDefaults(t *testing.T) {
 	require.NoError(t, err, "expected no error while unmarshalling config")
 
 	def := DefaultConfig().Config
-
-	assert.Equal(t, def.Paranoid, parsed.Paranoid, "paranoid mismatch")
-	assert.Equal(t, def.DisableTelemetry, parsed.DisableTelemetry, "disable_telemetry mismatch")
-	assert.Equal(t, def.SkipEventLogging, parsed.SkipEventLogging, "skip_event_logging mismatch")
-	assert.Equal(t, def.EventLogRetentionDays, parsed.EventLogRetentionDays, "event_log_retention_days mismatch")
-	assert.Equal(t, def.Verbosity, parsed.Verbosity, "verbosity mismatch")
+	assertTemplateCoversDefaults(t, "Config", reflect.ValueOf(def), reflect.ValueOf(parsed))
 
 	assert.NotEmpty(t, parsed.TrustedPackages, "expected at least one trusted_packages entry")
 
@@ -60,13 +56,38 @@ func TestTemplateMatchesDefaults(t *testing.T) {
 	assert.NotEmpty(t, first.Purl, "first trusted package has empty purl")
 	assert.NotEmpty(t, first.Reason, "first trusted package has empty reason")
 
-	assert.Equal(t, def.DependencyCooldown.Enabled, parsed.DependencyCooldown.Enabled, "dependency_cooldown.enabled mismatch")
-	assert.Equal(t, def.DependencyCooldown.Days, parsed.DependencyCooldown.Days, "dependency_cooldown.days mismatch")
-	assert.Equal(t, def.AdvisoryMessage, parsed.AdvisoryMessage, "advisory_message mismatch")
-
-	assert.Equal(t, def.Cloud.Enabled, parsed.Cloud.Enabled, "cloud.enabled mismatch")
 	assert.Empty(t, def.Proxy.Registries, "default proxy.registries must be empty")
 	assert.Empty(t, parsed.Proxy.Registries, "template proxy.registries must be empty")
+}
+
+// assertTemplateCoversDefaults walks the default and template-parsed configs
+// in lockstep. Every leaf whose Go default is non-empty must appear in the
+// template with the same value: loadViperConfig unmarshals into a zero
+// Config with the template as its only default source, so a template that
+// misses such a field silently loads it as zero. The template may carry
+// extra content the Go defaults leave empty (trusted packages, sandbox
+// policies); empty defaults are skipped.
+func assertTemplateCoversDefaults(t *testing.T, path string, def, parsed reflect.Value) {
+	t.Helper()
+
+	switch def.Kind() {
+	case reflect.Struct:
+		for i := 0; i < def.NumField(); i++ {
+			field := def.Type().Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			assertTemplateCoversDefaults(t, path+"."+field.Name, def.Field(i), parsed.Field(i))
+		}
+	case reflect.Slice, reflect.Map:
+		if def.Len() > 0 {
+			assert.Equal(t, def.Interface(), parsed.Interface(), "%s: template must carry the Go default", path)
+		}
+	default:
+		if !def.IsZero() {
+			assert.Equal(t, def.Interface(), parsed.Interface(), "%s: template must carry the Go default", path)
+		}
+	}
 }
 
 func TestTemplateHasCommentedRegistryExample(t *testing.T) {

--- a/config/config_template_test.go
+++ b/config/config_template_test.go
@@ -62,11 +62,11 @@ func TestTemplateMatchesDefaults(t *testing.T) {
 
 // assertTemplateCoversDefaults walks the default and template-parsed configs
 // in lockstep. Every leaf whose Go default is non-empty must appear in the
-// template with the same value: loadViperConfig unmarshals into a zero
+// template with the same value. loadViperConfig unmarshals into a zero
 // Config with the template as its only default source, so a template that
 // misses such a field silently loads it as zero. The template may carry
 // extra content the Go defaults leave empty (trusted packages, sandbox
-// policies); empty defaults are skipped.
+// policies). The walk skips empty defaults.
 func assertTemplateCoversDefaults(t *testing.T, path string, def, parsed reflect.Value) {
 	t.Helper()
 

--- a/config/proxy_registry.go
+++ b/config/proxy_registry.go
@@ -3,16 +3,38 @@ package config
 import (
 	"fmt"
 	"net"
-	"net/url"
 	"strings"
 	"unicode"
 
 	"github.com/safedep/pmg/internal/registryurl"
 )
 
+// ProxyRegistryEcosystem is the canonical set of ecosystems proxy.registries
+// accepts. The interceptor layer keys its ecosystem table on this type, so a
+// new ecosystem is added here first.
+type ProxyRegistryEcosystem string
+
+const (
+	ProxyRegistryEcosystemNpm  ProxyRegistryEcosystem = "npm"
+	ProxyRegistryEcosystemPypi ProxyRegistryEcosystem = "pypi"
+)
+
+func ProxyRegistryEcosystems() []ProxyRegistryEcosystem {
+	return []ProxyRegistryEcosystem{ProxyRegistryEcosystemNpm, ProxyRegistryEcosystemPypi}
+}
+
+func (e ProxyRegistryEcosystem) Valid() bool {
+	for _, known := range ProxyRegistryEcosystems() {
+		if e == known {
+			return true
+		}
+	}
+	return false
+}
+
 type ProxyRegistryConfig struct {
 	Name      string                        `mapstructure:"name"`
-	Ecosystem string                        `mapstructure:"ecosystem"`
+	Ecosystem ProxyRegistryEcosystem        `mapstructure:"ecosystem"`
 	Endpoints []ProxyRegistryEndpointConfig `mapstructure:"endpoints"`
 }
 
@@ -36,77 +58,103 @@ func (e *ProxyRegistriesError) Unwrap() error {
 	return e.err
 }
 
-// normalizedEndpoint splits a normalized endpoint URL into its origin and
-// base path so endpoint nesting can be checked across all registries.
-type normalizedEndpoint struct {
-	rawURL string
-	origin string
-	path   string
+// NormalizedRegistryEndpoint is one custom registry endpoint after
+// validation and URL normalization. The registry catalog consumes this model
+// directly, so config loading and catalog construction share one
+// normalization pass.
+type NormalizedRegistryEndpoint struct {
+	RegistryName string
+	Ecosystem    ProxyRegistryEcosystem
+	URL          string
+	Scheme       string
+	// Host is the lowercase hostname without brackets or port.
+	Host string
+	// Port is the effective port: the configured port, or the scheme default.
+	Port string
+	// BasePath is the normalized escaped base path with no trailing slash.
+	BasePath string
 }
 
-func splitEndpoint(rawURL string, u *url.URL) normalizedEndpoint {
-	return normalizedEndpoint{
-		rawURL: rawURL,
-		origin: u.Scheme + "://" + u.Host,
-		path:   u.EscapedPath(),
-	}
+func (e NormalizedRegistryEndpoint) origin() string {
+	return e.Scheme + "://" + e.Host + ":" + e.Port
 }
 
 func ValidateProxyRegistries(registries []ProxyRegistryConfig) error {
+	_, err := NormalizeProxyRegistries(registries)
+	return err
+}
+
+// NormalizeProxyRegistries validates proxy.registries and returns the
+// normalized endpoint model. It fails on the first invalid entry.
+func NormalizeProxyRegistries(registries []ProxyRegistryConfig) ([]NormalizedRegistryEndpoint, error) {
 	names := make(map[string]struct{}, len(registries))
-	endpoints := make(map[string]string)
-	var byOrigin []normalizedEndpoint
+	owners := make(map[string]string)
+	var normalized []NormalizedRegistryEndpoint
 
 	for registryIndex, registry := range registries {
 		name := strings.TrimSpace(registry.Name)
 		if name == "" {
-			return fmt.Errorf("proxy.registries[%d].name is required", registryIndex)
+			return nil, fmt.Errorf("proxy.registries[%d].name is required", registryIndex)
 		}
 		if name != registry.Name {
-			return fmt.Errorf("proxy.registries[%d].name must not have leading or trailing whitespace", registryIndex)
+			return nil, fmt.Errorf("proxy.registries[%d].name must not have leading or trailing whitespace", registryIndex)
 		}
 		if _, exists := names[name]; exists {
-			return fmt.Errorf("duplicate proxy registry name %q", name)
+			return nil, fmt.Errorf("duplicate proxy registry name %q", name)
 		}
 		names[name] = struct{}{}
 
-		if registry.Ecosystem != "npm" && registry.Ecosystem != "pypi" {
-			return fmt.Errorf("proxy registry %q has unsupported ecosystem %q", name, registry.Ecosystem)
+		if !registry.Ecosystem.Valid() {
+			return nil, fmt.Errorf("proxy registry %q has unsupported ecosystem %q", name, registry.Ecosystem)
 		}
 		if len(registry.Endpoints) == 0 {
-			return fmt.Errorf("proxy registry %q must define at least one endpoint", name)
+			return nil, fmt.Errorf("proxy registry %q must define at least one endpoint", name)
 		}
 
 		for endpointIndex, endpoint := range registry.Endpoints {
-			normalized, err := registryurl.Normalize(endpoint.URL)
+			u, err := registryurl.Normalize(endpoint.URL)
 			if err != nil {
-				return fmt.Errorf("proxy registry %q endpoint %d: %w", name, endpointIndex, err)
+				return nil, fmt.Errorf("proxy registry %q endpoint %d: %w", name, endpointIndex, err)
 			}
-			if owner, exists := endpoints[normalized.String()]; exists {
-				return fmt.Errorf("proxy registry endpoint %q is already assigned to %q", normalized, owner)
+			if owner, exists := owners[u.String()]; exists {
+				return nil, fmt.Errorf("proxy registry endpoint %q is already assigned to %q", u, owner)
 			}
-			endpoints[normalized.String()] = name
+			owners[u.String()] = name
 
-			if err := validateEndpointHost(normalized.Hostname()); err != nil {
-				return fmt.Errorf("proxy registry %q endpoint %d: %w", name, endpointIndex, err)
+			if err := validateEndpointHost(u.Hostname()); err != nil {
+				return nil, fmt.Errorf("proxy registry %q endpoint %d: %w", name, endpointIndex, err)
 			}
 
-			split := splitEndpoint(endpoint.URL, normalized)
+			port, valid := registryurl.EffectivePort(u.Scheme, u.Port())
+			if !valid {
+				return nil, fmt.Errorf("proxy registry %q endpoint %d: URL port must be between 1 and 65535", name, endpointIndex)
+			}
+
+			entry := NormalizedRegistryEndpoint{
+				RegistryName: name,
+				Ecosystem:    registry.Ecosystem,
+				URL:          u.String(),
+				Scheme:       u.Scheme,
+				Host:         u.Hostname(),
+				Port:         port,
+				BasePath:     u.EscapedPath(),
+			}
+
 			// Nested base paths on one origin are ambiguous regardless of
 			// ecosystem: in daemon mode both interceptors would handle the
 			// nested requests, and even single-ecosystem nesting forces an
 			// arbitration rule the config should state explicitly instead.
-			for _, existing := range byOrigin {
-				if existing.origin == split.origin && endpointPathsNest(existing.path, split.path) {
-					return fmt.Errorf("proxy registry %q endpoint %d (%q) overlaps %q: endpoint base paths on the same origin must not nest",
-						name, endpointIndex, endpoint.URL, existing.rawURL)
+			for _, existing := range normalized {
+				if existing.origin() == entry.origin() && endpointPathsNest(existing.BasePath, entry.BasePath) {
+					return nil, fmt.Errorf("proxy registry %q endpoint %d (%q) overlaps %q: endpoint base paths on the same origin must not nest",
+						name, endpointIndex, endpoint.URL, existing.URL)
 				}
 			}
-			byOrigin = append(byOrigin, split)
+			normalized = append(normalized, entry)
 		}
 	}
 
-	return nil
+	return normalized, nil
 }
 
 // validateEndpointHost rejects endpoint hosts PMG can never analyze:
@@ -136,7 +184,8 @@ func validateEndpointHost(hostname string) error {
 
 // endpointPathsNest reports whether one base path is a segment-prefix of the
 // other (either direction). An empty base path nests with every other path on
-// the same origin.
+// the same origin. Equal paths nest too, though the duplicate-endpoint check
+// reports those before this rule runs.
 func endpointPathsNest(a, b string) bool {
 	if a == "" || b == "" || a == b {
 		return true

--- a/docs/persistent-proxy.md
+++ b/docs/persistent-proxy.md
@@ -122,18 +122,19 @@ routed through it has its HTTPS intercepted and must trust the PMG CA.
 
 The daemon loads `proxy.registries` once, at startup, from the same config
 file the default proxy mode reads. See [Custom Registries](./proxy-mode.md#custom-registries)
-for the full configuration reference.
+for the configuration reference.
 
-Restart the daemon after you add, remove, or edit a registry entry:
+The daemon does not notice a config file edit. Restart it after you add,
+remove, or edit a registry entry:
 
 ```bash
 pmg proxy stop
 pmg proxy start --daemon
 ```
 
-A running daemon does not notice a config file edit on its own. The default
-proxy mode has no such limitation: `pmg npm install` starts a fresh proxy
-process for each command, so it always reads the current config file.
+The default proxy mode does not have this limitation. `pmg npm install`
+starts a fresh proxy process for each command, so it always reads the
+current config file.
 
 ## Certificate trust
 

--- a/docs/proxy-mode.md
+++ b/docs/proxy-mode.md
@@ -57,7 +57,7 @@ Note one trade-off versus the removed guard mode: the proxy analyzes packages as
 
 ## Custom Registries
 
-PMG analyzes packages from its built-in registries by default, such as `registry.npmjs.org` and `pypi.org`. It can also analyze packages from your own npm or PyPI compatible endpoint. Use this for an internal mirror or a registry proxy such as Artifactory or Nexus.
+By default PMG analyzes packages from its built-in registries, such as `registry.npmjs.org` and `pypi.org`. It can also analyze packages from your own npm or PyPI compatible endpoint. Use this for an internal mirror or a registry proxy such as Artifactory or Nexus.
 
 Configure custom registries under `proxy.registries`:
 
@@ -75,74 +75,66 @@ proxy:
         - url: https://artifacts.example.com/packages
 ```
 
-Both PyPI URLs belong to the same logical registry. Every metadata or artifact endpoint PMG should analyze must be listed explicitly; PMG does not automatically trust hosts discovered through metadata links or redirects.
+Both PyPI URLs belong to one logical registry. List every metadata and artifact endpoint you want PMG to analyze. PMG does not trust hosts that it discovers through metadata links or redirects.
 
 | Key | Description |
 |---|---|
 | `name` | A unique label for the registry. Used in logs. |
 | `ecosystem` | `npm` or `pypi`. No other ecosystem is supported. |
-| `endpoints[].url` | The base URL PMG matches requests against. Must be absolute, must use `http` or `https`, and must not carry credentials, a query string, or a fragment. |
-
-### Which hosts PMG intercepts
-
-PMG intercepts traffic only to the exact host in an endpoint URL. If you configure `packages.example.com`, PMG does not intercept `cdn.packages.example.com` or any other subdomain. For HTTPS, the configured port is part of the match: an endpoint on port 8443 does not cause PMG to decrypt traffic to port 443.
-
-This is different from PMG's built-in registries, which also cover their known subdomains automatically.
-
-PMG never decrypts traffic to a host it does not know, and a subdomain of a configured custom endpoint counts as unknown. That traffic goes through an ordinary encrypted tunnel; PMG cannot see the request path or body. PMG records the host in the audit log as a Host Observation event, so you can see which outside hosts your build reached.
+| `endpoints[].url` | The base URL PMG matches requests against. Must be absolute. Must use `http` or `https`. Must not contain credentials, a query string, or a fragment. |
 
 ### How PMG matches a request
 
-PMG decides whether to intercept a connection in two steps.
+PMG intercepts traffic only to the exact origin of an endpoint URL: the scheme, the host, and the port. If you configure `packages.example.com`, PMG does not intercept `cdn.packages.example.com`. An endpoint on port 8443 does not cause PMG to decrypt traffic to port 443. Built-in registries are different: they also cover their known subdomains.
 
-At CONNECT time, before any request path is visible, PMG checks the hostname and port. PMG decrypts the connection when they match the exact origin of a configured HTTPS endpoint. An `http://` endpoint never causes an HTTPS CONNECT connection to be decrypted. PMG also decrypts traffic for a built-in registry host, or one of its subdomains, that PMG analyzes. A few built-in hosts are recognized but not analyzed, for example GitHub's npm registry mirror and the PyPI test instances. PMG tunnels their traffic without decrypting it.
+PMG decides in two steps.
+
+At CONNECT time, before any request path is visible, PMG checks the hostname and port. PMG decrypts the connection when they match the exact origin of a configured HTTPS endpoint. An `http://` endpoint never causes an HTTPS connection to be decrypted. PMG also decrypts traffic for the built-in registry hosts that it analyzes. It recognizes but does not decrypt a few other built-in hosts, for example GitHub's npm registry mirror and the PyPI test instances.
+
+Traffic to every other host goes through an ordinary encrypted tunnel. PMG cannot see the request path or body. PMG records the host in the audit log as a Host Observation event, so you can see which outside hosts your build reached.
 
 After decryption, PMG matches each request against an endpoint by:
 
 1. Origin: scheme, exact host, and effective port. An omitted port defaults to 80 for `http` and 443 for `https`.
-2. Base path: the request path must equal the endpoint's base path, or start with the base path followed by `/`.
+2. Base path: the request path must equal the endpoint base path, or start with the base path followed by `/`.
 
-The base path check works on whole path segments, not on raw string prefixes. An endpoint base of `/repository/npm` matches `/repository/npm` and `/repository/npm/lodash`. It does not match `/repository/npm-private`, because `npm-private` is a different segment, not a continuation of `npm`. Query strings and fragments never affect the match.
+The base path check works on whole path segments, not on raw string prefixes. An endpoint base of `/repository/npm` matches `/repository/npm` and `/repository/npm/lodash`. It does not match `/repository/npm-private`, because `npm-private` is a different segment. Query strings and fragments never affect the match.
 
-PMG rejects nested endpoint base paths on the same origin during configuration validation, so a request cannot match more than one custom endpoint.
+Configuration validation rejects nested endpoint base paths on the same origin, so a request cannot match more than one custom endpoint.
 
-A request on a configured host whose path matches no endpoint passes through unchanged. Because the host matched a configured endpoint at CONNECT time, PMG already decrypted this traffic. PMG does not analyze the request, and does not block it.
+A request on a configured host whose path matches no endpoint passes through unchanged. PMG does not analyze it and does not block it.
+
+### How PMG identifies a package
+
+PMG reads a package name and version directly from the request URL: the npm tarball path shape, or the PyPI distribution filename. When the URL carries no identity, PMG fails open: it allows the download without analysis and never blocks on a guess. This covers opaque download URLs such as `.../download/opaque?id=42` and any path shape PMG does not recognize. Support to identify these downloads from registry metadata is planned.
 
 ### npm registry requirements
 
-A custom npm endpoint must serve a standard packument, full or abbreviated, the same JSON document `npm install` itself downloads. PMG identifies packages from the request URL (the tarball path shape) and does not otherwise read the packument, except when dependency cooldown changes what it reads and writes.
+A custom npm endpoint must serve a standard packument, full or abbreviated: the same JSON document that `npm install` downloads.
 
-When [dependency cooldown](./dependency-cooldown.md) is enabled, PMG requests the full packument from the endpoint. It reads the `time` object to check each version's publish date. An endpoint that can only serve abbreviated metadata gets no cooldown protection, because abbreviated metadata omits `time`. When cooldown strips a version, PMG rewrites `versions`, `time`, and `dist-tags` in the response.
+When [dependency cooldown](./dependency-cooldown.md) is enabled, PMG requests the full packument and reads the `time` object to check each version's publish date. An endpoint that can only serve abbreviated metadata gets no cooldown protection, because abbreviated metadata omits `time`. When cooldown strips a version, PMG rewrites `versions`, `time`, and `dist-tags` in the response.
 
 ### PyPI registry requirements
 
-A custom PyPI metadata endpoint must serve the [Simple Repository API](https://packaging.python.org/en/latest/specifications/simple-repository-api/), either the PEP 691 JSON format or the PEP 503 HTML format. An endpoint that can only serve PEP 503 HTML gets no dependency cooldown protection, because PMG reads upload times from the PEP 691 JSON response; malware analysis of file downloads is unaffected.
+A custom PyPI metadata endpoint must serve the [Simple Repository API](https://packaging.python.org/en/latest/specifications/simple-repository-api/), as PEP 691 JSON or PEP 503 HTML. An endpoint that can only serve PEP 503 HTML gets no dependency cooldown protection, because PMG reads upload times from the PEP 691 JSON response. Malware analysis of file downloads is not affected.
 
-An endpoint configured only for artifact downloads does not need to serve project metadata. PMG can analyze files beneath it when their standard wheel or source-distribution filenames contain the public package name and version.
+PMG identifies a distribution file, a wheel or an sdist, by its standard filename, at any depth below the configured base. An endpoint configured only for artifact downloads does not need to serve project metadata.
 
-The endpoint does not have to end in `/simple`. PMG recognizes `<base>/<project>/` when the configured base itself ends in `/simple`, and `<base>/simple/<project>/` when the base sits above the standard Simple API mount. For example, both `.../python/simple` plus `/requests/` and `.../python` plus `/simple/requests/` identify the project `requests`. PMG also recognizes the standard `<base>/pypi/<project>/json` metadata path.
+The endpoint base does not have to end in `/simple`. PMG recognizes these project page layouts:
 
-Some bases do not end in `/simple`. For example, a base might point at a mirror's API root above the Simple mount. PMG still recognizes the relative layouts `/simple/<project>/` and `/pypi/<project>/json` beneath a base like this. A Simple API exposed some other way, such as a root-mounted index or a `+simple` convention, gets no project-page recognition and no dependency cooldown. PMG still analyzes distribution file downloads under that base, because it identifies them from their filename rather than from the page that links to them.
+- `<base>/<project>/` when the base itself ends in `/simple`
+- `<base>/simple/<project>/` when the base sits above the standard Simple API mount
+- `<base>/pypi/<project>/json`, the standard JSON API path
 
-PMG identifies a distribution file, a wheel or an sdist, by its standard filename, at any depth below the configured base.
+A Simple API exposed some other way, such as a root-mounted index, gets no project page recognition and no dependency cooldown. PMG still analyzes distribution file downloads under that base, because it identifies them from their filename.
 
 ### Artifacts on a different host
 
-Some registries serve package metadata from one host and the actual files from another, or from a different path prefix on the same host. PMG never treats a link or a redirect target as a reason to trust a new host. It analyzes an artifact from another host only if that host is itself a configured endpoint.
-
-If your artifacts live on a separate origin or a disjoint path prefix, add it as its own endpoint. Nested endpoint prefixes on the same origin are rejected; an artifact already beneath an existing endpoint base is covered by that endpoint.
-
-### How PMG identifies a package from a URL
-
-PMG reads a package's name and version directly from the request URL: the npm tarball path shape, or the PyPI distribution filename. This covers most registries and needs no extra state.
-
-Some registries use opaque download URLs that carry no name or version, for example `.../download/opaque?id=42`. PMG cannot identify these downloads, so it currently allows them without analysis, the same fail-open behavior as an unparsable URL. Support for identifying them from registry metadata is planned.
+Some registries serve metadata from one host and files from another host or path prefix. PMG analyzes an artifact from another origin only when that origin is itself a configured endpoint. Add each artifact origin or disjoint path prefix as its own endpoint.
 
 ### Public packages only
 
-PMG's malware database covers public packages. A package PMG cannot find there, including any private package on a custom registry, keeps the current behavior: PMG allows it.
-
-Custom registry support targets public packages served through an internal mirror or a compatible registry proxy. PMG does not promise compatibility with any specific vendor. Metadata endpoints must serve the standard npm packument or PyPI Simple API beneath the URL you configure. Artifact-only PyPI endpoints must use standard distribution filenames.
+PMG's malware database covers public packages. PMG allows a package it cannot find there, including any private package on a custom registry. Custom registry support targets public packages served through an internal mirror or a compatible registry proxy. PMG does not promise compatibility with any specific vendor.
 
 ### Credentials
 
@@ -150,39 +142,40 @@ PMG does not store, inject, or log registry credentials. Keep credentials where 
 
 ### Plain HTTP endpoints
 
-PMG accepts an `http://` endpoint and prints one startup warning for it. Use `https://` where you can. Plain HTTP traffic is visible to anyone on the network path between the package manager and the registry.
+PMG accepts an `http://` endpoint. It prints one startup warning, and `pmg setup doctor` reports the endpoint. Use `https://` where you can. Anyone on the network path can read and change plain HTTP traffic.
 
 ### Troubleshooting
 
-**A shallow base path matches more than expected.** The base path check works on whole segments, so a shallow base also matches sibling repositories under the same prefix. A base of `/repository` also matches `/repository/npm-private` and `/repository/pypi-internal`. Configure the base as deep as your registry's actual mount point, not its parent.
+**A shallow base path matches more than expected.** The base path check works on whole segments, so a shallow base also matches sibling repositories under the same prefix. A base of `/repository` also matches `/repository/npm-private`. Configure the base as deep as your registry's actual mount point.
 
-**A vendor-specific PyPI project page is not recognized.** The endpoint does not need to end in `/simple`, but its metadata path must use one of the standard shapes described above. PMG does not guess that an arbitrary `<base>/<project>/` path is project metadata unless the base ends in `/simple`. Standard wheel and source-distribution filenames beneath the matched endpoint are still analyzed at any path depth.
+**A vendor-specific PyPI project page is not recognized.** The metadata path must use one of the standard layouts above. PMG does not guess that an arbitrary `<base>/<project>/` path is project metadata unless the base ends in `/simple`. Distribution file downloads under the matched endpoint are still analyzed.
 
-**An artifact is never analyzed.** Compare its URL with the configured endpoint's scheme, exact host, effective port, and segment-aware base path. A Host Observation means the artifact used an unknown origin; add that origin as an endpoint. A non-matching path on an already configured origin passes through without analysis and does not produce a Host Observation, so correct the existing base or add a disjoint endpoint. PMG rejects nested endpoint bases on the same origin. See "Artifacts on a different host" above.
+**An artifact is never analyzed.** Compare its URL with the configured endpoint origin and base path. A Host Observation in the audit log means the artifact used an unknown origin: add that origin as an endpoint. A non-matching path on a configured origin passes through without a Host Observation: correct the base path or add a disjoint endpoint.
 
-**Configuration or proxy startup fails.** PMG validates `proxy.registries` while loading the configuration and again when building the registry catalog before the proxy starts.
+**Configuration or proxy startup fails.** PMG validates `proxy.registries` when it loads the configuration, and again when it builds the registry catalog before the proxy starts. `pmg setup doctor` reports the failure.
 
-PMG rejects these endpoint values:
+PMG rejects these values:
 
 - A `name` that is empty, whitespace-only, or has leading or trailing whitespace
 - A duplicate `name`
 - An `ecosystem` other than `npm` or `pypi`
 - A registry with no `endpoints`
 - A URL that is relative, invalid, or uses a scheme other than `http` or `https`
-- A URL that includes credentials, a query string, or a fragment
-- A loopback host (`localhost`, `127.x`, `::1`), which proxied runs exclude via `NO_PROXY` so PMG could never analyze it
+- A URL that contains credentials, a query string, or a fragment
+- A loopback host (`localhost`, `127.x`, `::1`). Proxied runs exclude loopback via `NO_PROXY`, so PMG could never analyze it
 - An unspecified address (`0.0.0.0`, `::`)
-- A non-ASCII hostname; use the punycode (`xn--`) form, since package managers punycode before connecting
+- A non-ASCII hostname. Package managers punycode hostnames before they connect, so use the punycode (`xn--`) form
 - Two endpoints that normalize to the same origin and base path
-- Two endpoints on the same origin whose base paths nest into each other, such as `/npm` and `/npm/team` (npm and PyPI may share a host, but their base paths must be disjoint subtrees)
-- Endpoint paths with empty or dot segments (`/npm//team`, `/npm/../team`), which could never match real traffic
+- Two endpoints on the same origin whose base paths nest into each other, such as `/npm` and `/npm/team`. npm and PyPI may share a host, but their base paths must be disjoint subtrees
+- Endpoint paths with empty or dot segments (`/npm//team`, `/npm/../team`), which can never match real traffic
 - At proxy startup, an endpoint whose host is covered by a built-in registry (for example `registry.npmjs.org`, `pypi.org`, or their subdomains), because PMG already analyzes it
+- At proxy startup, an endpoint on `proxy.golang.org` or `sum.golang.org` (or their subdomains). These hosts belong to PMG's built-in Go module handling, and PMG never decrypts `sum.golang.org`
 
-The error names the registry and the specific problem. An empty or whitespace-only name has no registry name to report, so the error names the entry's position in the list instead, for example `proxy.registries[0]`. While the error stands, commands that run intercepted traffic (`pmg <pkg-manager>` installs, `pmg proxy start`) fail closed, because falling back to defaults would silently drop the configured protection. Non-install commands such as `pmg config`, `pmg doctor`, and `pmg version` still work, so you can repair the file with PMG itself. Fix the entry and retry.
+The error names the registry and the specific problem. An empty name has no registry name to report, so the error names the entry position instead, for example `proxy.registries[0]`. While the error stands, commands that run intercepted traffic (`pmg <pkg-manager>` installs, `pmg proxy start`) fail closed, because a fallback to defaults would silently drop the configured protection. Commands such as `pmg config`, `pmg setup doctor`, and `pmg version` still work, so you can repair the file with PMG itself.
 
 ### Find your current registry settings
 
-PMG does not read your package manager's own registry configuration automatically. Check each package manager yourself before you add a matching custom registry entry:
+PMG does not read your package manager's own registry configuration. Check each package manager before you add a matching custom registry entry:
 
 ```bash
 npm config get registry
@@ -190,7 +183,7 @@ npm config get @myscope:registry
 pip config debug
 ```
 
-`npm config get @myscope:registry` reports the registry for one scope; repeat it for every scope you use. `pip config debug` lists the `index-url` from every config file pip found, in the order pip applies them. It also lists active `PIP_*` environment variables under its `env_var:` section. An environment variable such as `PIP_INDEX_URL` overrides every config file.
+`npm config get @myscope:registry` reports the registry for one scope. Repeat it for every scope you use. `pip config debug` lists the `index-url` from every config file pip found, in the order pip applies them. It also lists active `PIP_*` environment variables under its `env_var:` section. An environment variable such as `PIP_INDEX_URL` overrides every config file.
 
 ## Supported Package Managers
 

--- a/internal/registryurl/url.go
+++ b/internal/registryurl/url.go
@@ -41,6 +41,9 @@ func Normalize(rawURL string) (*url.URL, error) {
 	}
 
 	hostname := NormalizeHostname(parsed.Hostname())
+	if hostname == "" {
+		return nil, fmt.Errorf("URL host is required")
+	}
 	host := hostname
 	if strings.Contains(hostname, ":") {
 		host = "[" + hostname + "]"
@@ -74,8 +77,11 @@ func NormalizeScheme(scheme string) string {
 	return strings.ToLower(scheme)
 }
 
+// NormalizeHostname lowercases a hostname and strips a single terminal DNS
+// dot: "sum.golang.org." names the same host as "sum.golang.org", and a
+// preserved dot would slip past every exact and suffix host comparison.
 func NormalizeHostname(hostname string) string {
-	return strings.ToLower(hostname)
+	return strings.ToLower(strings.TrimSuffix(hostname, "."))
 }
 
 func EffectivePort(scheme, port string) (string, bool) {

--- a/internal/registryurl/url_test.go
+++ b/internal/registryurl/url_test.go
@@ -142,3 +142,18 @@ func TestNormalizeBasePath(t *testing.T) {
 	assert.Equal(t, "", NormalizeBasePath("///"))
 	assert.Equal(t, "/npm/%2Fteam", NormalizeBasePath("/npm/%2fteam/"))
 }
+
+func TestNormalizeStripsTrailingDNSDot(t *testing.T) {
+	u, err := Normalize("https://SUM.golang.org./npm")
+	require.NoError(t, err)
+	assert.Equal(t, "https://sum.golang.org/npm", u.String())
+
+	_, err = Normalize("https://./npm")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host is required")
+}
+
+func TestNormalizeHostnameStripsTrailingDNSDot(t *testing.T) {
+	assert.Equal(t, "sum.golang.org", NormalizeHostname("Sum.Golang.Org."))
+	assert.Equal(t, "sum.golang.org", NormalizeHostname("sum.golang.org"))
+}

--- a/proxy/interceptors/base_registry.go
+++ b/proxy/interceptors/base_registry.go
@@ -325,8 +325,8 @@ type registryRequestHandler interface {
 
 // handleRegistryRequest is the shared registry request flow: match the
 // endpoint, gate on reads, parse the URL, and dispatch to the ecosystem's
-// artifact or metadata handler. It fails open: requests whose package
-// identity cannot be parsed from the URL are allowed without analysis.
+// artifact or metadata handler. It fails open. PMG allows a request
+// without analysis when it cannot parse a package identity from the URL.
 func handleRegistryRequest(
 	ctx *proxy.RequestContext,
 	registries registrySet,

--- a/proxy/interceptors/base_registry.go
+++ b/proxy/interceptors/base_registry.go
@@ -54,23 +54,6 @@ func newAnalyzerCircuitBreakerWithTimeout(name string, cooldown time.Duration) *
 	})
 }
 
-var _ proxy.Interceptor = (*baseRegistryInterceptor)(nil)
-
-// Name returns a default name - should be overridden by specific implementations
-func (b *baseRegistryInterceptor) Name() string {
-	return "base-registry-interceptor"
-}
-
-// ShouldIntercept returns false by default - must be overridden by specific implementations
-func (b *baseRegistryInterceptor) ShouldIntercept(ctx *proxy.RequestContext) bool {
-	return false
-}
-
-// HandleRequest returns allow by default - should be overridden by specific implementations
-func (b *baseRegistryInterceptor) HandleRequest(ctx *proxy.RequestContext) (*proxy.InterceptorResponse, error) {
-	return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
-}
-
 // fastAllow short-circuits the request when no security control should run for
 // this concrete version: insecure-installation mode (analysis globally off) or a
 // trusted package (waives every control). It returns (response, true) when it
@@ -313,4 +296,84 @@ func (b *baseRegistryInterceptor) requestUserConfirmation(
 	case <-time.After(5 * time.Minute):
 		return false, fmt.Errorf("timeout waiting for user confirmation")
 	}
+}
+
+// registryRequestMatcher gives an ecosystem interceptor its MITM and
+// intercept decisions from a registry set. Embed it and the interceptor
+// satisfies proxy.MITMDecider and the ShouldIntercept contract.
+type registryRequestMatcher struct {
+	registries registrySet
+}
+
+func (m *registryRequestMatcher) ShouldMITM(ctx *proxy.RequestContext) bool {
+	if ctx == nil {
+		return false
+	}
+	return registryHostSupportsAnalysis(m.registries, ctx.Hostname, ctx.Port)
+}
+
+func (m *registryRequestMatcher) ShouldIntercept(ctx *proxy.RequestContext) bool {
+	return registryRequestMatch(m.registries, ctx) != nil
+}
+
+// registryRequestHandler is the ecosystem-specific half of the shared
+// registry read-path flow.
+type registryRequestHandler interface {
+	handleArtifact(ctx *proxy.RequestContext, name, version string) (*proxy.InterceptorResponse, error)
+	handleMetadataRequest(ctx *proxy.RequestContext, pkgInfo packageInfo) (*proxy.InterceptorResponse, error)
+}
+
+// handleRegistryRequest is the shared registry request flow: match the
+// endpoint, gate on reads, parse the URL, and dispatch to the ecosystem's
+// artifact or metadata handler. It fails open: requests whose package
+// identity cannot be parsed from the URL are allowed without analysis.
+func handleRegistryRequest(
+	ctx *proxy.RequestContext,
+	registries registrySet,
+	ecosystemLabel string,
+	handler registryRequestHandler,
+) (*proxy.InterceptorResponse, error) {
+	log.Debugf("[%s] Handling %s registry request: %s", ctx.RequestID, ecosystemLabel, ctx.URL.Path)
+
+	match := registryRequestMatch(registries, ctx)
+	if match == nil {
+		// Shouldn't happen if ShouldIntercept is working correctly
+		log.Warnf("[%s] No registry config found for hostname: %s", ctx.RequestID, ctx.Hostname)
+		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+	}
+
+	// Analysis and cooldown only ever act on reads. Anything else (publish,
+	// registry API calls) passes through untouched: no header rewrites, no
+	// response modifiers.
+	if ctx.Method != http.MethodGet && ctx.Method != http.MethodHead {
+		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+	}
+
+	endpoint := match.Endpoint
+	if !endpoint.Analyze {
+		log.Debugf("[%s] Skipping analysis for %s registry (not supported for analysis): %s",
+			ctx.RequestID, endpoint.Host, ctx.URL.String())
+		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+	}
+
+	pkgInfo, parseErr := endpoint.Parser.ParseURL(match.RelativePath)
+
+	if parseErr == nil && packageInfoHasCompleteIdentity(pkgInfo) {
+		return handler.handleArtifact(ctx, pkgInfo.GetName(), pkgInfo.GetVersion())
+	}
+
+	if parseErr != nil {
+		logRegistryParseFailure(ctx, endpoint, ecosystemLabel, parseErr)
+		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+	}
+
+	if !pkgInfo.IsFileDownload() {
+		return handler.handleMetadataRequest(ctx, pkgInfo)
+	}
+
+	// A file-download parse without a complete identity: nothing reliable
+	// to analyze against. URLs that carry no identity at all (opaque
+	// download URLs some registries serve) land here too and are allowed
+	// without analysis.
+	return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
 }

--- a/proxy/interceptors/factory_test.go
+++ b/proxy/interceptors/factory_test.go
@@ -183,7 +183,7 @@ func TestInterceptorFactoryRejectsMalformedRegistryWithoutLoggingRawURL(t *testi
 func TestInterceptorFactoryRejectsEndpointsCoveredByBuiltIns(t *testing.T) {
 	tests := []struct {
 		name      string
-		ecosystem string
+		ecosystem config.ProxyRegistryEcosystem
 		endpoint  string
 	}{
 		{name: "analyzed npm host", ecosystem: "npm", endpoint: "https://registry.npmjs.org/npm-virtual"},

--- a/proxy/interceptors/factory_test.go
+++ b/proxy/interceptors/factory_test.go
@@ -190,6 +190,7 @@ func TestInterceptorFactoryRejectsEndpointsCoveredByBuiltIns(t *testing.T) {
 		{name: "analyzed pypi host", ecosystem: "pypi", endpoint: "https://pypi.org/simple"},
 		{name: "analyzed pypi files host", ecosystem: "pypi", endpoint: "https://files.pythonhosted.org/simple"},
 		{name: "subdomain of a built-in host", ecosystem: "npm", endpoint: "https://cdn.registry.npmjs.org/npm-virtual"},
+		{name: "built-in host with trailing DNS dot", ecosystem: "npm", endpoint: "https://registry.npmjs.org./npm-virtual"},
 		{name: "recognized but not analyzed host is still covered", ecosystem: "pypi", endpoint: "https://test.pypi.org/simple"},
 		{name: "npm custom endpoint on built-in pypi host", ecosystem: "npm", endpoint: "https://pypi.org/company/npm"},
 		{name: "pypi custom endpoint on built-in npm host", ecosystem: "pypi", endpoint: "https://registry.npmjs.org/company/simple"},

--- a/proxy/interceptors/npm_registry.go
+++ b/proxy/interceptors/npm_registry.go
@@ -1,8 +1,6 @@
 package interceptors
 
 import (
-	"net/http"
-
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/analyzer"
@@ -21,8 +19,8 @@ var npmRegistryEndpoints = []registryEndpoint{
 // It embeds baseRegistryInterceptor to reuse ecosystem agnostic functionality
 type NpmRegistryInterceptor struct {
 	baseRegistryInterceptor
+	registryRequestMatcher
 	cooldownHandler *npmCooldownHandler
-	registries      registrySet
 }
 
 var _ proxy.Interceptor = (*NpmRegistryInterceptor)(nil)
@@ -45,8 +43,8 @@ func newNpmRegistryInterceptor(
 			circuitBreaker:   newAnalyzerCircuitBreaker("malysis-analyzer-npm"),
 			execContext:      execContext,
 		},
-		cooldownHandler: newNpmCooldownHandler(statsCollector),
-		registries:      registries,
+		registryRequestMatcher: registryRequestMatcher{registries: registries},
+		cooldownHandler:        newNpmCooldownHandler(statsCollector),
 	}
 }
 
@@ -55,67 +53,10 @@ func (i *NpmRegistryInterceptor) Name() string {
 	return "npm-registry-interceptor"
 }
 
-func (i *NpmRegistryInterceptor) ShouldMITM(ctx *proxy.RequestContext) bool {
-	if ctx == nil {
-		return false
-	}
-	return registryHostSupportsAnalysis(i.registries, ctx.Hostname, ctx.Port)
-}
-
-// ShouldIntercept determines if this interceptor should handle the given request
-func (i *NpmRegistryInterceptor) ShouldIntercept(ctx *proxy.RequestContext) bool {
-	return registryRequestMatch(i.registries, ctx) != nil
-}
-
-// HandleRequest processes the request and returns response action
-// We take a fail-open approach here, allowing requests that we can't parse the package information from the URL.
+// HandleRequest runs the shared registry flow with npm's artifact and
+// metadata handlers.
 func (i *NpmRegistryInterceptor) HandleRequest(ctx *proxy.RequestContext) (*proxy.InterceptorResponse, error) {
-	log.Debugf("[%s] Handling NPM registry request: %s", ctx.RequestID, ctx.URL.Path)
-
-	// Get registry configuration
-	match := registryRequestMatch(i.registries, ctx)
-	if match == nil {
-		// Shouldn't happen if ShouldIntercept is working correctly
-		log.Warnf("[%s] No registry config found for hostname: %s", ctx.RequestID, ctx.Hostname)
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
-	}
-
-	// Analysis and cooldown only ever act on reads. Anything else (publish,
-	// registry API calls) passes through untouched: no header rewrites, no
-	// response modifiers.
-	if ctx.Method != http.MethodGet && ctx.Method != http.MethodHead {
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
-	}
-
-	// Skip analysis for registries that are not supported for analysis
-	endpoint := match.Endpoint
-	if !endpoint.Analyze {
-		log.Debugf("[%s] Skipping analysis for %s registry (not supported for analysis): %s",
-			ctx.RequestID, endpoint.Host, ctx.URL.String())
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
-	}
-
-	// Parse URL using registry-specific strategy
-	pkgInfo, parseErr := endpoint.Parser.ParseURL(match.RelativePath)
-
-	if parseErr == nil && packageInfoHasCompleteIdentity(pkgInfo) {
-		return i.handleArtifact(ctx, pkgInfo.GetName(), pkgInfo.GetVersion())
-	}
-
-	if parseErr != nil {
-		logRegistryParseFailure(ctx, endpoint, "NPM", parseErr)
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
-	}
-
-	if !pkgInfo.IsFileDownload() {
-		return i.handleMetadataRequest(ctx, pkgInfo)
-	}
-
-	// A file-download parse without a complete identity: nothing reliable
-	// to analyze against. URLs that carry no identity at all (opaque
-	// download URLs some registries serve) land here too and are allowed
-	// without analysis.
-	return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+	return handleRegistryRequest(ctx, i.registries, "NPM", i)
 }
 
 // handleMetadataRequest applies dependency cooldown to a metadata request.

--- a/proxy/interceptors/pypi_registry.go
+++ b/proxy/interceptors/pypi_registry.go
@@ -1,8 +1,6 @@
 package interceptors
 
 import (
-	"net/http"
-
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/analyzer"
@@ -21,8 +19,8 @@ var pypiRegistryEndpoints = []registryEndpoint{
 // It embeds baseRegistryInterceptor to reuse ecosystem agnostic functionality
 type PypiRegistryInterceptor struct {
 	baseRegistryInterceptor
+	registryRequestMatcher
 	cooldownHandler *pypiCooldownHandler
-	registries      registrySet
 }
 
 var _ proxy.Interceptor = (*PypiRegistryInterceptor)(nil)
@@ -52,8 +50,8 @@ func newPypiRegistryInterceptor(
 			circuitBreaker:   newAnalyzerCircuitBreaker("malysis-analyzer-pypi"),
 			execContext:      execContext,
 		},
-		cooldownHandler: newPypiCooldownHandler(statsCollector),
-		registries:      registries,
+		registryRequestMatcher: registryRequestMatcher{registries: registries},
+		cooldownHandler:        newPypiCooldownHandler(statsCollector),
 	}
 }
 
@@ -62,67 +60,10 @@ func (i *PypiRegistryInterceptor) Name() string {
 	return "pypi-registry-interceptor"
 }
 
-func (i *PypiRegistryInterceptor) ShouldMITM(ctx *proxy.RequestContext) bool {
-	if ctx == nil {
-		return false
-	}
-	return registryHostSupportsAnalysis(i.registries, ctx.Hostname, ctx.Port)
-}
-
-// ShouldIntercept determines if this interceptor should handle the given request
-func (i *PypiRegistryInterceptor) ShouldIntercept(ctx *proxy.RequestContext) bool {
-	return registryRequestMatch(i.registries, ctx) != nil
-}
-
-// HandleRequest processes the request and returns response action
-// We take a fail-open approach here, allowing requests that we can't parse the package information from the URL.
+// HandleRequest runs the shared registry flow with PyPI's artifact and
+// metadata handlers.
 func (i *PypiRegistryInterceptor) HandleRequest(ctx *proxy.RequestContext) (*proxy.InterceptorResponse, error) {
-	log.Debugf("[%s] Handling PyPI registry request: %s", ctx.RequestID, ctx.URL.Path)
-
-	// Get registry configuration
-	match := registryRequestMatch(i.registries, ctx)
-	if match == nil {
-		// Shouldn't happen if ShouldIntercept is working correctly
-		log.Warnf("[%s] No registry config found for hostname: %s", ctx.RequestID, ctx.Hostname)
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
-	}
-
-	// Analysis and cooldown only ever act on reads. Anything else (publish,
-	// registry API calls) passes through untouched: no header rewrites, no
-	// response modifiers.
-	if ctx.Method != http.MethodGet && ctx.Method != http.MethodHead {
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
-	}
-
-	// Skip analysis for registries that are not supported for analysis
-	endpoint := match.Endpoint
-	if !endpoint.Analyze {
-		log.Debugf("[%s] Skipping analysis for %s registry (not supported for analysis): %s",
-			ctx.RequestID, endpoint.Host, ctx.URL.String())
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
-	}
-
-	// Parse URL using registry-specific strategy
-	pkgInfo, parseErr := endpoint.Parser.ParseURL(match.RelativePath)
-
-	if parseErr == nil && packageInfoHasCompleteIdentity(pkgInfo) {
-		return i.handleArtifact(ctx, pkgInfo.GetName(), pkgInfo.GetVersion())
-	}
-
-	if parseErr != nil {
-		logRegistryParseFailure(ctx, endpoint, "PyPI", parseErr)
-		return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
-	}
-
-	if !pkgInfo.IsFileDownload() {
-		return i.handleMetadataRequest(ctx, pkgInfo)
-	}
-
-	// A file-download parse without a complete identity: nothing reliable
-	// to analyze against. URLs that carry no identity at all (opaque
-	// download URLs some registries serve) land here too and are allowed
-	// without analysis.
-	return &proxy.InterceptorResponse{Action: proxy.ActionAllow}, nil
+	return handleRegistryRequest(ctx, i.registries, "PyPI", i)
 }
 
 // handleMetadataRequest applies dependency cooldown to a metadata request.

--- a/proxy/interceptors/registry_catalog.go
+++ b/proxy/interceptors/registry_catalog.go
@@ -3,7 +3,7 @@ package interceptors
 import (
 	"fmt"
 	"net/http"
-	"net/url"
+	"strings"
 
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/safedep/dry/log"
@@ -12,6 +12,32 @@ import (
 	"github.com/safedep/pmg/proxy"
 )
 
+// ecosystemSpec is everything the catalog needs to support one ecosystem.
+// Adding an ecosystem means adding a config.ProxyRegistryEcosystem constant
+// and one entry here.
+type ecosystemSpec struct {
+	proto           packagev1.Ecosystem
+	builtIns        []registryEndpoint
+	newCustomParser func(basePath string) registryURLParser
+}
+
+var proxyEcosystems = map[config.ProxyRegistryEcosystem]ecosystemSpec{
+	config.ProxyRegistryEcosystemNpm: {
+		proto:    packagev1.Ecosystem_ECOSYSTEM_NPM,
+		builtIns: npmRegistryEndpoints,
+		newCustomParser: func(string) registryURLParser {
+			return npmParser{}
+		},
+	},
+	config.ProxyRegistryEcosystemPypi: {
+		proto:    packagev1.Ecosystem_ECOSYSTEM_PYPI,
+		builtIns: pypiRegistryEndpoints,
+		newCustomParser: func(basePath string) registryURLParser {
+			return pypiCustomParser{baseEndsInSimple: pypiBaseEndsInSimple(basePath)}
+		},
+	},
+}
+
 type RegistryCatalog struct {
 	byEcosystem map[packagev1.Ecosystem]registrySet
 }
@@ -19,45 +45,47 @@ type RegistryCatalog struct {
 func NewRegistryCatalog(registries []config.ProxyRegistryConfig) (*RegistryCatalog, error) {
 	// Keep this boundary self-validating because callers can construct a
 	// catalog directly without going through the global config loader.
-	if err := config.ValidateProxyRegistries(registries); err != nil {
+	normalized, err := config.NormalizeProxyRegistries(registries)
+	if err != nil {
 		return nil, fmt.Errorf("invalid custom proxy registries: %w", err)
 	}
 
 	catalog := newBuiltInRegistryCatalog()
 
-	for _, registry := range registries {
-		ecosystem := registryEcosystem(registry.Ecosystem)
-		for _, configured := range registry.Endpoints {
-			u, err := registryurl.Normalize(configured.URL)
-			if err != nil {
-				return nil, fmt.Errorf("invalid custom proxy registry %q endpoint: %w", registry.Name, err)
-			}
-			if endpoint := catalog.builtInForHostname(u.Hostname()); endpoint != nil {
-				return nil, fmt.Errorf("invalid custom %s registry %q endpoint: host %q is covered by the built-in npm/PyPI registries",
-					registry.Ecosystem, registry.Name, u.Hostname())
-			}
+	for _, configured := range normalized {
+		spec, ok := proxyEcosystems[configured.Ecosystem]
+		if !ok {
+			return nil, fmt.Errorf("invalid custom proxy registry %q: unsupported ecosystem %q", configured.RegistryName, configured.Ecosystem)
+		}
+		if catalog.builtInCoversHostname(configured.Host) {
+			return nil, fmt.Errorf("invalid custom %s registry %q endpoint: host %q is covered by the built-in npm/PyPI registries",
+				configured.Ecosystem, configured.RegistryName, configured.Host)
+		}
+		// The Go hosts are not catalog entries (Go routing derives from
+		// GOPROXY per run), so cover them here: a custom endpoint on them
+		// would decrypt Go module traffic, including sum.golang.org, which
+		// PMG never MITMs.
+		if reservedGoHost(configured.Host) {
+			return nil, fmt.Errorf("invalid custom %s registry %q endpoint: host %q is reserved for PMG's built-in Go module handling",
+				configured.Ecosystem, configured.RegistryName, configured.Host)
+		}
 
-			port, valid := registryurl.EffectivePort(u.Scheme, u.Port())
-			if !valid {
-				return nil, fmt.Errorf("invalid custom proxy registry %q endpoint port", registry.Name)
-			}
-			endpoint := registryEndpoint{
-				Name:     registry.Name,
-				Source:   registrySourceCustom,
-				Scope:    registryScopeOrigin,
-				Scheme:   u.Scheme,
-				Host:     u.Hostname(),
-				Port:     port,
-				BasePath: registryurl.NormalizeBasePath(u.EscapedPath()),
-				Analyze:  true,
-				Parser:   customRegistryParser(ecosystem, u),
-			}
-			set := catalog.byEcosystem[ecosystem]
-			set.entries = append(set.entries, endpoint)
-			catalog.byEcosystem[ecosystem] = set
-			if u.Scheme == "http" {
-				log.Warnf("Custom registry endpoint %q uses plain HTTP; traffic is inspectable but not encrypted", u.String())
-			}
+		endpoint := registryEndpoint{
+			Name:     configured.RegistryName,
+			Source:   registrySourceCustom,
+			Scope:    registryScopeOrigin,
+			Scheme:   configured.Scheme,
+			Host:     configured.Host,
+			Port:     configured.Port,
+			BasePath: configured.BasePath,
+			Analyze:  true,
+			Parser:   spec.newCustomParser(configured.BasePath),
+		}
+		set := catalog.byEcosystem[spec.proto]
+		set.entries = append(set.entries, endpoint)
+		catalog.byEcosystem[spec.proto] = set
+		if configured.Scheme == "http" {
+			log.Warnf("Custom registry endpoint %q uses plain HTTP; traffic is inspectable but not encrypted", configured.URL)
 		}
 	}
 
@@ -65,12 +93,11 @@ func NewRegistryCatalog(registries []config.ProxyRegistryConfig) (*RegistryCatal
 }
 
 func newBuiltInRegistryCatalog() *RegistryCatalog {
-	return &RegistryCatalog{
-		byEcosystem: map[packagev1.Ecosystem]registrySet{
-			packagev1.Ecosystem_ECOSYSTEM_NPM:  {entries: append([]registryEndpoint(nil), npmRegistryEndpoints...)},
-			packagev1.Ecosystem_ECOSYSTEM_PYPI: {entries: append([]registryEndpoint(nil), pypiRegistryEndpoints...)},
-		},
+	byEcosystem := make(map[packagev1.Ecosystem]registrySet, len(proxyEcosystems))
+	for _, spec := range proxyEcosystems {
+		byEcosystem[spec.proto] = registrySet{entries: append([]registryEndpoint(nil), spec.builtIns...)}
 	}
+	return &RegistryCatalog{byEcosystem: byEcosystem}
 }
 
 func (c *RegistryCatalog) registrySet(ecosystem packagev1.Ecosystem) registrySet {
@@ -81,6 +108,11 @@ func (c *RegistryCatalog) registrySet(ecosystem packagev1.Ecosystem) registrySet
 	return registrySet{entries: append([]registryEndpoint(nil), set.entries...)}
 }
 
+// IsKnownRegistryRequest reports whether a request targets a known registry
+// origin. It deliberately ignores paths: audit host observations are
+// suppressed for the whole origin, not per endpoint base path. This is a
+// third matching semantic next to MatchConnect (MITM decisions) and MatchURL
+// (per-request endpoint resolution); do not fold it into either.
 func (c *RegistryCatalog) IsKnownRegistryRequest(ctx *proxy.RequestContext) bool {
 	if ctx == nil || ctx.Hostname == "" {
 		return false
@@ -117,50 +149,33 @@ func (c *RegistryCatalog) IsKnownRegistryRequest(ctx *proxy.RequestContext) bool
 	return false
 }
 
-func (c *RegistryCatalog) builtInForHostname(hostname string) *registryEndpoint {
+func (c *RegistryCatalog) builtInCoversHostname(hostname string) bool {
 	hostname = normalizeHostnameWithOptionalPort(hostname)
-	var best *registryEndpoint
-	for _, ecosystem := range []packagev1.Ecosystem{
-		packagev1.Ecosystem_ECOSYSTEM_NPM,
-		packagev1.Ecosystem_ECOSYSTEM_PYPI,
-	} {
-		set := c.byEcosystem[ecosystem]
+	for _, set := range c.byEcosystem {
 		for index := range set.entries {
 			endpoint := &set.entries[index]
 			if endpoint.Source != registrySourceBuiltIn {
 				continue
 			}
-			exact, matches := endpointMatchesHostname(endpoint, hostname)
-			if !matches {
-				continue
-			}
-			if exact {
-				return endpoint
-			}
-			if best == nil || len(endpoint.Host) > len(best.Host) {
-				best = endpoint
+			if _, matches := endpointMatchesHostname(endpoint, hostname); matches {
+				return true
 			}
 		}
 	}
-	return best
+	return false
 }
 
-func registryEcosystem(ecosystem string) packagev1.Ecosystem {
-	switch ecosystem {
-	case "npm":
-		return packagev1.Ecosystem_ECOSYSTEM_NPM
-	case "pypi":
-		return packagev1.Ecosystem_ECOSYSTEM_PYPI
-	default:
-		panic(fmt.Sprintf("unsupported validated registry ecosystem %q", ecosystem))
+// reservedGoHost reports whether a hostname belongs to the well-known Go
+// module infrastructure, including subdomains. When PMG grows built-in Go
+// registry endpoints, proxy.golang.org moves into that built-in set and this
+// keeps guarding sum.golang.org.
+func reservedGoHost(hostname string) bool {
+	for host := range wellKnownGoHosts {
+		if hostname == host || strings.HasSuffix(hostname, "."+host) {
+			return true
+		}
 	}
-}
-
-func customRegistryParser(ecosystem packagev1.Ecosystem, u *url.URL) registryURLParser {
-	if ecosystem == packagev1.Ecosystem_ECOSYSTEM_PYPI {
-		return pypiCustomParser{baseEndsInSimple: pypiBaseEndsInSimple(u.EscapedPath())}
-	}
-	return npmParser{}
+	return false
 }
 
 func builtInRegistryEndpoint(host string, analyze bool, parser registryURLParser) registryEndpoint {

--- a/proxy/interceptors/registry_catalog.go
+++ b/proxy/interceptors/registry_catalog.go
@@ -62,7 +62,7 @@ func NewRegistryCatalog(registries []config.ProxyRegistryConfig) (*RegistryCatal
 				configured.Ecosystem, configured.RegistryName, configured.Host)
 		}
 		// The Go hosts are not catalog entries (Go routing derives from
-		// GOPROXY per run), so cover them here: a custom endpoint on them
+		// GOPROXY per run), so cover them here. A custom endpoint on them
 		// would decrypt Go module traffic, including sum.golang.org, which
 		// PMG never MITMs.
 		if reservedGoHost(configured.Host) {
@@ -85,7 +85,7 @@ func NewRegistryCatalog(registries []config.ProxyRegistryConfig) (*RegistryCatal
 		set.entries = append(set.entries, endpoint)
 		catalog.byEcosystem[spec.proto] = set
 		if configured.Scheme == "http" {
-			log.Warnf("Custom registry endpoint %q uses plain HTTP; traffic is inspectable but not encrypted", configured.URL)
+			log.Warnf("Custom registry endpoint %q uses plain HTTP. Anyone on the network path can read and change this traffic", configured.URL)
 		}
 	}
 
@@ -111,8 +111,8 @@ func (c *RegistryCatalog) registrySet(ecosystem packagev1.Ecosystem) registrySet
 // IsKnownRegistryRequest reports whether a request targets a known registry
 // origin. It deliberately ignores paths: audit host observations are
 // suppressed for the whole origin, not per endpoint base path. This is a
-// third matching semantic next to MatchConnect (MITM decisions) and MatchURL
-// (per-request endpoint resolution); do not fold it into either.
+// third matching semantic next to MatchConnect (MITM decisions) and
+// MatchURL (per-request endpoint resolution). Do not fold it into either.
 func (c *RegistryCatalog) IsKnownRegistryRequest(ctx *proxy.RequestContext) bool {
 	if ctx == nil || ctx.Hostname == "" {
 		return false

--- a/proxy/interceptors/registry_catalog_test.go
+++ b/proxy/interceptors/registry_catalog_test.go
@@ -59,8 +59,32 @@ func TestRegistryCatalogReturnsIndependentSets(t *testing.T) {
 	assert.NotEqual(t, "mutated.test", second.entries[0].Host)
 }
 
-func TestRegistryEcosystemRejectsInvalidValue(t *testing.T) {
-	assert.Panics(t, func() {
-		registryEcosystem("maven")
-	})
+func TestProxyEcosystemsCoverEveryConfigEcosystem(t *testing.T) {
+	for _, ecosystem := range config.ProxyRegistryEcosystems() {
+		assert.Contains(t, proxyEcosystems, ecosystem)
+	}
+	assert.Len(t, proxyEcosystems, len(config.ProxyRegistryEcosystems()))
+}
+
+func TestRegistryCatalogRejectsReservedGoHosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "go module proxy", endpoint: "https://proxy.golang.org/npm"},
+		{name: "go checksum database", endpoint: "https://sum.golang.org/npm"},
+		{name: "subdomain of a go host", endpoint: "https://mirror.sum.golang.org/npm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewRegistryCatalog([]config.ProxyRegistryConfig{{
+				Name:      "company-npm",
+				Ecosystem: "npm",
+				Endpoints: []config.ProxyRegistryEndpointConfig{{URL: tt.endpoint}},
+			}})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "reserved for PMG's built-in Go module handling")
+		})
+	}
 }

--- a/proxy/interceptors/registry_catalog_test.go
+++ b/proxy/interceptors/registry_catalog_test.go
@@ -74,6 +74,7 @@ func TestRegistryCatalogRejectsReservedGoHosts(t *testing.T) {
 		{name: "go module proxy", endpoint: "https://proxy.golang.org/npm"},
 		{name: "go checksum database", endpoint: "https://sum.golang.org/npm"},
 		{name: "subdomain of a go host", endpoint: "https://mirror.sum.golang.org/npm"},
+		{name: "go host with trailing DNS dot", endpoint: "https://sum.golang.org./npm"},
 	}
 
 	for _, tt := range tests {

--- a/proxy/interceptors/registry_test_helpers_test.go
+++ b/proxy/interceptors/registry_test_helpers_test.go
@@ -30,12 +30,12 @@ func newTestCustomRegistrySetFor(t *testing.T, ecosystem packagev1.Ecosystem, en
 	for index, endpointURL := range endpointURLs {
 		endpoints[index] = config.ProxyRegistryEndpointConfig{URL: endpointURL}
 	}
-	ecosystemName := "npm"
+	ecosystemName := config.ProxyRegistryEcosystemNpm
 	if ecosystem == packagev1.Ecosystem_ECOSYSTEM_PYPI {
-		ecosystemName = "pypi"
+		ecosystemName = config.ProxyRegistryEcosystemPypi
 	}
 	return newTestRegistrySetFor(t, ecosystem, []config.ProxyRegistryConfig{{
-		Name:      "custom-" + ecosystemName,
+		Name:      "custom-" + string(ecosystemName),
 		Ecosystem: ecosystemName,
 		Endpoints: endpoints,
 	}})

--- a/test/proxye2e/proxye2e_test.go
+++ b/test/proxye2e/proxye2e_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/proxy/interceptors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1284,6 +1285,59 @@ func TestProxyFlow_CustomRegistryTunneling(t *testing.T) {
 				assert.False(t, h.Registry.Requested("cdn.unconfigured.test", "/demo-1.2.3.tgz"),
 					"a MITM'd request would reach the registry; this must never happen for a discovered off-host URL")
 				assert.Zero(t, h.Analyzer.AnalyzedCount("demo", "1.2.3"))
+			},
+		},
+	})
+}
+
+// TestProxyFlow_ReservedGoHostRefusesInterception pins the fail-closed
+// startup contract for reserved Go hosts. The harness cannot start when the
+// catalog rejects the config, so this drives the same config path the runner
+// uses into the same factory the harness, the per-command flow, and the
+// daemon all build their interceptors from.
+func TestProxyFlow_ReservedGoHostRefusesInterception(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "go module proxy", endpoint: "https://proxy.golang.org/npm"},
+		{name: "go checksum database", endpoint: "https://sum.golang.org/npm"},
+		{name: "go checksum database with trailing DNS dot", endpoint: "https://sum.golang.org./npm"},
+		{name: "subdomain of a go host", endpoint: "https://mirror.sum.golang.org/npm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyConfig(t, customRegistry("company-npm", "npm", tt.endpoint))
+
+			_, err := interceptors.NewInterceptorFactory(
+				nil, interceptors.NewInMemoryAnalysisCache(), interceptors.NewAnalysisStatsCollector(),
+				make(chan *interceptors.ConfirmationRequest, 1), interceptors.InterceptorContext{},
+				config.Get().Config.Proxy.Registries,
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "reserved for PMG's built-in Go module handling")
+		})
+	}
+}
+
+// TestProxyFlow_GoChecksumDatabaseStaysTunneled pins the invariant the
+// reserved-host rejection protects: sum.golang.org is never decrypted.
+func TestProxyFlow_GoChecksumDatabaseStaysTunneled(t *testing.T) {
+	RunCases(t, []TestCase{
+		{
+			Name: "go checksum database is tunneled, not MITM'd",
+			Exec: func(h *Harness) ExecResult {
+				res := ExecResult{}
+				res.add(h.get("https://sum.golang.org/lookup/example.com/demo@v1.0.0", nil))
+				return res
+			},
+			Assert: func(t *testing.T, h *Harness, res ExecResult) {
+				assert.Contains(t, h.DialedAddrs(), "sum.golang.org:443",
+					"the CONNECT tunnel must still route through the mock override for hermeticity")
+				assert.False(t, h.Registry.Requested("sum.golang.org", "/lookup/example.com/demo@v1.0.0"),
+					"a MITM'd request would reach the registry; sum.golang.org must stay an opaque tunnel")
+				assert.Empty(t, h.Analyzer.Calls())
 			},
 		},
 	})

--- a/test/proxye2e/proxye2e_test.go
+++ b/test/proxye2e/proxye2e_test.go
@@ -1336,7 +1336,7 @@ func TestProxyFlow_GoChecksumDatabaseStaysTunneled(t *testing.T) {
 				assert.Contains(t, h.DialedAddrs(), "sum.golang.org:443",
 					"the CONNECT tunnel must still route through the mock override for hermeticity")
 				assert.False(t, h.Registry.Requested("sum.golang.org", "/lookup/example.com/demo@v1.0.0"),
-					"a MITM'd request would reach the registry; sum.golang.org must stay an opaque tunnel")
+					"a MITM'd request would reach the registry. sum.golang.org must stay an opaque tunnel")
 				assert.Empty(t, h.Analyzer.Calls())
 			},
 		},

--- a/test/proxye2e/proxye2e_test.go
+++ b/test/proxye2e/proxye2e_test.go
@@ -36,7 +36,7 @@ func combineConfig(fns ...func(rc *config.RuntimeConfig)) func(rc *config.Runtim
 
 // customRegistry appends one proxy.registries entry. Combine several with
 // combineConfig to model multiple registries sharing a host.
-func customRegistry(name, ecosystem string, endpointURLs ...string) func(rc *config.RuntimeConfig) {
+func customRegistry(name string, ecosystem config.ProxyRegistryEcosystem, endpointURLs ...string) func(rc *config.RuntimeConfig) {
 	endpoints := make([]config.ProxyRegistryEndpointConfig, len(endpointURLs))
 	for i, u := range endpointURLs {
 		endpoints[i] = config.ProxyRegistryEndpointConfig{URL: u}


### PR DESCRIPTION
## Summary

Follow-up to #408: two fixes, one new doctor check, two refactors, and a documentation rewrite. No behavior change for valid configurations except the new rejection of reserved Go hosts.

## Fixes

- **Reject custom endpoints on reserved Go hosts.** `NewRegistryCatalog` now rejects an endpoint on `proxy.golang.org` or `sum.golang.org` (including subdomains) with the same `InvalidProxyRegistries` error as the built-in npm/PyPI overlap. A custom endpoint there decrypted Go module traffic, including the checksum database that `docs/proxy-mode.md` states PMG never MITMs. When PMG grows built-in Go registry endpoints, `proxy.golang.org` moves into that built-in set and the guard keeps covering `sum.golang.org`.
- **Close the template-defaults trap.** `loadViperConfig` unmarshals into a zero `Config` with the embedded template as the only default source, so a future field with a non-zero Go default that is missing from the template would silently load as zero. `TestTemplateMatchesDefaults` now walks the whole struct by reflection and asserts every non-empty Go default appears in the template.

## New

- **`pmg setup doctor` reports custom registry state.** A config load error fails the check (installs and `pmg proxy start` fail closed until the file is repaired), plain-HTTP endpoints warn with their URLs, and valid HTTPS endpoints pass with a count. Both conditions were previously visible only in logs, which the daemon hides. The check flows into `setup info --json` and `setup doctor --json` through the shared status report.

## Refactors

- **One ecosystem table.** A typed `config.ProxyRegistryEcosystem` and one `proxyEcosystems` spec table in the interceptor layer replace the `"npm"`/`"pypi"` literals scattered across the validation check, the `registryEcosystem` panic-switch, `customRegistryParser`, and the built-in catalog map. A new ecosystem is now one constant, one table entry, and its parser. A test pins the table to `config.ProxyRegistryEcosystems()`.
- **One normalization pass.** `NormalizeProxyRegistries` validates `proxy.registries` and returns the normalized endpoint model. The catalog consumes that model instead of re-running `registryurl.Normalize` per endpoint, which also removes the unreachable invalid-port branch.
- **One registry request flow.** The identical `HandleRequest` bodies in the npm and PyPI interceptors move into a shared `handleRegistryRequest`, and an embedded `registryRequestMatcher` provides `ShouldMITM`/`ShouldIntercept`. Each interceptor keeps only its ecosystem-specific artifact and metadata handlers. `baseRegistryInterceptor`'s placeholder `Name`/`ShouldIntercept`/`HandleRequest` are deleted: every embedder overrides them.
- Small cleanups: `builtInForHostname` becomes `builtInCoversHostname` returning a bool, and `IsKnownRegistryRequest` documents why it is a separate matching semantic from `MatchConnect` and `MatchURL`.

## Docs

- Rewrote the Custom Registries section of `docs/proxy-mode.md` and the daemon note in `docs/persistent-proxy.md` in Simplified Technical English: one idea per sentence, active voice, the fail-open contract stated once instead of three times. Documents the reserved Go host rejection and the doctor check.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./... -count=1` pass, including the hermetic proxy E2E suite. New tests: reserved Go host rejection (catalog), ecosystem table/config sync, the doctor check table test, and the exhaustive template-defaults walk. Existing E2E cases pass unmodified, which pins that the refactors preserve behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNXf6yZ54MEzJhWsrHh9gd

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNXf6yZ54MEzJhWsrHh9gd)_