### PR TITLE
chore(ci): remove the need-analysis label step from issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,10 +4,9 @@ on:
   issues:
     types: [opened]
 
-# Minimal permissions - only what's needed to add a label.
+# The workflow does not use the default token.
 # Project access is handled by ISSUE_TRIAGE_GITHUB_TOKEN secret.
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   triage:
@@ -19,14 +18,3 @@ jobs:
         with:
           project-url: https://github.com/orgs/safedep/projects/5
           github-token: ${{ secrets.ISSUE_TRIAGE_GITHUB_TOKEN }}
-
-      - name: Add need-analysis label
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['need-analysis']
-            });


### PR DESCRIPTION
## What

The issue triage workflow put the `need-analysis` label on each new issue. This removes that step.

The workflow keeps the step that adds the issue to the SafeDep Operations project.

## Permissions

The label step was the only user of the default `GITHUB_TOKEN`, so the workflow permissions go to none.

`permissions: {}` is an explicit grant of nothing. If you remove the key, GitHub falls back to the repo or org default, which can be read and write for all scopes. The project step uses the `ISSUE_TRIAGE_GITHUB_TOKEN` secret, so the default token needs no scope.

## Notes

This changes new issues only. Issues that already carry `need-analysis` keep the label, and the label stays in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)