### PR TITLE
fix(sandbox): fail closed when the Landlock supervisor cannot read memory

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -485,15 +485,16 @@ descendant (grandchildren, great-grandchildren, etc.):
    reset `dumpable` to 0, so the helper can keep opening `/proc/<pid>/mem` for any
    descendant. Deny rules like `~/.ssh` are enforced for the full process tree.
 
-**Fail closed when memory is unreadable**: the supervisor probes `/proc/<child>/mem` at
-startup and refuses to run if it cannot read it, so a host that blocks the read (a `hidepid`
-proc mount, `kernel.yama.ptrace_scope=3`, or a hardening LSM) fails to start rather than
-enforce nothing. It does not fall back to Bubblewrap; Bubblewrap may not be installed. At
-runtime, a trapped path or exec syscall whose memory the supervisor cannot read is **denied**,
-not allowed, so a process cannot slip a path past the deny list by blinding the supervisor to
-its own memory with `prctl(PR_SET_DUMPABLE, 0)`. A hardening tool that sets `dumpable=0`
-(gpg-agent, ssh-agent) therefore loses file access on the Landlock driver; run it under the
-Bubblewrap driver, which enforces at the mount layer with no memory read.
+**Fail closed when memory is unreadable**: the supervisor reads `/proc/<child>/mem` at
+startup. If it cannot read it, the run stops. So a host that blocks the read stops the run
+instead of running with no enforcement. Examples are a `hidepid` proc mount,
+`kernel.yama.ptrace_scope=3`, and a hardening LSM. PMG does not fall back to Bubblewrap here.
+Bubblewrap may not be installed. At runtime the supervisor denies a trapped path or exec
+syscall when it cannot read the memory that holds the path. So a process cannot read a denied
+file by making its own memory unreadable with `prctl(PR_SET_DUMPABLE, 0)`. A tool that sets
+`dumpable=0`, such as gpg-agent or ssh-agent, loses file access on the Landlock driver. Run it
+under the Bubblewrap driver. Bubblewrap enforces at the mount layer and does not read process
+memory.
 
 The user namespace is purely a capability vehicle. Host uid/gid are preserved through the
 mapping, so targets see the same filesystem ownership they normally would. Tools that

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -485,6 +485,16 @@ descendant (grandchildren, great-grandchildren, etc.):
    reset `dumpable` to 0, so the helper can keep opening `/proc/<pid>/mem` for any
    descendant. Deny rules like `~/.ssh` are enforced for the full process tree.
 
+**Fail closed when memory is unreadable**: the supervisor probes `/proc/<child>/mem` at
+startup and refuses to run if it cannot read it, so a host that blocks the read (a `hidepid`
+proc mount, `kernel.yama.ptrace_scope=3`, or a hardening LSM) fails to start rather than
+enforce nothing. It does not fall back to Bubblewrap; Bubblewrap may not be installed. At
+runtime, a trapped path or exec syscall whose memory the supervisor cannot read is **denied**,
+not allowed, so a process cannot slip a path past the deny list by blinding the supervisor to
+its own memory with `prctl(PR_SET_DUMPABLE, 0)`. A hardening tool that sets `dumpable=0`
+(gpg-agent, ssh-agent) therefore loses file access on the Landlock driver; run it under the
+Bubblewrap driver, which enforces at the mount layer with no memory read.
+
 The user namespace is purely a capability vehicle. Host uid/gid are preserved through the
 mapping, so targets see the same filesystem ownership they normally would. Tools that
 refuse to run as root (npm's root-in-container warning) are unaffected because the

--- a/sandbox/platform/landlock_diagnostics_linux.go
+++ b/sandbox/platform/landlock_diagnostics_linux.go
@@ -163,6 +163,12 @@ func landlockDenyKey(e auditEvent) string {
 }
 
 func landlockViolationKind(e auditEvent) sandbox.ViolationKind {
+	// The supervisor could not read the target, so the direction and the path
+	// are unknown. Report a generic deny, not a read or a write.
+	if e.Unverifiable {
+		return sandbox.ViolationKindGenericDeny
+	}
+
 	switch e.Syscall {
 	case "execve", "execveat":
 		return sandbox.ViolationKindExec

--- a/sandbox/platform/landlock_diagnostics_linux_test.go
+++ b/sandbox/platform/landlock_diagnostics_linux_test.go
@@ -415,4 +415,9 @@ func TestLandlockViolationKind_PathSyscalls(t *testing.T) {
 			assert.Equal(t, tc.want, landlockViolationKind(auditEvent{Syscall: tc.syscall, Access: tc.access}))
 		})
 	}
+
+	// An unverifiable openat is a generic deny, not a write. The supervisor
+	// could not read the path, so the direction is unknown.
+	assert.Equal(t, sandbox.ViolationKindGenericDeny,
+		landlockViolationKind(auditEvent{Syscall: "openat", Unverifiable: true}))
 }

