### PR TITLE
ci(release): wait for the platform package before the smoke test

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -112,12 +112,18 @@ jobs:
 
       - name: Wait for package on registry
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
+          # The registry makes the wrapper and the platform packages visible in
+          # any order, so wait for the platform package this runner needs too.
+          plat=$(node -p "process.platform + '-' + process.arch")
           for i in $(seq 1 20); do
-            npm view "@safedep/pmg@${{ steps.version.outputs.version }}" version > /dev/null 2>&1 && break
-            echo "Waiting... ($i/20)"
+            npm view "@safedep/pmg@${VERSION}" version > /dev/null 2>&1 \
+              && npm view "@safedep/pmg-${plat}@${VERSION}" version > /dev/null 2>&1 && break
+            echo "Waiting for @safedep/pmg and @safedep/pmg-${plat} at ${VERSION}... ($i/20)"
             sleep 30
-            [ "$i" -eq 20 ] && echo "Package not available after 10 minutes" && exit 1
+            [ "$i" -eq 20 ] && echo "Packages not available after 10 minutes" && exit 1
           done
 
       - name: Install


### PR DESCRIPTION
All four macOS install tests failed on the `v0.28.1` release run ([attempt 1](https://github.com/safedep/pmg/actions/runs/33775574208/attempts/1)). `pmg version` could not find its platform binary:

```
Expected platform package: @safedep/pmg-darwin-arm64
Cannot find module '@safedep/pmg-darwin-arm64/package.json'
```

## Cause

A race with the npm registry. The release job published all six packages in the right order, and all six landed. The registry then made them visible out of order.

| Time (UTC) | Event |
| --- | --- |
| 15:59:58 | `pnpm publish` reports `pmg-darwin-arm64` published |
| 16:00:27 | `pnpm publish` reports the wrapper `@safedep/pmg` published |
| 16:01:22 | registry makes the wrapper resolvable |
| 16:01:45 | `Wait for package on registry` sees the wrapper and exits the loop |
| 16:01:46 | `npm install -g` reports `added 1 package`, then the smoke test fails |
| 16:04:10 | registry makes `pmg-darwin-arm64` resolvable, 3 minutes late |

Two things combine:

1. The gate polls only the wrapper. npm publishes the platform packages first, but a visible wrapper does not prove that the platform packages resolve.
2. npm treats a missing `optionalDependencies` entry as non-fatal. The `Install` step passed and hid the real problem.

Only macOS failed, because `macos-latest` is arm64 and `darwin-arm64` was the package that lagged. `darwin-x64` was visible at 16:00:05.

A re-run of the same tag passed with no code change, so `v0.28.1` on npm is correct.

## Change

The gate now also waits for the platform package that the runner needs. `node -p "process.platform + '-' + process.arch"` returns `darwin-arm64`, `linux-x64`, or `win32-x64`, which match the package names under `packages/`. `node` is on the path already, because `Set up Node` is the first step in the job.

The version now goes through an `env:` variable instead of an expression inside the script.