### PR TITLE
ci: run the full test suite on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
     timeout-minutes: 15
     runs-on: windows-latest
     steps:
+      # Git for Windows converts text files to CRLF on checkout. Tests that
+      # compare an embedded template against a literal then fail.
+      - name: Keep LF line endings
+        run: git config --global core.autocrlf false
+
       - name: Checkout Source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -77,11 +82,13 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # The sandbox is not supported on Windows. Its packages are excluded
+      # rather than tagged file by file.
       - name: Build and Test
         run: |
           go mod tidy
           go build -o pmg.exe main.go
-          go test -count=1 -v ./...
+          go test -count=1 -v $(go list ./... | Where-Object { $_ -notmatch '/sandbox' })
 
   e2e-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           go mod tidy
           go build -o pmg.exe main.go
-          go test -v ./internal/flows/...
+          go test -count=1 -v ./...
 
   e2e-test:
     runs-on: ubuntu-latest

--- a/cmd/setup/doctor_test.go
+++ b/cmd/setup/doctor_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/safedep/pmg/config"
@@ -138,26 +137,6 @@ func TestCheckEventLogDirResult(t *testing.T) {
 	t.Run("writable directory passes", func(t *testing.T) {
 		result := checkEventLogDirResult(false, t.TempDir(), configDir)
 		assert.Equal(t, doctor.StatusPass, result.Status)
-	})
-
-	t.Run("unwritable directory fails with triaged remedy", func(t *testing.T) {
-		if os.Geteuid() == 0 {
-			t.Skip("running as root: directory permissions are not enforced")
-		}
-		if runtime.GOOS == "windows" {
-			t.Skip("os.Chmod does not make a directory unwritable on Windows")
-		}
-		dir := t.TempDir()
-		require.NoError(t, os.Chmod(dir, 0o555))
-		t.Cleanup(func() {
-			require.NoError(t, os.Chmod(dir, 0o755))
-		})
-
-		result := checkEventLogDirResult(false, dir, configDir)
-		assert.Equal(t, doctor.StatusFail, result.Status)
-		assert.Equal(t, "Event log directory not writable", result.Message)
-		_, expectedFix := config.UnwritableConfigDirRemedy(configDir)
-		assert.Equal(t, expectedFix, result.Fix)
 	})
 }
 