--- a/sandbox/platform/landlock_e2e_linux_test.go
+++ b/sandbox/platform/landlock_e2e_linux_test.go
@@ -657,6 +657,61 @@ func TestLandlockHelper_DenyBlocksMoveLinkAndSymlink(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "nothing moved into the protected directory")
 }
 
+// A process that blinds the supervisor to its own memory with
+// prctl(PR_SET_DUMPABLE, 0) must not thereby read a denied file. The
+// supervisor cannot read the path of the trapped openat, so it fails closed.
+func TestLandlockHelper_DumpableZeroFailsClosed(t *testing.T) {
+	if !landlockE2EEnabled() {
+		t.Skip("PMG_LANDLOCK_E2E not set; skipping landlock e2e (requires AppArmor disabled / unprivileged-userns sysctl)")
+	}
+	if _, err := landlockDetectABI(); err != nil {
+		t.Skipf("Landlock not available: %v", err)
+	}
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not found")
+	}
+
+	home := t.TempDir()
+	home, err = filepath.EvalSymlinks(home)
+	require.NoError(t, err)
+	const secret = "DUMPABLE-SECRET"
+	secretPath := filepath.Join(home, ".env")
+	require.NoError(t, os.WriteFile(secretPath, []byte(secret), 0o600))
+
+	// PR_SET_DUMPABLE = 4. Set dumpable=0, then read the denied file. The
+	// read must fail whether the supervisor loses the memory read (fail
+	// closed) or keeps it and matches the deny by path. Either way, no leak.
+	script := `import ctypes, os
+libc = ctypes.CDLL(None, use_errno=True)
+print('DUMPABLE_SET' if libc.prctl(4, 0, 0, 0, 0) == 0 else 'PRCTL_FAILED')
+try:
+    data = open(` + strconv.Quote(secretPath) + `).read()
+    print('LEAK:' + data)
+except OSError:
+    print('DENIED')
+`
+
+	policy := &landlockExecPolicy{
+		FilesystemRules: append(baseRules(),
+			landlockPathRule{Path: home, Access: landlockRuleReadExec},
+		),
+		DenyPaths: []denyPathEntry{
+			{Path: secretPath, Mode: denyBoth},
+		},
+		SkipPIDNamespace: true,
+		SkipIPCNamespace: true,
+		Command:          python,
+		Args:             []string{"-c", script},
+	}
+	policyPath := writePolicyFile(t, policy)
+
+	stdout, stderr, _ := runHelper(t, policyPath)
+	assert.Contains(t, stdout, "DUMPABLE_SET", "stdout=%q stderr=%q", stdout, stderr)
+	assert.Contains(t, stdout, "DENIED", "the read after dumpable=0 must be denied; stdout=%q stderr=%q", stdout, stderr)
+	assert.NotContains(t, stdout+stderr, secret, "the denied file must not leak")
+}
+
 // Landlock does not hook chroot and root in the user namespace keeps
 // CAP_SYS_CHROOT. Only the supervisor stops "chroot(project); open(/.env)".
 func TestLandlockHelper_DenyBlocksChroot(t *testing.T) {

--- a/sandbox/platform/landlock_e2e_linux_test.go
+++ b/sandbox/platform/landlock_e2e_linux_test.go
@@ -657,9 +657,9 @@ func TestLandlockHelper_DenyBlocksMoveLinkAndSymlink(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "nothing moved into the protected directory")
 }
 
