### PR TITLE
Fix goreleaser tag selection for dual stable/edge releases

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -72,6 +72,10 @@ jobs:
         run: pnpm nx run pmg:build-release
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          # Without this goreleaser picks the current tag from the tags that
+          # point at HEAD. A stable tag and an edge tag on the same commit then
+          # release the edge tag twice.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Attest Go binary provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0


### PR DESCRIPTION
Goreleaser was selecting the wrong tag when both a stable and edge tag pointed to the same commit, causing the edge tag to be released twice.

This change explicitly sets `GORELEASER_CURRENT_TAG` to the current git ref name in the release workflow. This ensures goreleaser uses the intended tag for the release instead of picking arbitrarily from multiple tags at HEAD.

**Key changes:**
- Set `GORELEASER_CURRENT_TAG` environment variable to `${{ github.ref_name }}` in the goreleaser build step
- Added explanatory comment documenting the issue and solution

https://claude.ai/code/session_01WSpa55vJ4rFTfxTV2WokDT