--- a/cmd/setup/doctor_test.go
+++ b/cmd/setup/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/safedep/pmg/config"
@@ -142,6 +143,9 @@ func TestCheckEventLogDirResult(t *testing.T) {
 	t.Run("unwritable directory fails with triaged remedy", func(t *testing.T) {
 		if os.Geteuid() == 0 {
 			t.Skip("running as root: directory permissions are not enforced")
+		}
+		if runtime.GOOS == "windows" {
+			t.Skip("os.Chmod does not make a directory unwritable on Windows")
 		}
 		dir := t.TempDir()
 		require.NoError(t, os.Chmod(dir, 0o555))

--- a/cmd/setup/doctor_unix_test.go
+++ b/cmd/setup/doctor_unix_test.go
@@ -1,0 +1,33 @@
+//go:build unix
+
+package setup
+
+import (
+	"os"
+	"testing"
+
+	"github.com/safedep/pmg/config"
+	"github.com/safedep/pmg/internal/doctor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// os.Chmod cannot make a directory unwritable on Windows, so the probe
+// succeeds there and the failure path never runs.
+func TestCheckEventLogDirResultUnwritable(t *testing.T) {
+	configDir := "/home/dev/.config/safedep/pmg"
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: directory permissions are not enforced")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o555))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chmod(dir, 0o755))
+	})
+
+	result := checkEventLogDirResult(false, dir, configDir)
+	assert.Equal(t, doctor.StatusFail, result.Status)
+	assert.Equal(t, "Event log directory not writable", result.Message)
+	_, expectedFix := config.UnwritableConfigDirRemedy(configDir)
+	assert.Equal(t, expectedFix, result.Fix)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,7 @@ func TestConfigHasDefaultValues(t *testing.T) {
 		assert.Equal(t, false, config.Config.Paranoid)
 		assert.Len(t, config.Config.TrustedPackages, 1)
 		assert.Equal(t, "/tmp/pmg-test/random-does-not-exist", config.configDir)
-		assert.Equal(t, "/tmp/pmg-test/random-does-not-exist/config.yml", config.configFilePath)
+		assert.Equal(t, filepath.Join("/tmp/pmg-test/random-does-not-exist", "config.yml"), config.configFilePath)
 		assert.Equal(t, false, config.Config.Proxy.InstallOnly)
 	})
 

--- a/config/rootdir_test.go
+++ b/config/rootdir_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package config
 
 import (

--- a/config/sandbox_allow_test.go
+++ b/config/sandbox_allow_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package config
 
 import (

--- a/internal/alias/alias_test.go
+++ b/internal/alias/alias_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package alias
 
 import (

--- a/internal/alias/shells_test.go
+++ b/internal/alias/shells_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package alias
 
 import (

--- a/internal/audit/cloud_sink_test.go
+++ b/internal/audit/cloud_sink_test.go
@@ -459,6 +459,9 @@ func TestInvokingUserKeepsSudoAttributionWithoutPasswdEntry(t *testing.T) {
 
 func TestCloudSinkCapturesExecCommand(t *testing.T) {
 	sink, _ := newTestCloudSink(t)
+	// Windows cannot delete the sqlite file while the emitter holds it open,
+	// and t.TempDir cleanup fails on that.
+	defer func() { require.NoError(t, sink.Close()) }()
 
 	err := sink.Handle(context.Background(), AuditEvent{
 		Type:           EventTypeExecStarted,

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -181,6 +181,11 @@ func TestPrependPath(t *testing.T) {
 }
 
 func TestCheckShimScripts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// CheckShimScripts reads the executable bit, which Windows does not
+		// have. The Windows form of the shim-directory check owns this.
+		t.Skip("executable bit is Unix only")
+	}
 	tmpDir := t.TempDir()
 	shimDir := filepath.Join(tmpDir, ".pmg", "bin")
 	require.NoError(t, os.MkdirAll(shimDir, 0o755))

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -116,7 +117,8 @@ func TestResolveProtectionBinary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			binDir := t.TempDir()
 			for _, name := range tt.available {
-				require.NoError(t, os.WriteFile(filepath.Join(binDir, name), []byte("#!/bin/sh\n"), 0o755))
+				// LookPath on Windows needs a PATHEXT extension to find a file.
+				require.NoError(t, os.WriteFile(filepath.Join(binDir, name+exeSuffix()), []byte("#!/bin/sh\n"), 0o755))
 			}
 			t.Setenv("PATH", binDir)
 
@@ -140,38 +142,6 @@ func TestRunProtectionCheckReportsAllCandidatesWhenNoneAvailable(t *testing.T) {
 	result := RunProtectionCheck(tc, "pmg")
 	assert.Equal(t, StatusWarn, result.Status)
 	assert.Contains(t, result.Message, "pip/pip3 not available")
-}
-
-func TestRunProtectionCheckUsesVenvPipWhenNoSystemPip(t *testing.T) {
-	realPython, err := exec.LookPath("python3")
-	if err != nil {
-		t.Skip("python3 not available")
-	}
-
-	binDir := t.TempDir()
-	require.NoError(t, os.Symlink(realPython, filepath.Join(binDir, "python3")))
-
-	argvFile := filepath.Join(t.TempDir(), "argv.txt")
-	pmgStub := filepath.Join(binDir, "pmg-stub")
-	stub := fmt.Sprintf("#!/bin/sh\necho \"$@\" > %s\necho '%s'\nexit 1\n", argvFile, ui.MalwareBlockedHeadline)
-	require.NoError(t, os.WriteFile(pmgStub, []byte(stub), 0o755))
-
-	t.Setenv("PATH", binDir)
-
-	var pipCase ProtectionTestCase
-	for _, tc := range ProtectionTestCases() {
-		if tc.PackageManager == "pip" {
-			pipCase = tc
-		}
-	}
-	require.True(t, pipCase.NeedsVenv)
-
-	result := RunProtectionCheck(pipCase, pmgStub)
-	assert.Equal(t, StatusPass, result.Status)
-
-	argv, err := os.ReadFile(argvFile)
-	require.NoError(t, err)
-	assert.Equal(t, "pip install --no-cache-dir safedep-test-pkg==0.0.4", strings.TrimSpace(string(argv)))
 }
 
 func TestProtectionTestCases(t *testing.T) {
@@ -210,20 +180,6 @@ func TestPrependPath(t *testing.T) {
 	assert.Equal(t, "TERM=xterm", result[2])
 }
 
-func TestSetupVenv(t *testing.T) {
-	if _, err := exec.LookPath("python3"); err != nil {
-		t.Skip("python3 not available")
-	}
-
-	tmpDir := t.TempDir()
-	venvDir, err := setupVenv(tmpDir)
-	require.NoError(t, err)
-
-	pipPath := filepath.Join(venvDir, "bin", "pip")
-	_, err = os.Stat(pipPath)
-	assert.NoError(t, err)
-}
-
 func TestCheckShimScripts(t *testing.T) {
 	tmpDir := t.TempDir()
 	shimDir := filepath.Join(tmpDir, ".pmg", "bin")
@@ -235,4 +191,11 @@ func TestCheckShimScripts(t *testing.T) {
 	found, missing := CheckShimScripts(shimDir, []string{"npm", "pip"})
 	assert.Equal(t, []string{"npm"}, found)
 	assert.Equal(t, []string{"pip"}, missing)
+}
+
+func exeSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
 }

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -180,24 +180,6 @@ func TestPrependPath(t *testing.T) {
 	assert.Equal(t, "TERM=xterm", result[2])
 }
 
-func TestCheckShimScripts(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// CheckShimScripts reads the executable bit, which Windows does not
-		// have. The Windows form of the shim-directory check owns this.
-		t.Skip("executable bit is Unix only")
-	}
-	tmpDir := t.TempDir()
-	shimDir := filepath.Join(tmpDir, ".pmg", "bin")
-	require.NoError(t, os.MkdirAll(shimDir, 0o755))
-
-	shimPath := filepath.Join(shimDir, "npm")
-	require.NoError(t, os.WriteFile(shimPath, []byte("#!/bin/sh\nexec pmg npm \"$@\""), 0o755))
-
-	found, missing := CheckShimScripts(shimDir, []string{"npm", "pip"})
-	assert.Equal(t, []string{"npm"}, found)
-	assert.Equal(t, []string{"pip"}, missing)
-}
-
 func exeSuffix() string {
 	if runtime.GOOS == "windows" {
 		return ".exe"

--- a/internal/doctor/checks_unix_test.go
+++ b/internal/doctor/checks_unix_test.go
@@ -65,3 +65,18 @@ func TestSetupVenv(t *testing.T) {
 	_, err = os.Stat(pipPath)
 	assert.NoError(t, err)
 }
+
+// CheckShimScripts reads the executable bit, which Windows does not have.
+// The Windows form of the shim-directory check owns that case.
+func TestCheckShimScripts(t *testing.T) {
+	tmpDir := t.TempDir()
+	shimDir := filepath.Join(tmpDir, ".pmg", "bin")
+	require.NoError(t, os.MkdirAll(shimDir, 0o755))
+
+	shimPath := filepath.Join(shimDir, "npm")
+	require.NoError(t, os.WriteFile(shimPath, []byte("#!/bin/sh\nexec pmg npm \"$@\""), 0o755))
+
+	found, missing := CheckShimScripts(shimDir, []string{"npm", "pip"})
+	assert.Equal(t, []string{"npm"}, found)
+	assert.Equal(t, []string{"pip"}, missing)
+}

--- a/internal/doctor/checks_unix_test.go
+++ b/internal/doctor/checks_unix_test.go
@@ -1,0 +1,67 @@
+//go:build unix
+
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/safedep/pmg/internal/ui"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The pmg stub is a #!/bin/sh script and python3 is reached through a
+// symlink. Neither runs on Windows.
+func TestRunProtectionCheckUsesVenvPipWhenNoSystemPip(t *testing.T) {
+	realPython, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	binDir := t.TempDir()
+	require.NoError(t, os.Symlink(realPython, filepath.Join(binDir, "python3")))
+
+	argvFile := filepath.Join(t.TempDir(), "argv.txt")
+	pmgStub := filepath.Join(binDir, "pmg-stub")
+	stub := fmt.Sprintf("#!/bin/sh\necho \"$@\" > %s\necho '%s'\nexit 1\n", argvFile, ui.MalwareBlockedHeadline)
+	require.NoError(t, os.WriteFile(pmgStub, []byte(stub), 0o755))
+
+	t.Setenv("PATH", binDir)
+
+	var pipCase ProtectionTestCase
+	for _, tc := range ProtectionTestCases() {
+		if tc.PackageManager == "pip" {
+			pipCase = tc
+		}
+	}
+	require.True(t, pipCase.NeedsVenv)
+
+	result := RunProtectionCheck(pipCase, pmgStub)
+	assert.Equal(t, StatusPass, result.Status)
+
+	argv, err := os.ReadFile(argvFile)
+	require.NoError(t, err)
+	assert.Equal(t, "pip install --no-cache-dir safedep-test-pkg==0.0.4", strings.TrimSpace(string(argv)))
+}
+
+// A Windows venv puts pip.exe under Scripts\, not bin/. setupVenv does not
+// handle that layout, and the pip protection check on Windows is outside the
+// Windows support spec.
+func TestSetupVenv(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	tmpDir := t.TempDir()
+	venvDir, err := setupVenv(tmpDir)
+	require.NoError(t, err)
+
+	pipPath := filepath.Join(venvDir, "bin", "pip")
+	_, err = os.Stat(pipPath)
+	assert.NoError(t, err)
+}

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -16,7 +16,7 @@ func TestGetDefaultLogDir(t *testing.T) {
 	assert.NoError(t, err, "failed to get default log directory")
 
 	assert.NotEmpty(t, logDir, "log directory should not be empty")
-	assert.Contains(t, logDir, "safedep/pmg/logs")
+	assert.Contains(t, logDir, filepath.Join("safedep", "pmg", "logs"))
 }
 
 func TestLoggerInitialization(t *testing.T) {

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -3,6 +3,7 @@ package fsutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,6 +48,10 @@ func TestMkdirAllRootOwnedLeavesExistingDirsAlone(t *testing.T) {
 
 	require.NoError(t, MkdirAllRootOwned(filepath.Join(existing, "created"), 0o755))
 
+	if runtime.GOOS == "windows" {
+		// Windows has no Unix permission bits to preserve.
+		return
+	}
 	info, err := os.Stat(existing)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -3,7 +3,6 @@ package fsutil
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,21 +38,4 @@ func TestMkdirAllRootOwnedRejectsFileCollision(t *testing.T) {
 
 	assert.Error(t, MkdirAllRootOwned(blocker, 0o755))
 	assert.Error(t, MkdirAllRootOwned(filepath.Join(blocker, "sub"), 0o755))
-}
-
-func TestMkdirAllRootOwnedLeavesExistingDirsAlone(t *testing.T) {
-	root := t.TempDir()
-	existing := filepath.Join(root, "existing")
-	require.NoError(t, os.Mkdir(existing, 0o700))
-
-	require.NoError(t, MkdirAllRootOwned(filepath.Join(existing, "created"), 0o755))
-
-	if runtime.GOOS == "windows" {
-		// Windows has no Unix permission bits to preserve.
-		return
-	}
-	info, err := os.Stat(existing)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
-		"pre-existing directory permissions must not be changed")
 }

--- a/internal/fsutil/fsutil_unix_test.go
+++ b/internal/fsutil/fsutil_unix_test.go
@@ -1,0 +1,26 @@
+//go:build unix
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Windows has no Unix permission bits to preserve.
+func TestMkdirAllRootOwnedLeavesExistingDirsAlone(t *testing.T) {
+	root := t.TempDir()
+	existing := filepath.Join(root, "existing")
+	require.NoError(t, os.Mkdir(existing, 0o700))
+
+	require.NoError(t, MkdirAllRootOwned(filepath.Join(existing, "created"), 0o755))
+
+	info, err := os.Stat(existing)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
+		"pre-existing directory permissions must not be changed")
+}

--- a/internal/proxyserver/state_test.go
+++ b/internal/proxyserver/state_test.go
@@ -3,7 +3,6 @@ package proxyserver
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,17 +46,6 @@ func TestRemoveState(t *testing.T) {
 
 	_, err := os.Stat(path)
 	assert.True(t, os.IsNotExist(err))
-}
-
-func TestIsRunningCurrentProcess(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// IsRunning probes with Signal(0), which Windows does not support.
-		// The daemon is not supported on Windows, and its liveness check is
-		// its own issue.
-		t.Skip("Signal(0) liveness probe is Unix only")
-	}
-	s := State{PID: os.Getpid(), Addr: "127.0.0.1:1"}
-	assert.True(t, s.IsRunning())
 }
 
 func TestIsRunningDeadPID(t *testing.T) {

--- a/internal/proxyserver/state_test.go
+++ b/internal/proxyserver/state_test.go
@@ -3,6 +3,7 @@ package proxyserver
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,12 @@ func TestRemoveState(t *testing.T) {
 }
 
 func TestIsRunningCurrentProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// IsRunning probes with Signal(0), which Windows does not support.
+		// The daemon is not supported on Windows, and its liveness check is
+		// its own issue.
+		t.Skip("Signal(0) liveness probe is Unix only")
+	}
 	s := State{PID: os.Getpid(), Addr: "127.0.0.1:1"}
 	assert.True(t, s.IsRunning())
 }
@@ -59,7 +66,7 @@ func TestIsRunningDeadPID(t *testing.T) {
 }
 
 func TestStateFilePath(t *testing.T) {
-	assert.Equal(t, "/some/dir/proxy-state.json", stateFilePath("/some/dir"))
+	assert.Equal(t, filepath.Join("/some/dir", "proxy-state.json"), stateFilePath("/some/dir"))
 }
 
 func TestResolveStatePath(t *testing.T) {

--- a/internal/proxyserver/state_unix_test.go
+++ b/internal/proxyserver/state_unix_test.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package proxyserver
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// IsRunning probes with Signal(0), which Windows does not support. The
+// daemon is not supported on Windows, and its liveness check is its own
+// issue.
+func TestIsRunningCurrentProcess(t *testing.T) {
+	s := State{PID: os.Getpid(), Addr: "127.0.0.1:1"}
+	assert.True(t, s.IsRunning())
+}

--- a/internal/runner/childexit_test.go
+++ b/internal/runner/childexit_test.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"errors"
 	"os/exec"
-	"runtime"
 	"testing"
 
 	"github.com/safedep/dry/usefulerror"
@@ -14,28 +13,6 @@ import (
 )
 
 func TestExtractExit(t *testing.T) {
-	t.Run("direct non-zero exit resolves the real code", func(t *testing.T) {
-		requireSh(t)
-		err := exec.Command("sh", "-c", "exit 2").Run()
-		require.Error(t, err)
-
-		code, signaled, resolved := extractExit(err)
-		assert.Equal(t, 2, code)
-		assert.False(t, signaled)
-		assert.True(t, resolved)
-	})
-
-	t.Run("direct signal termination resolves to 128+signum", func(t *testing.T) {
-		requireSh(t)
-		err := exec.Command("sh", "-c", "kill -INT $$").Run()
-		require.Error(t, err)
-
-		code, signaled, resolved := extractExit(err)
-		assert.Equal(t, 130, code) // 128 + SIGINT(2)
-		assert.True(t, signaled)
-		assert.True(t, resolved)
-	})
-
 	t.Run("pty exit error reads its fields directly", func(t *testing.T) {
 		code, signaled, resolved := extractExit(&pty.ExitError{Code: 1})
 		assert.Equal(t, 1, code)
@@ -112,12 +89,4 @@ func TestClassifyTransparentChildExit(t *testing.T) {
 	require.True(t, errors.As(err, &ce))
 	assert.Equal(t, 1, ce.ExitCode())
 	assert.Equal(t, "npm", ce.PMName)
-}
-
-// requireSh skips a case that drives sh and Unix signals.
-func requireSh(t *testing.T) {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("needs sh and Unix exit semantics")
-	}
 }

--- a/internal/runner/childexit_test.go
+++ b/internal/runner/childexit_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"errors"
 	"os/exec"
+	"runtime"
 	"testing"
 
 	"github.com/safedep/dry/usefulerror"
@@ -14,6 +15,7 @@ import (
 
 func TestExtractExit(t *testing.T) {
 	t.Run("direct non-zero exit resolves the real code", func(t *testing.T) {
+		requireSh(t)
 		err := exec.Command("sh", "-c", "exit 2").Run()
 		require.Error(t, err)
 
@@ -24,6 +26,7 @@ func TestExtractExit(t *testing.T) {
 	})
 
 	t.Run("direct signal termination resolves to 128+signum", func(t *testing.T) {
+		requireSh(t)
 		err := exec.Command("sh", "-c", "kill -INT $$").Run()
 		require.Error(t, err)
 
@@ -109,4 +112,12 @@ func TestClassifyTransparentChildExit(t *testing.T) {
 	require.True(t, errors.As(err, &ce))
 	assert.Equal(t, 1, ce.ExitCode())
 	assert.Equal(t, "npm", ce.PMName)
+}
+
+// requireSh skips a case that drives sh and Unix signals.
+func requireSh(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("needs sh and Unix exit semantics")
+	}
 }

--- a/internal/runner/childexit_unix_test.go
+++ b/internal/runner/childexit_unix_test.go
@@ -1,0 +1,35 @@
+//go:build unix
+
+package runner
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A real child exit through sh, including a signal death, which has no
+// Windows equivalent.
+func TestExtractExitFromChild(t *testing.T) {
+	t.Run("direct non-zero exit resolves the real code", func(t *testing.T) {
+		err := exec.Command("sh", "-c", "exit 2").Run()
+		require.Error(t, err)
+
+		code, signaled, resolved := extractExit(err)
+		assert.Equal(t, 2, code)
+		assert.False(t, signaled)
+		assert.True(t, resolved)
+	})
+
+	t.Run("direct signal termination resolves to 128+signum", func(t *testing.T) {
+		err := exec.Command("sh", "-c", "kill -INT $$").Run()
+		require.Error(t, err)
+
+		code, signaled, resolved := extractExit(err)
+		assert.Equal(t, 130, code) // 128 + SIGINT(2)
+		assert.True(t, signaled)
+		assert.True(t, resolved)
+	})
+}

--- a/internal/shim/path_unix_test.go
+++ b/internal/shim/path_unix_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package shim
 
 import (

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -14,64 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShimManagerInstall(t *testing.T) {
-	homeDir := t.TempDir()
-	binDir := filepath.Join(homeDir, ".pmg", "bin")
-
-	bashrc := filepath.Join(homeDir, ".bashrc")
-	zshrc := filepath.Join(homeDir, ".zshrc")
-	fishConfig := filepath.Join(homeDir, ".config", "fish")
-	require.NoError(t, os.MkdirAll(fishConfig, 0o755))
-	require.NoError(t, os.WriteFile(bashrc, []byte("# existing bashrc\n"), 0o644))
-	require.NoError(t, os.WriteFile(zshrc, []byte("# existing zshrc\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(fishConfig, "config.fish"), []byte("# existing fish config\n"), 0o644))
-
-	pms := []string{"npm", "pip"}
-	pmgBin := filepath.Join(homeDir, "bin", "pmg")
-	shells := []alias.Shell{
-		&stubShell{name: "bash", path: ".bashrc", useFish: false},
-		&stubShell{name: "fish", path: ".config/fish/config.fish", useFish: true},
-	}
-
-	mgr := NewShimManager(ShimConfig{
-		BinDir:          binDir,
-		HomeDir:         homeDir,
-		PMGBin:          pmgBin,
-		PackageManagers: pms,
-		Shells:          shells,
-	})
-
-	require.NoError(t, mgr.Install())
-
-	for _, pm := range pms {
-		shimPath := filepath.Join(binDir, pm)
-		info, err := os.Stat(shimPath)
-		require.NoError(t, err, "shim %s should exist", pm)
-		if runtime.GOOS != "windows" {
-			assert.NotZero(t, info.Mode()&0o111, "shim %s should be executable", pm)
-		}
-
-		content, err := os.ReadFile(shimPath)
-		require.NoError(t, err)
-		assert.Contains(t, string(content), "#!/bin/sh")
-		assert.Contains(t, string(content), "PMG_BIN='"+pmgBin+"'")
-		assert.Contains(t, string(content), `exec "$PMG_BIN" `+pm+` "$@"`)
-		assert.Contains(t, string(content), `PMG_SHIM_PATH=$(cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")`)
-		assert.Contains(t, string(content), "export PMG_SHIM_PATH")
-		assert.NotContains(t, string(content), "command -v pmg")
-		assert.NotContains(t, string(content), "exec pmg")
-		assert.NotContains(t, string(content), "falling back to native")
-	}
-
-	bashContent, err := os.ReadFile(bashrc)
-	require.NoError(t, err)
-	assert.Contains(t, string(bashContent), binDir)
-
-	fishContent, err := os.ReadFile(filepath.Join(fishConfig, "config.fish"))
-	require.NoError(t, err)
-	assert.Contains(t, string(fishContent), binDir)
-}
-
 func TestShimManagerInstallIdempotent(t *testing.T) {
 	homeDir := t.TempDir()
 	binDir := filepath.Join(homeDir, ".pmg", "bin")

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -47,7 +47,9 @@ func TestShimManagerInstall(t *testing.T) {
 		shimPath := filepath.Join(binDir, pm)
 		info, err := os.Stat(shimPath)
 		require.NoError(t, err, "shim %s should exist", pm)
-		assert.NotZero(t, info.Mode()&0o111, "shim %s should be executable", pm)
+		if runtime.GOOS != "windows" {
+			assert.NotZero(t, info.Mode()&0o111, "shim %s should be executable", pm)
+		}
 
 		content, err := os.ReadFile(shimPath)
 		require.NoError(t, err)
@@ -63,23 +65,11 @@ func TestShimManagerInstall(t *testing.T) {
 
 	bashContent, err := os.ReadFile(bashrc)
 	require.NoError(t, err)
-	assert.Contains(t, string(bashContent), ".pmg/bin")
+	assert.Contains(t, string(bashContent), binDir)
 
 	fishContent, err := os.ReadFile(filepath.Join(fishConfig, "config.fish"))
 	require.NoError(t, err)
-	assert.Contains(t, string(fishContent), ".pmg/bin")
-}
-
-func TestShimManagerRemoveReturnsDirectoryError(t *testing.T) {
-	root := t.TempDir()
-	blocker := filepath.Join(root, "blocker")
-	require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o644))
-
-	mgr := NewShimManager(ShimConfig{
-		BinDir: filepath.Join(blocker, "bin"),
-	})
-
-	assert.Error(t, mgr.Remove())
+	assert.Contains(t, string(fishContent), binDir)
 }
 
 func TestShimManagerInstallIdempotent(t *testing.T) {
@@ -104,7 +94,7 @@ func TestShimManagerInstallIdempotent(t *testing.T) {
 
 	count := 0
 	for _, line := range strings.Split(string(content), "\n") {
-		if strings.Contains(line, ".pmg/bin") {
+		if strings.Contains(line, binDir) {
 			count++
 		}
 	}
@@ -133,7 +123,7 @@ func TestShimManagerRemove(t *testing.T) {
 
 	content, err := os.ReadFile(bashrc)
 	require.NoError(t, err)
-	assert.NotContains(t, string(content), ".pmg/bin")
+	assert.NotContains(t, string(content), binDir)
 }
 
 func TestShimManagerIsInstalled(t *testing.T) {
@@ -181,26 +171,6 @@ func TestNewDefaultShimManager(t *testing.T) {
 	assert.Contains(t, mgr.config.PackageManagers, "npm")
 	assert.Contains(t, mgr.config.PackageManagers, "pip")
 	assert.NotEmpty(t, mgr.config.Shells)
-}
-
-func TestShimManagerInstallEscapesPMGBin(t *testing.T) {
-	homeDir := t.TempDir()
-	binDir := filepath.Join(homeDir, ".pmg", "bin")
-	pmgBin := filepath.Join(homeDir, "PMG's bin", "pmg")
-
-	mgr := NewShimManager(ShimConfig{
-		BinDir:          binDir,
-		HomeDir:         homeDir,
-		PMGBin:          pmgBin,
-		PackageManagers: []string{"npm"},
-	})
-
-	require.NoError(t, mgr.Install())
-
-	content, err := os.ReadFile(filepath.Join(binDir, "npm"))
-	require.NoError(t, err)
-	assert.Contains(t, string(content), `PMG_BIN='`+homeDir+`/PMG'\''s bin/pmg'`)
-	assert.NotContains(t, string(content), "command -v pmg")
 }
 
 type stubShell struct {

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -222,7 +222,7 @@ func (s *stubShell) InstallRcFiles(homeDir string, create bool) ([]string, error
 
 func TestUserBinDirPrefersLegacyDirWithShims(t *testing.T) {
 	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
+	setHomeDir(t, homeDir)
 	t.Setenv("XDG_DATA_HOME", filepath.Join(homeDir, "xdg-data"))
 
 	legacyDir := filepath.Join(homeDir, legacyUserDirName, "bin")
@@ -238,7 +238,7 @@ func TestUserBinDirPrefersLegacyDirWithShims(t *testing.T) {
 func TestUserBinDirUsesDataDirWhenLegacyEmpty(t *testing.T) {
 	homeDir := t.TempDir()
 	dataHome := filepath.Join(homeDir, "xdg-data")
-	t.Setenv("HOME", homeDir)
+	setHomeDir(t, homeDir)
 	t.Setenv("XDG_DATA_HOME", dataHome)
 
 	// An empty legacy directory is not an install; a fresh setup must not
@@ -362,4 +362,14 @@ func TestPruneEmptyParentsIgnoresSystemDirs(t *testing.T) {
 	pruneEmptyParents(binDir, "")
 
 	assert.DirExists(t, filepath.Join(root, "usr", "local", "lib", "pmg"))
+}
+
+// setHomeDir points the home directory at dir. Windows reads USERPROFILE,
+// every other platform reads HOME.
+func setHomeDir(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", dir)
+	}
 }

--- a/internal/shim/shim_unix_test.go
+++ b/internal/shim/shim_unix_test.go
@@ -7,9 +7,68 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/safedep/pmg/internal/alias"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// The sh body, the executable bit and the rc-file PATH export are the Unix
+// half of the shim.
+func TestShimManagerInstall(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, ".pmg", "bin")
+
+	bashrc := filepath.Join(homeDir, ".bashrc")
+	zshrc := filepath.Join(homeDir, ".zshrc")
+	fishConfig := filepath.Join(homeDir, ".config", "fish")
+	require.NoError(t, os.MkdirAll(fishConfig, 0o755))
+	require.NoError(t, os.WriteFile(bashrc, []byte("# existing bashrc\n"), 0o644))
+	require.NoError(t, os.WriteFile(zshrc, []byte("# existing zshrc\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(fishConfig, "config.fish"), []byte("# existing fish config\n"), 0o644))
+
+	pms := []string{"npm", "pip"}
+	pmgBin := filepath.Join(homeDir, "bin", "pmg")
+	shells := []alias.Shell{
+		&stubShell{name: "bash", path: ".bashrc", useFish: false},
+		&stubShell{name: "fish", path: ".config/fish/config.fish", useFish: true},
+	}
+
+	mgr := NewShimManager(ShimConfig{
+		BinDir:          binDir,
+		HomeDir:         homeDir,
+		PMGBin:          pmgBin,
+		PackageManagers: pms,
+		Shells:          shells,
+	})
+
+	require.NoError(t, mgr.Install())
+
+	for _, pm := range pms {
+		shimPath := filepath.Join(binDir, pm)
+		info, err := os.Stat(shimPath)
+		require.NoError(t, err, "shim %s should exist", pm)
+		assert.NotZero(t, info.Mode()&0o111, "shim %s should be executable", pm)
+
+		content, err := os.ReadFile(shimPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "#!/bin/sh")
+		assert.Contains(t, string(content), "PMG_BIN='"+pmgBin+"'")
+		assert.Contains(t, string(content), `exec "$PMG_BIN" `+pm+` "$@"`)
+		assert.Contains(t, string(content), `PMG_SHIM_PATH=$(cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")`)
+		assert.Contains(t, string(content), "export PMG_SHIM_PATH")
+		assert.NotContains(t, string(content), "command -v pmg")
+		assert.NotContains(t, string(content), "exec pmg")
+		assert.NotContains(t, string(content), "falling back to native")
+	}
+
+	bashContent, err := os.ReadFile(bashrc)
+	require.NoError(t, err)
+	assert.Contains(t, string(bashContent), binDir)
+
+	fishContent, err := os.ReadFile(filepath.Join(fishConfig, "config.fish"))
+	require.NoError(t, err)
+	assert.Contains(t, string(fishContent), binDir)
+}
 
 // os.RemoveAll under a file parent returns nil on Windows, so this only
 // proves the error path on Unix.

--- a/internal/shim/shim_unix_test.go
+++ b/internal/shim/shim_unix_test.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// os.RemoveAll under a file parent returns nil on Windows, so this only
+// proves the error path on Unix.
+func TestShimManagerRemoveReturnsDirectoryError(t *testing.T) {
+	root := t.TempDir()
+	blocker := filepath.Join(root, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o644))
+
+	mgr := NewShimManager(ShimConfig{
+		BinDir: filepath.Join(blocker, "bin"),
+	})
+
+	assert.Error(t, mgr.Remove())
+}
+
+// The shim body single-quotes a POSIX path. A Windows shim has a different
+// body and its own test.
+func TestShimManagerInstallEscapesPMGBin(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, ".pmg", "bin")
+	pmgBin := filepath.Join(homeDir, "PMG's bin", "pmg")
+
+	mgr := NewShimManager(ShimConfig{
+		BinDir:          binDir,
+		HomeDir:         homeDir,
+		PMGBin:          pmgBin,
+		PackageManagers: []string{"npm"},
+	})
+
+	require.NoError(t, mgr.Install())
+
+	content, err := os.ReadFile(filepath.Join(binDir, "npm"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `PMG_BIN='`+homeDir+`/PMG'\''s bin/pmg'`)
+	assert.NotContains(t, string(content), "command -v pmg")
+}

--- a/internal/shim/system_unix_test.go
+++ b/internal/shim/system_unix_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package shim
 
 import (

--- a/proxy/certmanager/certmanager_test.go
+++ b/proxy/certmanager/certmanager_test.go
@@ -360,10 +360,10 @@ func TestSystemCABundleCandidatesForOS_WindowsIncludesCommonBundlePaths(t *testi
 	candidates := systemCABundleCandidatesForOS(goosWindows)
 	joined := strings.Join(candidates, "|")
 
-	assert.Contains(t, joined, `Git/mingw64/ssl/certs/ca-bundle.crt`)
-	assert.Contains(t, joined, `Git/usr/ssl/certs/ca-bundle.crt`)
-	assert.Contains(t, joined, `Git/mingw32/ssl/certs/ca-bundle.crt`)
-	assert.Contains(t, joined, `System32/curl-ca-bundle.crt`)
+	assert.Contains(t, joined, filepath.FromSlash("Git/mingw64/ssl/certs/ca-bundle.crt"))
+	assert.Contains(t, joined, filepath.FromSlash("Git/usr/ssl/certs/ca-bundle.crt"))
+	assert.Contains(t, joined, filepath.FromSlash("Git/mingw32/ssl/certs/ca-bundle.crt"))
+	assert.Contains(t, joined, filepath.FromSlash("System32/curl-ca-bundle.crt"))
 }
 
 func TestSystemCABundleCandidatesForOS_DarwinIncludesKnownBundlePaths(t *testing.T) {


### PR DESCRIPTION
## What this implements

Decision group 7 of [`2026-09-09-pmg-windows-support-design.md`](https://github.com/safedep/control-tower/blob/main/docs/specs/2026-09-09-pmg-windows-support-design.md): the `test-windows` job runs the full test suite in place of `go test ./internal/flows/...`.

## Why this is a useful standalone increment

The spec puts this first on purpose. Decision groups 3 and 5 are defects that a top-level test does not reach, so the harness must exist before those fixes land, or nothing in CI proves they work. `test/proxye2e` is in the widened set and passes on Windows. `test/acceptance` is not, because it sits behind the `acceptance` build tag and runs against production.

## Two deviations from the literal spec

1. **The sandbox packages are excluded.** The spec says `go test ./...`. The first Windows run failed every sandbox package (`sandbox`, `sandbox/executor`, `sandbox/util`, `sandbox/platform`, `cmd/sandbox`). The sandbox port is a spec non-goal, and the failures are in product code, not only in tests: the built-in profile loader opens `profiles\aube.yml` on an `embed.FS`, which needs `/`, and the mandatory deny globs come out as `**\.env`. The job runs `go list ./... | Where-Object { $_ -notmatch '/sandbox' }` rather than tagging about fifty test files one by one. Everything else runs: 45 packages.
2. **Checkout keeps LF.** Git for Windows converts text files to CRLF on checkout, and `TestTemplateHasCommentedRegistryExample` compares the embedded template against a literal. The job sets `core.autocrlf false` before checkout.

## Test triage

`GOOS=windows go vet ./...` already passed, so every test compiles. The runner found 14 failing packages. Each fix is one of two kinds, and no test was weakened or deleted.

**Platform-neutral fixes.** The test was wrong on Windows and is now right everywhere.

| File | Cause | Fix |
|---|---|---|
| `config`, `internal/eventlog`, `internal/proxyserver`, `proxy/certmanager` | Assertions spell a path with `/` | Build it with `filepath` |
| `internal/audit/cloud_sink_test.go` | The sink was never closed; Windows cannot delete an open sqlite file | Close the sink |
| `internal/shim/shim_test.go` | `.pmg/bin` literal vs `\`; `HOME` vs `USERPROFILE` | Compare against `binDir`; `setHomeDir` sets both |
| `internal/doctor/checks_test.go` | `LookPath` needs a `PATHEXT` extension | `.exe` suffix on Windows |

**File build tags.** The test encodes a Unix fact. It moves to a `_unix_test.go` file, or the file gets the `unix` tag. There is no inline `runtime.GOOS` check left in a shared test file, so the convention is uniform: a shared file runs on every platform, a `_unix_test.go` file runs on Unix. A Unix-only test that lands in a shared file fails the Windows job, and that failure is the signal a future author gets.

| File | Unix fact |
|---|---|
| `internal/shim/path_unix_test.go` (was `path_test.go`) | Every table is a `:`-joined Unix PATH |
| `internal/shim/system_unix_test.go` (was `system_test.go`) | System install is Linux only; the executable bit |
| `internal/shim/shim_unix_test.go` | The sh body, the executable bit, the rc-file PATH export, `os.RemoveAll` under a file parent |
| `internal/doctor/checks_unix_test.go` | venv `bin/` vs `Scripts\`, a symlink, a `#!/bin/sh` stub, `CheckShimScripts` reads the executable bit |
| `cmd/setup/doctor_unix_test.go` | `os.Chmod` cannot make a directory unwritable |
| `internal/runner/childexit_unix_test.go` | `sh` and a Unix signal |
| `internal/fsutil/fsutil_unix_test.go` | Unix permission bits |
| `internal/proxyserver/state_unix_test.go` | `Signal(0)` liveness probe; the daemon is a spec non-goal |
| `config/rootdir_test.go` | sudo and `HOME` semantics |
| `config/sandbox_allow_test.go` | Unix absolute paths for the sandbox |
| `internal/alias/*_test.go` | Unix shell rc files only, by design |

## Found, not fixed here

The sandbox profile loader uses `filepath.Join` on an `embed.FS` (`profiles\aube.yml: file does not exist`). `pmg sandbox profile ...` cannot load a built-in profile on Windows. The sandbox is a non-goal of this spec, so it needs its own issue.

## What is intentionally left for later

- The Windows shim body, PATH registry and doctor checks (decision groups 1 and 4) bring their own `//go:build windows` tests.
- The pip protection check does not handle a Windows venv. That is outside the spec, and the comment on `TestSetupVenv` says so.

## Tests and validation

- Windows job on this pull request: `test-windows: pass`, 45 packages, `test/proxye2e` included ([run](https://github.com/safedep/pmg/actions/runs/34340664918)). The first run was red on 14 packages; the second commit is the triage against that real list, and the third moves every inline `runtime.GOOS` check into a `_unix_test.go` file.
- Every other check on the pull request passes.
- `go test -count=1` on darwin for every package this touches. `go vet` and `GOOS=windows go vet` pass.

## Dependencies

None. #450 and #451 run on Windows only once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
