### PR TITLE
fix(cloud): log the check-in skip and success

### DIFF
--- a/internal/audit/check_in_test.go
+++ b/internal/audit/check_in_test.go
@@ -1,10 +1,12 @@
 package audit
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
+	drylog "github.com/safedep/dry/log"
 	"github.com/safedep/pmg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,5 +68,20 @@ func TestCheckInWithRateLimit(t *testing.T) {
 		assert.Equal(t, codes.Unavailable, status.Code(err))
 		require.NoError(t, checkInWithRateLimit(ctx, cfg, checkIn))
 		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("logs the check-in and the rate-limited skip", func(t *testing.T) {
+		var logs bytes.Buffer
+		restore := drylog.SwapGlobalForTest(&logs)
+		defer restore()
+
+		cfg := newCheckInConfig(t)
+		checkIn := func(context.Context) error { return nil }
+
+		require.NoError(t, checkInWithRateLimit(ctx, cfg, checkIn))
+		assert.Contains(t, logs.String(), "cloud check-in sent")
+
+		require.NoError(t, checkInWithRateLimit(ctx, cfg, checkIn))
+		assert.Contains(t, logs.String(), "cloud check-in skipped")
 	})
 }

--- a/internal/audit/cloud_client.go
+++ b/internal/audit/cloud_client.go
@@ -98,15 +98,25 @@ func (b *SyncClientBundle) CheckIn(ctx context.Context) error {
 // cloud-sync.lastrun, the file records every attempt, so a failing endpoint
 // or an old server does not retry on every sync.
 func checkInWithRateLimit(ctx context.Context, cfg *config.RuntimeConfig, checkIn func(context.Context) error) error {
-	if !SyncCooldownElapsed(cfg.CloudCheckInLastRunPath(), cfg.Config.Cloud.AutoSync.MinInterval) {
+	lastRunPath := cfg.CloudCheckInLastRunPath()
+	minInterval := cfg.Config.Cloud.AutoSync.MinInterval
+
+	if !SyncCooldownElapsed(lastRunPath, minInterval) {
+		log.Debugf("cloud check-in skipped: last attempt %s ago, min interval %s",
+			time.Since(ReadLastSyncAttempt(lastRunPath)).Round(time.Second), minInterval)
 		return nil
 	}
 
-	if err := WriteLastSyncAttempt(cfg.CloudCheckInLastRunPath()); err != nil {
+	if err := WriteLastSyncAttempt(lastRunPath); err != nil {
 		return fmt.Errorf("update check-in lastrun: %w", err)
 	}
 
-	return checkIn(ctx)
+	if err := checkIn(ctx); err != nil {
+		return err
+	}
+
+	log.Debugf("cloud check-in sent")
+	return nil
 }
 
 func (b *SyncClientBundle) Close() error {


### PR DESCRIPTION
Closes #429

The check-in printed nothing in the logs, so a skip & a success looked the same. To know what happened, you had to open `cloud-checkin.lastrun` & read it by hand

**Changes:**

Two debug logs in `checkInWithRateLimit`:

```
cloud check-in skipped: last attempt 7m0s ago, min interval 15m0s
cloud check-in sent
```

The test covers both

**Notes:**

- The RPC failure is not logged here. Both callers already log it with `log.Warnf`
- The lastrun stamp stays before the RPC. It records every attempt on purpose, so a down endpoint does not retry on every run
- I did not add a separate success timestamp. That needs a new file in the config directory, so I left the call to you. It would also show when a check-in last worked, which the skip log does not