### PR TITLE
chore(goreleaser): drop deprecated homebrew cask url.verified

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,8 +63,6 @@ homebrew_casks:
     license: "Apache-2.0"
     binaries:
       - pmg
-    url:
-      verified: github.com/safedep/pmg
     hooks:
       post:
         install: |


### PR DESCRIPTION
Hi! This removes the deprecated `verified` parameter from the homebrew cask `url` in `.goreleaser.yaml`.

## What users see

Every `brew install`/`brew upgrade` that touches the `pmg` cask prints two deprecation warnings to users:

```
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
```

This PR fixes the **first** one. Homebrew now verifies the download host automatically, and since the cask `url` points at `github.com/safedep/pmg/...` releases, the default verification already covers it. Dropping `url.verified` is a no-op behaviourally — Homebrew accepts `verified` only for backward compatibility (it's in `DEPRECATED_URL_SPECS` in `cask/url.rb`).

## About the second warning (`postflight`)

The `postflight` warning comes from GoReleaser's cask generator, which always renders the `hooks.post.install` hook as a `postflight do` block — there is currently no config knob in `.goreleaser.yaml` to make it emit `postflight_steps`. So that half needs to be fixed upstream in GoReleaser's `homebrew_casks` cask template. I left the post-install hook (the macOS `xattr -dr com.apple.quarantine`) untouched — only removed the redundant `verified` line.

No functional change to the generated cask; this just stops one of the two warnings.