### PR TITLE
fix: match the PATH key case-insensitively for a child environment

### DIFF
--- a/internal/shim/path.go
+++ b/internal/shim/path.go
@@ -101,15 +101,18 @@ func ResolveRealBinary(name string) (string, error) {
 func FilterPMGFromEnv(env []string) []string {
 	result := make([]string, 0, len(env))
 
+	// Windows os.Environ() returns `Path=`, so the key match folds case. A
+	// prefix match kept the shim directory on the child PATH, and an npm
+	// lifecycle script that called npm re-entered the shim and PMG.
 	for _, entry := range env {
-		if pathValue, ok := strings.CutPrefix(entry, "PATH="); ok {
-			filtered := FilterPMGFromPath(pathValue)
-			result = append(result, "PATH="+filtered)
+		key, value, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(key, "PATH") {
+			result = append(result, key+"="+FilterPMGFromPath(value))
 			continue
 		}
 		// Drop PMG_SHIM_PATH so child processes don't inherit a stale marker
 		// from the shim invocation that triggered this exec.
-		if strings.HasPrefix(entry, pmgShimPathEnv+"=") {
+		if ok && strings.EqualFold(key, pmgShimPathEnv) {
 			continue
 		}
 		result = append(result, entry)

--- a/internal/shim/path_unix_test.go
+++ b/internal/shim/path_unix_test.go
@@ -303,6 +303,18 @@ func TestFilterPMGFromEnv(t *testing.T) {
 				"PATH=/usr/bin",
 			},
 		},
+		{
+			// Windows os.Environ() spells the key `Path`. The key keeps its
+			// spelling so the child sees the variable it expects.
+			name: "filters a Path entry and drops a lower-case marker",
+			env: []string{
+				"Path=/home/user/.pmg/bin:/usr/bin",
+				"pmg_shim_path=/home/user/.pmg/bin/npm",
+			},
+			expected: []string{
+				"Path=/usr/bin",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## What this implements

Decision group 3 of [`2026-09-09-pmg-windows-support-design.md`](https://github.com/safedep/control-tower/blob/main/docs/specs/2026-09-09-pmg-windows-support-design.md): `FilterPMGFromEnv` matches the environment key with `strings.EqualFold`.

## Why this is a useful standalone increment

`internal/shim/path.go` filtered the child environment with `strings.CutPrefix(entry, "PATH=")`. Windows `os.Environ()` returns `Path=...`, so the prefix never matched and the child kept the shim directory on PATH.

The top-level call still worked, because `os.Getenv("PATH")` is case-insensitive on Windows. The defect appears one level down: an npm lifecycle script that calls `npm` re-enters the shim and recurses into PMG. This is one of the two defects the spec calls out as unreachable from a top-level test, which is why the Windows CI job (#449) lands first.

The key keeps its spelling in the output, so the child sees the variable it expects. The same comparison covers the `PMG_SHIM_PATH` marker the function drops.

## What is intentionally left for later

- Dropping `PMG_RAW_ARGS` from the child environment belongs to decision group 2, with the launch contract that introduces the variable.

## Deviation from the spec

The spec asks for a `test/proxye2e` case for a nested manager call "with no new scaffolding". The harness drives traffic with an in-process HTTP client through the real proxy. It has no process boundary and never builds a child environment, so a nested-manager case cannot reach `FilterPMGFromEnv` without new scaffolding that spawns a real child. This change also does not touch the proxy flow, so the `CLAUDE.md` rule that requires a `proxye2e` case does not apply to it. The unit test below is the test the spec names for this defect, and the differential argument test in decision group 2 is where a real nested process runs.

If you want the `proxye2e` case anyway, say so and I will add the scaffolding as its own change.

## Tests and validation

- `TestFilterPMGFromEnv/filters a Path entry and drops a lower-case marker`: a `Path=` entry is filtered and keeps its key, and a `pmg_shim_path=` entry is dropped. It fails on `main`.
- `go test -count=1 ./internal/shim ./internal/runner` passes on darwin. `go vet` passes.

## Dependencies

- Independent of #450. Both edit `internal/shim/path.go` in different functions.
- Runs on Windows once #449 merges. Based on `main`; #449 renames `path_test.go` to `path_unix_test.go`, and I will rebase if git does not carry the edit across the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)