### PR TITLE
fix(acceptance): pin cloud endpoint id for hosted runners

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -42,6 +42,9 @@ jobs:
       SAFEDEP_API_KEY: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
       SAFEDEP_TENANT_ID: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN }}
       PMG_CLOUD_ENABLED: "true"
+      # All hosted runners share one stable endpoint. Without this each
+      # ephemeral runner registers a new endpoint on every acceptance run.
+      PMG_CLOUD_ENDPOINT_ID: "gh:${{ github.repository }}"
     defaults:
       run:
         shell: bash

--- a/test/acceptance/acceptance_test.go
+++ b/test/acceptance/acceptance_test.go
@@ -131,13 +131,14 @@ func selectorFromEnv() Selector {
 	return sel
 }
 
-// forwardCloudCredentials copies the SafeDep Cloud credential variables set in
-// the host environment into the testscript environment, so cloud-category scripts
-// reach the authenticated analyzer. testscript does not forward host env, so
-// community-category scripts (which never call this) keep their unauthenticated
-// community path.
+// forwardCloudCredentials copies the SafeDep Cloud env vars from the host into
+// the testscript environment. testscript does not forward host env. Cloud-category
+// scripts need these to reach the authenticated analyzer. PMG_CLOUD_ENDPOINT_ID
+// gives every hosted runner one stable endpoint identity. Without it each
+// ephemeral runner registers a new endpoint. Community-category scripts never
+// call this, so they keep their unauthenticated community path.
 func forwardCloudCredentials(env *testscript.Env) {
-	for _, key := range []string{"SAFEDEP_API_KEY", "SAFEDEP_TENANT_ID", "PMG_CLOUD_ENABLED"} {
+	for _, key := range []string{"SAFEDEP_API_KEY", "SAFEDEP_TENANT_ID", "PMG_CLOUD_ENABLED", "PMG_CLOUD_ENDPOINT_ID"} {
 		if v, ok := os.LookupEnv(key); ok && v != "" {
 			env.Setenv(key, v)
 		}


### PR DESCRIPTION
## Problem

The authenticated acceptance suite registers a new SafeDep Cloud endpoint on every run. The tenant fills with throwaway `runnervm*` endpoints, one per hosted runner.

Root cause: the suite runs the real `pmg` binary through `testscript`. `testscript` builds a clean environment from a hardcoded allowlist and does not forward `GITHUB_*` vars. So `pmg` cannot detect CI. The CI-identity convention in `defaultCIEndpointID()` needs `GITHUB_ACTIONS` and `GITHUB_RUN_ID`, which are absent. `pmg` falls back to the host machine id. Each ephemeral runner has a new hostname, so each run makes a new endpoint.

## Fix

Set `PMG_CLOUD_ENDPOINT_ID` to `gh:<repo>` in the workflow. Forward the var through `testscript`. `pmg` maps it to `cloud.endpoint_id`. The sync client derives a stable machine id from it. All hosted runners now sync as one endpoint.

This matches the exact value the convention would produce. It does not depend on the CI-detection heuristic firing inside the sandboxed subprocess.

## Why not forward the GITHUB_* vars

Forwarding `GITHUB_ACTIONS`, `GITHUB_RUN_ID`, `RUNNER_ENVIRONMENT`, and `GITHUB_REPOSITORY` also works, but it couples the fix to the detection heuristic and adds four vars. The explicit `endpoint_id` is the documented override. It is one var and it cannot fall through to the machine id.

The tradeoff: the synced events carry no CI context (branch, actor, PR, sha), because the resolver still returns nil. The acceptance scripts test malware blocking, not endpoint metadata, so this is acceptable.

## Notes

- Existing `runnervm*` endpoints stay. This fix only stops new ones. Delete the old ones in the tenant UI once.
- `AutomaticEnv` is off under config lockdown. Hosted runners have no locked managed config, so the override applies.