-// A process that blinds the supervisor to its own memory with
-// prctl(PR_SET_DUMPABLE, 0) must not thereby read a denied file. The
-// supervisor cannot read the path of the trapped openat, so it fails closed.
+// A process must not read a denied file by making its own memory unreadable
+// with prctl(PR_SET_DUMPABLE, 0). The supervisor cannot read the path of the
+// trapped openat, so it denies the read.
 func TestLandlockHelper_DumpableZeroFailsClosed(t *testing.T) {
 	if !landlockE2EEnabled() {
 		t.Skip("PMG_LANDLOCK_E2E not set; skipping landlock e2e (requires AppArmor disabled / unprivileged-userns sysctl)")
@@ -679,9 +679,10 @@ func TestLandlockHelper_DumpableZeroFailsClosed(t *testing.T) {
 	secretPath := filepath.Join(home, ".env")
 	require.NoError(t, os.WriteFile(secretPath, []byte(secret), 0o600))
 
-	// PR_SET_DUMPABLE = 4. Set dumpable=0, then read the denied file. The
-	// read must fail whether the supervisor loses the memory read (fail
-	// closed) or keeps it and matches the deny by path. Either way, no leak.
+	// PR_SET_DUMPABLE = 4. Set dumpable=0, then read the denied file. The read
+	// fails two ways. The supervisor loses the memory read and denies it. Or
+	// the supervisor keeps the read and matches the deny by path. No leak
+	// either way.
 	script := `import ctypes, os
 libc = ctypes.CDLL(None, use_errno=True)
 print('DUMPABLE_SET' if libc.prctl(4, 0, 0, 0, 0) == 0 else 'PRCTL_FAILED')

--- a/sandbox/platform/landlock_seccomp_linux.go
+++ b/sandbox/platform/landlock_seccomp_linux.go
@@ -460,6 +460,32 @@ func (s *seccompSupervisor) loop() {
 	}
 }
 
+// denyUnverifiable denies a trapped syscall whose target the supervisor
+// could not read or resolve. A process that blinds the supervisor to its own
+// memory (prctl(PR_SET_DUMPABLE, 0), or a dead or recycled task) must not
+// thereby slip a path or an exec past the deny list. This matches
+// handleConnect, which already fails closed on an unreadable sockaddr under
+// lockdown. A hardening tool that sets dumpable=0 (gpg-agent, ssh-agent)
+// loses file access on the Landlock driver as a result; the Bubblewrap driver
+// enforces at the mount layer and is not affected.
+func (s *seccompSupervisor) denyUnverifiable(notif *seccompNotification, phase *seccompPhase, reason string) {
+	name := syscallName(notif.Data.Nr)
+	if phase.auditWriter != nil {
+		if err := landlockWriteAuditEvent(phase.auditWriter, auditEvent{
+			Type:    auditSeccompDeny,
+			Syscall: name,
+			Access:  reason,
+			Comm:    procComm(notif.PID),
+			PID:     int(notif.PID),
+			Ts:      time.Now().UnixNano(),
+		}); err != nil {
+			log.Warnf("sandbox: failed to record a denial: %v", err)
+		}
+	}
+	traceSeccompDecision("deny %s pid=%d reason=%s", name, notif.PID, reason)
+	s.deny(notif.ID)
+}
+
 func (s *seccompSupervisor) handleExec(notif *seccompNotification, phase *seccompPhase) {
 	// For execve: args[0] is filename pointer.
 	// For execveat: args[0] is dirfd, args[1] is filename pointer.
@@ -476,23 +502,23 @@ func (s *seccompSupervisor) handleExec(notif *seccompNotification, phase *seccom
 
 	memFd := phase.memFdFor(notif.PID)
 	if memFd == nil {
-		// Process gone or /proc/<pid>/mem unreadable — fail-closed would
-		// kill the process; fail-open to avoid breaking legit flows.
-		s.continueSyscall(notif.ID)
+		// Unreadable process memory. The startup probe proved the supervisor
+		// can read the child, so this is a self-blinded (dumpable=0) or dead
+		// task, not a hostile host. Fail closed. See denyUnverifiable.
+		s.denyUnverifiable(notif, phase, "unreadable process memory")
 		return
 	}
 	defer closeMemFd(memFd)
 
 	rawPath, err := readPathFromMem(memFd, pathAddr)
 	if err != nil {
-		// Cannot read memory (EIO, ESRCH) — process may have died. Continue.
-		s.continueSyscall(notif.ID)
+		s.denyUnverifiable(notif, phase, "unreadable exec path")
 		return
 	}
 
 	resolved, err := resolveNotifPath(notif.PID, dirfd, rawPath, true)
 	if err != nil {
-		s.continueSyscall(notif.ID)
+		s.denyUnverifiable(notif, phase, "unresolvable exec path")
 		return
 	}
 

--- a/sandbox/platform/landlock_seccomp_linux.go
+++ b/sandbox/platform/landlock_seccomp_linux.go
@@ -102,7 +102,11 @@ type auditEvent struct {
 	PID      int            `json:"pid,omitempty"`
 	Message  string         `json:"message,omitempty"`
 	Error    string         `json:"error,omitempty"`
-	Ts       int64          `json:"ts"`
+	// Unverifiable marks a deny the supervisor could not evaluate because it
+	// could not read the target. The diagnostics report it as a generic deny,
+	// not a read or a write, since the direction and the path are unknown.
+	Unverifiable bool  `json:"unverifiable,omitempty"`
+	Ts           int64 `json:"ts"`
 }
 
 // writeAuditEvent JSON-encodes an audit event and writes it as a single line to w.
@@ -475,13 +479,14 @@ func (s *seccompSupervisor) denyUnverifiable(notif *seccompNotification, phase *
 		// label for open events, and the diagnostics classify the violation
 		// by it. Path holds a placeholder because the real path is unknown.
 		if err := landlockWriteAuditEvent(phase.auditWriter, auditEvent{
-			Type:    auditSeccompDeny,
-			Syscall: name,
-			Path:    "<unverifiable>",
-			Message: reason,
-			Comm:    procComm(notif.PID),
-			PID:     int(notif.PID),
-			Ts:      time.Now().UnixNano(),
+			Type:         auditSeccompDeny,
+			Syscall:      name,
+			Path:         "<unverifiable>",
+			Message:      reason,
+			Unverifiable: true,
+			Comm:         procComm(notif.PID),
+			PID:          int(notif.PID),
+			Ts:           time.Now().UnixNano(),
 		}); err != nil {
 			log.Warnf("sandbox: failed to record a denial: %v", err)
 		}

--- a/sandbox/platform/landlock_seccomp_linux.go
+++ b/sandbox/platform/landlock_seccomp_linux.go
@@ -471,10 +471,14 @@ func (s *seccompSupervisor) loop() {
 func (s *seccompSupervisor) denyUnverifiable(notif *seccompNotification, phase *seccompPhase, reason string) {
 	name := syscallName(notif.Data.Nr)
 	if phase.auditWriter != nil {
+		// The reason goes in Message, not Access. Access is the read or write
+		// label for open events, and the diagnostics classify the violation
+		// by it. Path holds a placeholder because the real path is unknown.
 		if err := landlockWriteAuditEvent(phase.auditWriter, auditEvent{
 			Type:    auditSeccompDeny,
 			Syscall: name,
-			Access:  reason,
+			Path:    "<unverifiable>",
+			Message: reason,
 			Comm:    procComm(notif.PID),
 			PID:     int(notif.PID),
 			Ts:      time.Now().UnixNano(),

--- a/sandbox/platform/landlock_seccomp_linux.go
+++ b/sandbox/platform/landlock_seccomp_linux.go
@@ -460,14 +460,14 @@ func (s *seccompSupervisor) loop() {
 	}
 }
 
-// denyUnverifiable denies a trapped syscall whose target the supervisor
-// could not read or resolve. A process that blinds the supervisor to its own
-// memory (prctl(PR_SET_DUMPABLE, 0), or a dead or recycled task) must not
-// thereby slip a path or an exec past the deny list. This matches
-// handleConnect, which already fails closed on an unreadable sockaddr under
-// lockdown. A hardening tool that sets dumpable=0 (gpg-agent, ssh-agent)
-// loses file access on the Landlock driver as a result; the Bubblewrap driver
-// enforces at the mount layer and is not affected.
+// denyUnverifiable denies a trapped syscall when the supervisor cannot read
+// or resolve its target. A process must not read or write a denied path by
+// making its own memory unreadable with prctl(PR_SET_DUMPABLE, 0). A dead or
+// recycled task also reaches this path. handleConnect already denies an
+// unreadable sockaddr under lockdown. This does the same for a path or an
+// exec. A tool that sets dumpable=0, such as gpg-agent or ssh-agent, loses
+// file access on the Landlock driver. The Bubblewrap driver enforces at the
+// mount layer and is not affected.
 func (s *seccompSupervisor) denyUnverifiable(notif *seccompNotification, phase *seccompPhase, reason string) {
 	name := syscallName(notif.Data.Nr)
 	if phase.auditWriter != nil {
@@ -502,9 +502,9 @@ func (s *seccompSupervisor) handleExec(notif *seccompNotification, phase *seccom
 
 	memFd := phase.memFdFor(notif.PID)
 	if memFd == nil {
-		// Unreadable process memory. The startup probe proved the supervisor
-		// can read the child, so this is a self-blinded (dumpable=0) or dead
-		// task, not a hostile host. Fail closed. See denyUnverifiable.
+		// The supervisor cannot read the memory. The startup probe proved it
+		// can read the child, so the task made itself unreadable (dumpable=0)
+		// or died. Deny it. See denyUnverifiable.
 		s.denyUnverifiable(notif, phase, "unreadable process memory")
 		return
 	}

--- a/sandbox/platform/landlock_seccomp_path_linux.go
+++ b/sandbox/platform/landlock_seccomp_path_linux.go
@@ -410,9 +410,9 @@ func (s *seccompSupervisor) resolveOperand(notif *seccompNotification, memFd *os
 func (s *seccompSupervisor) handlePathOp(notif *seccompNotification, phase *seccompPhase, op pathSyscall) {
 	memFd := phase.memFdFor(notif.PID)
 	if memFd == nil {
-		// Unreadable process memory (self-blinded dumpable=0, or a dead task).
-		// Fail closed so a process cannot slip a path past the deny list by
-		// making its own memory unreadable. See denyUnverifiable.
+		// The supervisor cannot read the memory that holds the path. Deny it
+		// so a process cannot read a denied path by making its own memory
+		// unreadable. See denyUnverifiable.
 		s.denyUnverifiable(notif, phase, "unreadable process memory")
 		return
 	}

--- a/sandbox/platform/landlock_seccomp_path_linux.go
+++ b/sandbox/platform/landlock_seccomp_path_linux.go
@@ -410,8 +410,10 @@ func (s *seccompSupervisor) resolveOperand(notif *seccompNotification, memFd *os
 func (s *seccompSupervisor) handlePathOp(notif *seccompNotification, phase *seccompPhase, op pathSyscall) {
 	memFd := phase.memFdFor(notif.PID)
 	if memFd == nil {
-		// Unreadable after an execve that cleared dumpable. See docs/sandbox.md.
-		s.continueSyscall(notif.ID)
+		// Unreadable process memory (self-blinded dumpable=0, or a dead task).
+		// Fail closed so a process cannot slip a path past the deny list by
+		// making its own memory unreadable. See denyUnverifiable.
+		s.denyUnverifiable(notif, phase, "unreadable process memory")
 		return
 	}
 	defer closeMemFd(memFd)
@@ -424,7 +426,7 @@ func (s *seccompSupervisor) handlePathOp(notif *seccompNotification, phase *secc
 
 	src, err := s.resolveOperand(notif, memFd, op.src, followsLeaf(op, op.src, flags), args.resolve)
 	if err != nil {
-		s.continueSyscall(notif.ID)
+		s.denyUnverifiable(notif, phase, "unresolvable path")
 		return
 	}
 
@@ -446,7 +448,7 @@ func (s *seccompSupervisor) handlePathOp(notif *seccompNotification, phase *secc
 	case pathOpRename, pathOpLink:
 		dst, err := s.resolveOperand(notif, memFd, op.dst, followsLeaf(op, op.dst, flags), args.resolve)
 		if err != nil {
-			s.continueSyscall(notif.ID)
+			s.denyUnverifiable(notif, phase, "unresolvable rename or link target")
 			return
 		}
 		exchange := op.kind == pathOpRename && flags&unix.RENAME_EXCHANGE != 0


### PR DESCRIPTION
## What

On the Linux Landlock driver, the seccomp supervisor resolves a trapped path or exec syscall by reading the target's `/proc/<pid>/mem`. When that read failed, `handleExec` and `handlePathOp` continued the syscall (fail open). A process could read or write a denied path by blinding the supervisor to its own memory with `prctl(PR_SET_DUMPABLE, 0)` right before the call.

Both handlers now deny an unverifiable syscall, matching `handleConnect`, which already fails closed on an unreadable sockaddr under lockdown. The startup probe already proves the supervisor can read the child, so an unreadable state at notification time is a self-blinded or dead task, not a hostile host.

## Why it is safe

- The startup child-memory probe (already in `main`) refuses to run when `/proc/<child>/mem` is unreadable, so a hostile host (`hidepid`, `kernel.yama.ptrace_scope=3`, a hardening LSM) fails to start rather than enforce nothing. No Bubblewrap fallback; Bubblewrap may not be installed.
- At runtime, a nil memory read means the process blinded itself or died. Denying that syscall closes the bypass and is harmless for a dead task.

## Trade-off

A hardening tool that sets `dumpable=0` (gpg-agent, ssh-agent) loses file access on the Landlock driver. The Bubblewrap driver enforces at the mount layer with no memory read and is not affected. Documented in `docs/sandbox.md`.

## Tests

A Landlock e2e case sets `dumpable=0` and reads a denied file, asserting it never leaks. It catches the vulnerability on kernels where `dumpable=0` blocks the supervisor's read and stays correct where it does not.

Tracked as FOU-272. Follow-up to the sandbox-exec red-team review of #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CExG6rA1iReWHygFmiv5ba

---
_Generated by [Claude Code](https://claude.ai/code/session_01CExG6rA1iReWHygFmiv5ba)_