### PR TITLE
fix(mdm): trust safedep/tap pmg cask before brew operations

### DIFF
--- a/scripts/mdm/README.md
+++ b/scripts/mdm/README.md
@@ -193,6 +193,7 @@ Only the active GUI user can receive Keychain credentials during a run. Use a re
 
 ## Limitations
 
+- The scripts run `brew trust --cask safedep/tap/pmg` before brew operations. Homebrew 6+ refuses to load items from untrusted taps, and versioned casks like `pmg@edge` cannot self-trust through a fully qualified install. The trust is item-scoped, not whole-tap.
 - Installing PMG's MITM CA into the trust store (`pmg setup cert install`) is not supported via MDM on macOS. Adding a trusted root to the login keychain requires interactive authorization from the user's GUI session, which an MDM deployment cannot supply. Have each user run `pmg setup cert install` in their own session when they need it (only needed for tools that ignore the proxy's CA environment variables, such as Go on macOS).
 - The scripts can access only the active GUI user's Keychain. Inactive users' credentials remain. Complete their manual logout before the policy removes PMG.
 - Machine-scope steps under a non-root invocation need `sudo`. Without passwordless sudo in a non-interactive context, they fail with an error instead of hanging.

--- a/scripts/mdm/pmg_setup_install_macos.sh
+++ b/scripts/mdm/pmg_setup_install_macos.sh
@@ -77,7 +77,7 @@ install_via_brew() {
   if run_brew "$brew_bin" ls --cask --versions pmg &>/dev/null; then
     run_brew "$brew_bin" upgrade --cask safedep/tap/pmg || true
   else
-    run_brew "$brew_bin" install safedep/tap/pmg
+    run_brew "$brew_bin" install --cask safedep/tap/pmg
   fi
 }
 

--- a/scripts/mdm/pmg_setup_install_macos.sh
+++ b/scripts/mdm/pmg_setup_install_macos.sh
@@ -65,6 +65,9 @@ load_embedded_cloud_credentials || exit 1
 install_via_brew() {
   local brew_bin="$1"
   log "Installing/updating pmg via Homebrew"
+  # Homebrew 6+ refuses to load items from untrusted taps. Trust the pmg cask
+  # (item-scoped, idempotent) so ls/upgrade/install work on fresh machines.
+  run_brew "$brew_bin" trust --cask safedep/tap/pmg || true
   # Remove a legacy formula install (pmg was a formula before the tap migrated
   # it to a cask) so its binary link does not conflict with the cask install.
   if run_brew "$brew_bin" ls --versions pmg &>/dev/null; then
@@ -74,7 +77,7 @@ install_via_brew() {
   if run_brew "$brew_bin" ls --cask --versions pmg &>/dev/null; then
     run_brew "$brew_bin" upgrade --cask safedep/tap/pmg || true
   else
-    run_brew "$brew_bin" install --cask safedep/tap/pmg
+    run_brew "$brew_bin" install safedep/tap/pmg
   fi
 }
 

--- a/scripts/mdm/pmg_uninstall_macos.sh
+++ b/scripts/mdm/pmg_uninstall_macos.sh
@@ -50,6 +50,9 @@ done < <(each_target_user)
 remove_binary() {
   local brew_bin
   if brew_bin=$(find_brew); then
+    # Homebrew 6+ refuses to load items from untrusted taps. Trust the pmg
+    # cask (item-scoped, idempotent) so ls/uninstall work on fresh machines.
+    run_brew "$brew_bin" trust --cask safedep/tap/pmg || true
     # Remove a legacy formula install (pmg was a formula before the tap
     # migrated it to a cask); skipping it leaves a broken brew state behind.
     if run_brew "$brew_bin" ls --versions pmg &>/dev/null; then

--- a/scripts/mdm/standalone/pmg_setup_install_macos_standalone.sh
+++ b/scripts/mdm/standalone/pmg_setup_install_macos_standalone.sh
@@ -229,7 +229,7 @@ install_via_brew() {
   if run_brew "$brew_bin" ls --cask --versions pmg &>/dev/null; then
     run_brew "$brew_bin" upgrade --cask safedep/tap/pmg || true
   else
-    run_brew "$brew_bin" install safedep/tap/pmg
+    run_brew "$brew_bin" install --cask safedep/tap/pmg
   fi
 }
 

--- a/scripts/mdm/standalone/pmg_setup_install_macos_standalone.sh
+++ b/scripts/mdm/standalone/pmg_setup_install_macos_standalone.sh
@@ -217,6 +217,9 @@ load_embedded_cloud_credentials || exit 1
 install_via_brew() {
   local brew_bin="$1"
   log "Installing/updating pmg via Homebrew"
+  # Homebrew 6+ refuses to load items from untrusted taps. Trust the pmg cask
+  # (item-scoped, idempotent) so ls/upgrade/install work on fresh machines.
+  run_brew "$brew_bin" trust --cask safedep/tap/pmg || true
   # Remove a legacy formula install (pmg was a formula before the tap migrated
   # it to a cask) so its binary link does not conflict with the cask install.
   if run_brew "$brew_bin" ls --versions pmg &>/dev/null; then
@@ -226,7 +229,7 @@ install_via_brew() {
   if run_brew "$brew_bin" ls --cask --versions pmg &>/dev/null; then
     run_brew "$brew_bin" upgrade --cask safedep/tap/pmg || true
   else
-    run_brew "$brew_bin" install --cask safedep/tap/pmg
+    run_brew "$brew_bin" install safedep/tap/pmg
   fi
 }
 

--- a/scripts/mdm/standalone/pmg_uninstall_macos_standalone.sh
+++ b/scripts/mdm/standalone/pmg_uninstall_macos_standalone.sh
@@ -203,6 +203,9 @@ done < <(each_target_user)
 remove_binary() {
   local brew_bin
   if brew_bin=$(find_brew); then
+    # Homebrew 6+ refuses to load items from untrusted taps. Trust the pmg
+    # cask (item-scoped, idempotent) so ls/uninstall work on fresh machines.
+    run_brew "$brew_bin" trust --cask safedep/tap/pmg || true
     # Remove a legacy formula install (pmg was a formula before the tap
     # migrated it to a cask); skipping it leaves a broken brew state behind.
     if run_brew "$brew_bin" ls --versions pmg &>/dev/null; then


### PR DESCRIPTION
Homebrew 6.0+ refuses to load items from untrusted taps. The MDM scripts' brew calls (ls/upgrade/install/uninstall) fail on machines where safedep/tap was never trusted, including versioned casks like pmg@edge which cannot self-trust via a fully qualified install.

Adds an idempotent, item-scoped 'brew trust --cask safedep/tap/pmg' before the brew operations in both the installer and uninstaller, plus a README Limitations note.