### PR TITLE
feat: install .cmd shims and a user PATH entry on Windows

### DIFF
--- a/cmd/setup/info.go
+++ b/cmd/setup/info.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -65,26 +66,29 @@ func executeSetupInfo() error {
 	ui.PrintInfoSection("Configuration", configEntries)
 
 	// Shell Integration section
-	aliasCfg := alias.DefaultConfig()
-	rcFileManager, err := alias.NewDefaultRcFileManager(cfg.ConfigDir(), aliasCfg.RcFileName)
-	if err != nil {
-		return fmt.Errorf("failed to create alias manager: %w", err)
-	}
-
-	aliasManager := alias.New(aliasCfg, rcFileManager)
-	isInstalled, err := aliasManager.IsInstalled()
-	if err != nil {
-		isInstalled = false
-	}
-
 	shellEntries := make(map[string]string)
 	shell, err := alias.DetectShell()
 	if err != nil {
 		shell = "unknown"
 	}
-
 	shellEntries["Detected Shell"] = shell
-	shellEntries["Aliases"] = installedState(isInstalled, aliasManager.GetRcPath())
+
+	// PMG installs no shell alias on Windows, so there is no row to report.
+	if runtime.GOOS != "windows" {
+		aliasCfg := alias.DefaultConfig()
+		rcFileManager, err := alias.NewDefaultRcFileManager(cfg.ConfigDir(), aliasCfg.RcFileName)
+		if err != nil {
+			return fmt.Errorf("failed to create alias manager: %w", err)
+		}
+
+		aliasManager := alias.New(aliasCfg, rcFileManager)
+		isInstalled, err := aliasManager.IsInstalled()
+		if err != nil {
+			isInstalled = false
+		}
+		shellEntries["Aliases"] = installedState(isInstalled, aliasManager.GetRcPath())
+	}
+
 	userBinDir, err := shim.UserBinDir()
 	if err != nil {
 		userBinDir = ""

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -73,23 +73,21 @@ func install(system bool) error {
 			fmt.Sprintf("Using globally managed config: %s", config.Get().ConfigFilePath()))
 	}
 
-	if runtime.GOOS == "windows" {
-		fmt.Printf("%s %s\n", ui.Colors.Green("✓"), "PMG config written successfully")
-		fmt.Printf("   %s\n", ui.Colors.Dim(fmt.Sprintf("Config:  %s", config.Get().ConfigDir())))
-		fmt.Printf("\n%s Shell aliases and PATH shims are not supported on Windows. Use WSL for full shell integration.\n",
-			ui.Colors.Yellow("⚠"))
-		return nil
-	}
+	// PMG installs no shell alias on Windows. The .cmd shims on PATH are the
+	// whole interception layer there.
+	var aliasPath string
+	if runtime.GOOS != "windows" {
+		cfg := alias.DefaultConfig()
+		rcFileManager, err := alias.NewDefaultRcFileManager(config.Get().ConfigDir(), cfg.RcFileName)
+		if err != nil {
+			return fmt.Errorf("failed to create alias manager: %w", err)
+		}
 
-	cfg := alias.DefaultConfig()
-	rcFileManager, err := alias.NewDefaultRcFileManager(config.Get().ConfigDir(), cfg.RcFileName)
-	if err != nil {
-		return fmt.Errorf("failed to create alias manager: %w", err)
-	}
-
-	aliasManager := alias.New(cfg, rcFileManager)
-	if err := aliasManager.Install(); err != nil {
-		return fmt.Errorf("failed to install aliases: %w", err)
+		aliasManager := alias.New(cfg, rcFileManager)
+		if err := aliasManager.Install(); err != nil {
+			return fmt.Errorf("failed to install aliases: %w", err)
+		}
+		aliasPath = aliasManager.GetRcPath()
 	}
 
 	shimMgr, err := shim.NewDefaultShimManager()
@@ -101,7 +99,7 @@ func install(system bool) error {
 		return fmt.Errorf("failed to install shims: %w", err)
 	}
 
-	ui.PrintSetupInstallCmdInfo(aliasManager.GetRcPath(), shimMgr.GetBinDir(), config.Get().ConfigDir())
+	ui.PrintSetupInstallCmdInfo(aliasPath, shimMgr.GetBinDir(), config.Get().ConfigDir())
 	return nil
 }
 
@@ -165,20 +163,14 @@ func remove(system, removeConfig bool) error {
 		}
 	}
 
-	if runtime.GOOS == "windows" {
-		if len(errs) > 0 {
-			return errors.Join(errs...)
+	if runtime.GOOS != "windows" {
+		cfg := alias.DefaultConfig()
+		rcFileManager, err := alias.NewDefaultRcFileManager(config.Get().ConfigDir(), cfg.RcFileName)
+		if err != nil {
+			errs = append(errs, err)
+		} else if err := alias.New(cfg, rcFileManager).Remove(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove aliases: %w", err))
 		}
-		fmt.Printf("%s %s\n", ui.Colors.Green("✓"), "PMG config removed. No aliases or shims to clean up on Windows.")
-		return nil
-	}
-
-	cfg := alias.DefaultConfig()
-	rcFileManager, err := alias.NewDefaultRcFileManager(config.Get().ConfigDir(), cfg.RcFileName)
-	if err != nil {
-		errs = append(errs, err)
-	} else if err := alias.New(cfg, rcFileManager).Remove(); err != nil {
-		errs = append(errs, fmt.Errorf("failed to remove aliases: %w", err))
 	}
 
 	shimMgr, err := shim.NewDefaultShimManager()

--- a/internal/shim/path.go
+++ b/internal/shim/path.go
@@ -36,6 +36,11 @@ const (
 	// cause FilterPMGFromPath to strip the wrong directory from PATH lookup
 	// and could prevent pmg from resolving the real package manager.
 	pmgShimPathEnv = "PMG_SHIM_PATH"
+
+	// pmgRawArgsEnv is the env var the Windows .cmd shim exports with the
+	// argument tail byte for byte. The launch contract replays it to cmd.exe
+	// so the manager sees one parse, not two.
+	pmgRawArgsEnv = "PMG_RAW_ARGS"
 )
 
 var resolverMu sync.Mutex
@@ -133,9 +138,10 @@ func FilterPMGFromEnv(env []string) []string {
 			result = append(result, key+"="+FilterPMGFromPath(value))
 			continue
 		}
-		// Drop PMG_SHIM_PATH so child processes don't inherit a stale marker
-		// from the shim invocation that triggered this exec.
-		if ok && strings.EqualFold(key, pmgShimPathEnv) {
+		// Drop the shim marker and the raw tail so child processes don't
+		// inherit stale values from the shim invocation that triggered this
+		// exec. A nested pmg would otherwise replay the outer arguments.
+		if ok && (strings.EqualFold(key, pmgShimPathEnv) || strings.EqualFold(key, pmgRawArgsEnv)) {
 			continue
 		}
 		result = append(result, entry)

--- a/internal/shim/path_unix_test.go
+++ b/internal/shim/path_unix_test.go
@@ -326,6 +326,18 @@ func TestFilterPMGFromEnv(t *testing.T) {
 				"Path=/usr/bin",
 			},
 		},
+		{
+			// A nested pmg that inherits the raw tail would replay the outer
+			// arguments.
+			name: "drops PMG_RAW_ARGS from child env",
+			env: []string{
+				"PMG_RAW_ARGS=install lodash",
+				"HOME=/home/user",
+			},
+			expected: []string{
+				"HOME=/home/user",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/shim/script_unix.go
+++ b/internal/shim/script_unix.go
@@ -1,0 +1,54 @@
+//go:build !windows
+
+package shim
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/safedep/dry/log"
+)
+
+func shimFileName(pm string) string { return pm }
+
+func shimScript(pmgBin, pm string) string {
+	return fmt.Sprintf(`#!/bin/sh
+%[1]s
+%[2]s=%[3]s
+if [ ! -x "$%[2]s" ]; then
+  echo "[pmg] error: PMG binary not found or not executable: $%[2]s" >&2
+  echo "[pmg] error: run 'pmg setup install' again or remove shims with 'pmg setup remove'" >&2
+  exit 127
+fi
+PMG_SHIM_PATH=$(cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")
+export PMG_SHIM_PATH
+exec "$%[2]s" %[4]s "$@"
+`, shimScriptMarker, shimPMGBinVar, shellQuote(pmgBin), pm)
+}
+
+// The shim directory reaches PATH through each shell's rc file.
+func (m *ShimManager) installPath() error { return m.addPathToShells() }
+
+func (m *ShimManager) removePath() error { return m.removePathFromShells() }
+
+func (m *ShimManager) pathInstalled() (bool, error) {
+	for _, shell := range m.config.Shells {
+		for _, configPath := range shell.CandidateRcFiles(m.config.HomeDir) {
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				log.Warnf("Warning: could not read %s (%s)", configPath, err)
+				continue
+			}
+
+			if strings.Contains(string(data), shimMarker) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/internal/shim/script_windows.go
+++ b/internal/shim/script_windows.go
@@ -17,13 +17,19 @@ func shimFileName(pm string) string { return pm + ".cmd" }
 // tail byte for byte so PMG can replay it to cmd.exe without a second
 // serialisation. The marker sits in a rem line so shimsPresent finds it.
 func shimScript(pmgBin, pm string) string {
+	bin := batchEscape(pmgBin)
 	lines := []string{
 		"@echo off",
 		"rem " + shimScriptMarker,
 		"setlocal DisableDelayedExpansion",
-		`set "PMG_SHIM_PATH=%~f0"`,
-		`set "PMG_RAW_ARGS=%*"`,
-		fmt.Sprintf(`"%s" %s %%*`, batchEscape(pmgBin), pm),
+		fmt.Sprintf(`if not exist "%s" (`, bin),
+		fmt.Sprintf(`  echo [pmg] error: PMG binary not found: %s 1>&2`, bin),
+		`  echo [pmg] error: run 'pmg setup install' again or remove shims with 'pmg setup remove' 1>&2`,
+		"  exit /b 127",
+		")",
+		fmt.Sprintf(`set "%s=%%~f0"`, pmgShimPathEnv),
+		fmt.Sprintf(`set "%s=%%*"`, pmgRawArgsEnv),
+		fmt.Sprintf(`"%s" %s %%*`, bin, pm),
 		"exit /b %ERRORLEVEL%",
 		"",
 	}

--- a/internal/shim/script_windows.go
+++ b/internal/shim/script_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package shim
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A .cmd file is what every caller that applies PATHEXT finds: cmd.exe,
+// PowerShell and Go's exec.LookPath.
+func shimFileName(pm string) string { return pm + ".cmd" }
+
+// shimScript is the batch body. setlocal alone inherits delayed expansion
+// from the caller, which would make !NAME! expand inside the captured tail,
+// so DisableDelayedExpansion is explicit. PMG_RAW_ARGS carries the argument
+// tail byte for byte so PMG can replay it to cmd.exe without a second
+// serialisation. The marker sits in a rem line so shimsPresent finds it.
+func shimScript(pmgBin, pm string) string {
+	lines := []string{
+		"@echo off",
+		"rem " + shimScriptMarker,
+		"setlocal DisableDelayedExpansion",
+		`set "PMG_SHIM_PATH=%~f0"`,
+		`set "PMG_RAW_ARGS=%*"`,
+		fmt.Sprintf(`"%s" %s %%*`, batchEscape(pmgBin), pm),
+		"exit /b %ERRORLEVEL%",
+		"",
+	}
+	return strings.Join(lines, "\r\n")
+}
+
+// batchEscape keeps a literal percent sign in a batch file, where a bare
+// one starts a variable expansion.
+func batchEscape(value string) string {
+	return strings.ReplaceAll(value, "%", "%%")
+}
+
+// The shim directory reaches PATH through HKCU\Environment, which every new
+// shell reads.
+func (m *ShimManager) installPath() error { return registerUserPath(m.config.BinDir) }
+
+func (m *ShimManager) removePath() error { return unregisterUserPath(m.config.BinDir) }
+
+func (m *ShimManager) pathInstalled() (bool, error) { return userPathContains(m.config.BinDir) }

--- a/internal/shim/script_windows.go
+++ b/internal/shim/script_windows.go
@@ -24,7 +24,7 @@ func shimScript(pmgBin, pm string) string {
 		"setlocal DisableDelayedExpansion",
 		fmt.Sprintf(`if not exist "%s" (`, bin),
 		fmt.Sprintf(`  echo [pmg] error: PMG binary not found: %s 1>&2`, bin),
-		`  echo [pmg] error: run 'pmg setup install' again or remove shims with 'pmg setup remove' 1>&2`,
+		`  echo [pmg] error: reinstall PMG and run 'pmg setup install', or delete %~dp0 to remove the shims 1>&2`,
 		"  exit /b 127",
 		")",
 		fmt.Sprintf(`set "%s=%%~f0"`, pmgShimPathEnv),

--- a/internal/shim/script_windows.go
+++ b/internal/shim/script_windows.go
@@ -22,18 +22,26 @@ func shimScript(pmgBin, pm string) string {
 		"@echo off",
 		"rem " + shimScriptMarker,
 		"setlocal DisableDelayedExpansion",
-		// Inside quotes a ) or & in a path is literal. Unquoted, a ) ends the
-		// block early and a & starts a second command.
+		// The paths in the echo lines are quoted. cmd.exe reads the whole
+		// `( ... )` block before it runs the `if`. An unquoted `)` in a path
+		// such as `Program Files (x86)` would end the block early, and an
+		// unquoted `&` would start a second command. Inside double quotes
+		// both characters are plain text.
 		fmt.Sprintf(`if not exist "%s" (`, bin),
 		fmt.Sprintf(`  echo [pmg] error: PMG binary not found: "%s" 1>&2`, bin),
 		`  echo [pmg] error: reinstall PMG and run 'pmg setup install', or delete "%~dp0" to remove the shims 1>&2`,
 		"  exit /b 127",
 		")",
 		fmt.Sprintf(`set "%s=%%~f0"`, pmgShimPathEnv),
-		// No wrapping quotes here. A set "VAR=%*" would invert the quote
-		// state of the tail, so a > or & the user put inside quotes becomes
-		// live. Without them the set line has the same quote parity as the
-		// launch line below, and an empty tail clears the variable.
+		// The value is not wrapped in quotes on purpose. cmd.exe flips an
+		// "inside quotes" flag at every double quote, and the characters
+		// `>`, `<`, `&` and `|` act only outside quotes. With
+		// `set "VAR=%*"` the wrapping quote makes the user's own quotes
+		// close instead of open: for `install "lodash@>=4"` the `>` lands
+		// outside quotes, cmd.exe writes a file named `=4`, and the variable
+		// holds a truncated tail. Without the wrapping quotes this line reads
+		// the tail exactly as the launch line below does. A bare command
+		// sets an empty value, which cmd.exe treats as unset.
 		fmt.Sprintf(`set %s=%%*`, pmgRawArgsEnv),
 		fmt.Sprintf(`"%s" %s %%*`, bin, pm),
 		"exit /b %ERRORLEVEL%",

--- a/internal/shim/script_windows.go
+++ b/internal/shim/script_windows.go
@@ -22,13 +22,19 @@ func shimScript(pmgBin, pm string) string {
 		"@echo off",
 		"rem " + shimScriptMarker,
 		"setlocal DisableDelayedExpansion",
+		// Inside quotes a ) or & in a path is literal. Unquoted, a ) ends the
+		// block early and a & starts a second command.
 		fmt.Sprintf(`if not exist "%s" (`, bin),
-		fmt.Sprintf(`  echo [pmg] error: PMG binary not found: %s 1>&2`, bin),
-		`  echo [pmg] error: reinstall PMG and run 'pmg setup install', or delete %~dp0 to remove the shims 1>&2`,
+		fmt.Sprintf(`  echo [pmg] error: PMG binary not found: "%s" 1>&2`, bin),
+		`  echo [pmg] error: reinstall PMG and run 'pmg setup install', or delete "%~dp0" to remove the shims 1>&2`,
 		"  exit /b 127",
 		")",
 		fmt.Sprintf(`set "%s=%%~f0"`, pmgShimPathEnv),
-		fmt.Sprintf(`set "%s=%%*"`, pmgRawArgsEnv),
+		// No wrapping quotes here. A set "VAR=%*" would invert the quote
+		// state of the tail, so a > or & the user put inside quotes becomes
+		// live. Without them the set line has the same quote parity as the
+		// launch line below, and an empty tail clears the variable.
+		fmt.Sprintf(`set %s=%%*`, pmgRawArgsEnv),
 		fmt.Sprintf(`"%s" %s %%*`, bin, pm),
 		"exit /b %ERRORLEVEL%",
 		"",

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -34,9 +34,10 @@ type ShimConfig struct {
 	PMGBin          string
 	PackageManagers []string
 	Shells          []alias.Shell
-	// SkipShellRc skips per-user shell rc PATH edits. Used by system install,
+	// SkipUserPath skips the per-user PATH registration: the shell rc edits
+	// on Unix, the HKCU\Environment write on Windows. Used by system install,
 	// which relies on the system profile or ENV PATH instead.
-	SkipShellRc bool
+	SkipUserPath bool
 	// SystemProfile installs and removes the OS login-shell PATH snippet
 	// (Linux: /etc/profile.d/pmg.sh) with Install/Remove, and marks this
 	// manager as a system-wide install: Install then also validates the pmg
@@ -128,7 +129,7 @@ func (m *ShimManager) Install() error {
 		}
 	}
 
-	if m.config.SkipShellRc {
+	if m.config.SkipUserPath {
 		return nil
 	}
 
@@ -163,7 +164,7 @@ func (m *ShimManager) Remove() error {
 		}
 	}
 
-	if !m.config.SkipShellRc {
+	if !m.config.SkipUserPath {
 		if err := m.removePath(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to remove shims from PATH: %w", err))
 		}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -132,8 +132,8 @@ func (m *ShimManager) Install() error {
 		return nil
 	}
 
-	if err := m.addPathToShells(); err != nil {
-		return fmt.Errorf("failed to update shell configs: %w", err)
+	if err := m.installPath(); err != nil {
+		return fmt.Errorf("failed to add shims to PATH: %w", err)
 	}
 
 	return nil
@@ -164,8 +164,8 @@ func (m *ShimManager) Remove() error {
 	}
 
 	if !m.config.SkipShellRc {
-		if err := m.removePathFromShells(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to clean shell configs: %w", err))
+		if err := m.removePath(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove shims from PATH: %w", err))
 		}
 	}
 
@@ -173,24 +173,7 @@ func (m *ShimManager) Remove() error {
 }
 
 func (m *ShimManager) IsInstalled() (bool, error) {
-	for _, shell := range m.config.Shells {
-		for _, configPath := range shell.CandidateRcFiles(m.config.HomeDir) {
-			data, err := os.ReadFile(configPath)
-			if err != nil {
-				if os.IsNotExist(err) {
-					continue
-				}
-				log.Warnf("Warning: could not read %s (%s)", configPath, err)
-				continue
-			}
-
-			if strings.Contains(string(data), shimMarker) {
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
+	return m.pathInstalled()
 }
 
 func (m *ShimManager) GetBinDir() string {
@@ -235,21 +218,8 @@ func LegacyUserBinDir() (string, error) {
 }
 
 func (m *ShimManager) writeShimScript(pm string) error {
-	shimPath := filepath.Join(m.config.BinDir, pm)
-	pmgBin := shellQuote(m.config.PMGBin)
-
-	content := fmt.Sprintf(`#!/bin/sh
-%[1]s
-%[2]s=%[3]s
-if [ ! -x "$%[2]s" ]; then
-  echo "[pmg] error: PMG binary not found or not executable: $%[2]s" >&2
-  echo "[pmg] error: run 'pmg setup install' again or remove shims with 'pmg setup remove'" >&2
-  exit 127
-fi
-PMG_SHIM_PATH=$(cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")
-export PMG_SHIM_PATH
-exec "$%[2]s" %[4]s "$@"
-`, shimScriptMarker, shimPMGBinVar, pmgBin, pm)
+	shimPath := filepath.Join(m.config.BinDir, shimFileName(pm))
+	content := shimScript(m.config.PMGBin, pm)
 
 	if err := os.WriteFile(shimPath, []byte(content), 0o755); err != nil {
 		return err

--- a/internal/shim/shim_cmd_windows_test.go
+++ b/internal/shim/shim_cmd_windows_test.go
@@ -1,0 +1,168 @@
+//go:build windows
+
+package shim
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The byte tests prove what the shim says. This file proves what cmd.exe
+// does with it. The test binary doubles as pmg.exe: with PMG_SHIM_TEST_HELPER
+// set it reports the shim's exports and its own argv as JSON, then exits with
+// the code the test asked for.
+const (
+	helperEnv     = "PMG_SHIM_TEST_HELPER"
+	helperExitEnv = "PMG_SHIM_TEST_EXIT"
+)
+
+type helperReport struct {
+	RawArgs  string   `json:"raw_args"`
+	ShimPath string   `json:"shim_path"`
+	Args     []string `json:"args"`
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv(helperEnv) == "" {
+		os.Exit(m.Run())
+	}
+
+	report := helperReport{
+		RawArgs:  os.Getenv(pmgRawArgsEnv),
+		ShimPath: os.Getenv(pmgShimPathEnv),
+		Args:     os.Args[1:],
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+		os.Exit(3)
+	}
+	code, _ := strconv.Atoi(os.Getenv(helperExitEnv))
+	os.Exit(code)
+}
+
+// TestCmdShimOnCmdExe runs the generated .cmd through a real cmd.exe. The
+// pmg.exe path carries a space, a parenthesis, an ampersand and a percent
+// sign, because the shim quotes it and any of those breaks an unquoted form.
+func TestCmdShimOnCmdExe(t *testing.T) {
+	isolateUserPath(t)
+	root := t.TempDir()
+
+	testBin, err := os.Executable()
+	require.NoError(t, err)
+	pmgBin := filepath.Join(root, "100% (x86) & co", "pmg.exe")
+	require.NoError(t, os.MkdirAll(filepath.Dir(pmgBin), 0o755))
+	copyFile(t, testBin, pmgBin)
+
+	shimDir := filepath.Join(root, "shims (user)")
+	require.NoError(t, NewShimManager(ShimConfig{
+		BinDir:          shimDir,
+		PMGBin:          pmgBin,
+		PackageManagers: []string{"npm"},
+		SkipUserPath:    true,
+	}).Install())
+	shimPath := filepath.Join(shimDir, "npm.cmd")
+
+	tails := []struct {
+		name string
+		tail string
+	}{
+		{"quoted redirect character", `install "lodash@>=4"`},
+		{"quoted ampersand", `install "a & b"`},
+		{"quoted pipe and carets", `install "^1 || ^2"`},
+		{"percent sign", `install 100%`},
+		{"delayed-expansion marker", `install !x!`},
+		{"empty tail", ``},
+	}
+
+	for _, tc := range tails {
+		t.Run(tc.name, func(t *testing.T) {
+			workDir := t.TempDir()
+			report, code := runShim(t, shimPath, tc.tail, workDir, 7)
+
+			assert.Equal(t, 7, code, "exit /b must carry the pmg exit code")
+			assert.Equal(t, tc.tail, report.RawArgs, "PMG_RAW_ARGS must be the tail byte for byte")
+			assert.Equal(t, shimPath, report.ShimPath)
+			assert.Equal(t, "npm", report.Args[0])
+
+			leftovers, err := os.ReadDir(workDir)
+			require.NoError(t, err)
+			assert.Empty(t, leftovers, "a live > or & would create a file or run a command here")
+		})
+	}
+
+	t.Run("missing pmg.exe fails closed with the pmg message", func(t *testing.T) {
+		require.NoError(t, os.Remove(pmgBin))
+		out, code := runCmd(t, `"`+shimPath+`" install x`, t.TempDir(), nil)
+		assert.Equal(t, 127, code)
+		assert.Contains(t, string(out), "[pmg] error: PMG binary not found")
+		assert.Contains(t, string(out), "pmg setup install")
+	})
+}
+
+// runShim runs `<shim> <tail>` through cmd.exe in workDir with the helper
+// role armed, and decodes the helper's report.
+func runShim(t *testing.T, shimPath, tail, workDir string, exitCode int) (helperReport, int) {
+	t.Helper()
+	env := append(os.Environ(), helperEnv+"=1", helperExitEnv+"="+strconv.Itoa(exitCode))
+	line := `"` + shimPath + `"`
+	if tail != "" {
+		line += " " + tail
+	}
+	out, code := runCmd(t, line, workDir, env)
+
+	var report helperReport
+	require.NoError(t, json.Unmarshal(out, &report), "helper output: %s", out)
+	return report, code
+}
+
+// runCmd hands cmd.exe one raw command line, the way a typed command
+// reaches it. /s keeps the outer quote pair intact so a shim path with a
+// space survives.
+func runCmd(t *testing.T, line, workDir string, env []string) ([]byte, int) {
+	t.Helper()
+	cmd := exec.Command(comspecForTest())
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: fmt.Sprintf(`cmd.exe /d /s /c "%s"`, line)}
+	cmd.Dir = workDir
+	cmd.Env = env
+
+	out, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+		return out, 0
+	case errors.As(err, &exitErr):
+		return out, exitErr.ExitCode()
+	default:
+		require.NoError(t, err)
+		return nil, -1
+	}
+}
+
+func comspecForTest() string {
+	if c := os.Getenv("COMSPEC"); c != "" {
+		return c
+	}
+	return "cmd.exe"
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	in, err := os.Open(src)
+	require.NoError(t, err)
+	defer in.Close()
+	out, err := os.Create(dst)
+	require.NoError(t, err)
+	_, err = io.Copy(out, in)
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+}

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/safedep/pmg/config"
@@ -14,36 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShimManagerInstallIdempotent(t *testing.T) {
-	homeDir := t.TempDir()
-	binDir := filepath.Join(homeDir, ".pmg", "bin")
-
-	bashrc := filepath.Join(homeDir, ".bashrc")
-	require.NoError(t, os.WriteFile(bashrc, []byte("# existing bashrc\n"), 0o644))
-
-	mgr := NewShimManager(ShimConfig{
-		BinDir:          binDir,
-		HomeDir:         homeDir,
-		PackageManagers: []string{"npm"},
-		Shells:          []alias.Shell{&stubShell{name: "bash", path: ".bashrc", useFish: false}},
-	})
-
-	require.NoError(t, mgr.Install())
-	require.NoError(t, mgr.Install())
-
-	content, err := os.ReadFile(bashrc)
-	require.NoError(t, err)
-
-	count := 0
-	for _, line := range strings.Split(string(content), "\n") {
-		if strings.Contains(line, binDir) {
-			count++
-		}
-	}
-	assert.Equal(t, 1, count, "PATH export should appear exactly once")
-}
-
 func TestShimManagerRemove(t *testing.T) {
+	isolateUserPath(t)
 	homeDir := t.TempDir()
 	binDir := filepath.Join(homeDir, ".pmg", "bin")
 
@@ -69,6 +40,7 @@ func TestShimManagerRemove(t *testing.T) {
 }
 
 func TestShimManagerIsInstalled(t *testing.T) {
+	isolateUserPath(t)
 	homeDir := t.TempDir()
 	binDir := filepath.Join(homeDir, ".pmg", "bin")
 
@@ -200,6 +172,7 @@ func TestUserBinDirUsesDataDirWhenLegacyEmpty(t *testing.T) {
 }
 
 func TestShimManagerRemoveClearsLegacyDir(t *testing.T) {
+	isolateUserPath(t)
 	homeDir := t.TempDir()
 	binDir := filepath.Join(homeDir, "xdg-data", "safedep", "pmg", "bin")
 	legacyBinDir := filepath.Join(homeDir, legacyUserDirName, "bin")
@@ -226,6 +199,7 @@ func TestShimManagerRemoveClearsLegacyDir(t *testing.T) {
 }
 
 func TestShimManagerRemoveKeepsNonEmptyLegacyParent(t *testing.T) {
+	isolateUserPath(t)
 	homeDir := t.TempDir()
 	legacyDir := filepath.Join(homeDir, legacyUserDirName)
 	legacyBinDir := filepath.Join(legacyDir, "bin")
@@ -250,6 +224,7 @@ func TestShimManagerRemoveKeepsNonEmptyLegacyParent(t *testing.T) {
 }
 
 func TestShimManagerRemoveClearsBothPopulatedLayouts(t *testing.T) {
+	isolateUserPath(t)
 	homeDir := t.TempDir()
 	legacyBinDir := filepath.Join(homeDir, legacyUserDirName, "bin")
 	dataBinDir := filepath.Join(homeDir, ".local", "share", "safedep", "pmg", "bin")

--- a/internal/shim/shim_unix_test.go
+++ b/internal/shim/shim_unix_test.go
@@ -5,6 +5,7 @@ package shim
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/safedep/pmg/internal/alias"
@@ -12,8 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The sh body, the executable bit and the rc-file PATH export are the Unix
-// half of the shim.
+// isolateUserPath is a no-op off Windows. The shim directory reaches PATH
+// through rc files in the test's home directory.
+func isolateUserPath(t *testing.T) { t.Helper() }
+
+// The sh body and the rc-file PATH export are the Unix half of the shim.
+// Windows writes a .cmd and a registry entry, tested in shim_windows_test.go.
 func TestShimManagerInstall(t *testing.T) {
 	homeDir := t.TempDir()
 	binDir := filepath.Join(homeDir, ".pmg", "bin")
@@ -68,6 +73,35 @@ func TestShimManagerInstall(t *testing.T) {
 	fishContent, err := os.ReadFile(filepath.Join(fishConfig, "config.fish"))
 	require.NoError(t, err)
 	assert.Contains(t, string(fishContent), binDir)
+}
+
+func TestShimManagerInstallIdempotent(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, ".pmg", "bin")
+
+	bashrc := filepath.Join(homeDir, ".bashrc")
+	require.NoError(t, os.WriteFile(bashrc, []byte("# existing bashrc\n"), 0o644))
+
+	mgr := NewShimManager(ShimConfig{
+		BinDir:          binDir,
+		HomeDir:         homeDir,
+		PackageManagers: []string{"npm"},
+		Shells:          []alias.Shell{&stubShell{name: "bash", path: ".bashrc", useFish: false}},
+	})
+
+	require.NoError(t, mgr.Install())
+	require.NoError(t, mgr.Install())
+
+	content, err := os.ReadFile(bashrc)
+	require.NoError(t, err)
+
+	count := 0
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.Contains(line, binDir) {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "PATH export should appear exactly once")
 }
 
 // os.RemoveAll under a file parent returns nil on Windows, so this only

--- a/internal/shim/shim_windows_test.go
+++ b/internal/shim/shim_windows_test.go
@@ -1,0 +1,141 @@
+//go:build windows
+
+package shim
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/registry"
+)
+
+// isolateUserPath points the user PATH code at a throwaway registry key, so
+// a test never edits the real HKCU\Environment.
+func isolateUserPath(t *testing.T) {
+	t.Helper()
+	keyPath := fmt.Sprintf(`Software\safedep\pmg-test\%s`, strings.ReplaceAll(t.Name(), "/", "_"))
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, keyPath, registry.ALL_ACCESS)
+	require.NoError(t, err)
+	require.NoError(t, key.Close())
+
+	orig := userEnvironmentKey
+	userEnvironmentKey = keyPath
+	t.Cleanup(func() {
+		userEnvironmentKey = orig
+		require.NoError(t, registry.DeleteKey(registry.CURRENT_USER, keyPath))
+	})
+}
+
+func TestShimManagerInstallWritesCmdShims(t *testing.T) {
+	isolateUserPath(t)
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "safedep", "pmg", "bin")
+	// A percent sign in the binary path must not start a batch expansion.
+	pmgBin := filepath.Join(homeDir, "100%", "pmg.exe")
+
+	mgr := NewShimManager(ShimConfig{
+		BinDir:          binDir,
+		HomeDir:         homeDir,
+		PMGBin:          pmgBin,
+		PackageManagers: []string{"npm", "pip"},
+	})
+	require.NoError(t, mgr.Install())
+
+	for _, pm := range []string{"npm", "pip"} {
+		content, err := os.ReadFile(filepath.Join(binDir, pm+".cmd"))
+		require.NoError(t, err, "shim %s.cmd should exist", pm)
+		body := string(content)
+
+		assert.True(t, strings.HasPrefix(body, "@echo off\r\n"))
+		assert.Contains(t, body, "rem "+shimScriptMarker+"\r\n")
+		assert.Contains(t, body, "setlocal DisableDelayedExpansion\r\n")
+		assert.Contains(t, body, `set "PMG_SHIM_PATH=%~f0"`+"\r\n")
+		assert.Contains(t, body, `set "PMG_RAW_ARGS=%*"`+"\r\n")
+		assert.Contains(t, body, fmt.Sprintf(`"%s" %s %%*`+"\r\n", strings.ReplaceAll(pmgBin, "%", "%%"), pm))
+		assert.True(t, strings.HasSuffix(body, "exit /b %ERRORLEVEL%\r\n"))
+	}
+
+	assert.True(t, shimsPresent(binDir), "shimsPresent must recognise a .cmd shim")
+
+	installed, err := mgr.IsInstalled()
+	require.NoError(t, err)
+	assert.True(t, installed)
+}
+
+func TestShimManagerRemoveDeletesShimsAndPathEntry(t *testing.T) {
+	isolateUserPath(t)
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "safedep", "pmg", "bin")
+
+	mgr := NewShimManager(ShimConfig{
+		BinDir:          binDir,
+		HomeDir:         homeDir,
+		PMGBin:          filepath.Join(homeDir, "pmg.exe"),
+		PackageManagers: []string{"npm"},
+	})
+	require.NoError(t, mgr.Install())
+	require.NoError(t, mgr.Remove())
+
+	assert.NoDirExists(t, binDir)
+	installed, err := mgr.IsInstalled()
+	require.NoError(t, err)
+	assert.False(t, installed)
+}
+
+func TestUserPathRegistry(t *testing.T) {
+	isolateUserPath(t)
+	shimDir := `C:\Users\dev\AppData\Local\safedep\pmg\bin`
+
+	t.Run("prepends once and keeps the value type", func(t *testing.T) {
+		// Windows writes the default user PATH as REG_EXPAND_SZ so
+		// %USERPROFILE% style entries stay unexpanded.
+		require.NoError(t, writeUserPath([]string{`%USERPROFILE%\bin`, `C:\Tools`}, true))
+
+		require.NoError(t, registerUserPath(shimDir))
+		require.NoError(t, registerUserPath(shimDir))
+
+		entries, expand, err := readUserPath()
+		require.NoError(t, err)
+		assert.Equal(t, []string{shimDir, `%USERPROFILE%\bin`, `C:\Tools`}, entries)
+		assert.True(t, expand)
+	})
+
+	t.Run("contains folds case", func(t *testing.T) {
+		found, err := userPathContains(strings.ToUpper(shimDir))
+		require.NoError(t, err)
+		assert.True(t, found)
+	})
+
+	t.Run("removes only the shim entry", func(t *testing.T) {
+		require.NoError(t, unregisterUserPath(strings.ToLower(shimDir)))
+
+		entries, _, err := readUserPath()
+		require.NoError(t, err)
+		assert.Equal(t, []string{`%USERPROFILE%\bin`, `C:\Tools`}, entries)
+
+		found, err := userPathContains(shimDir)
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+
+	t.Run("a missing Path value reads as empty", func(t *testing.T) {
+		key, err := registry.OpenKey(registry.CURRENT_USER, userEnvironmentKey, registry.SET_VALUE)
+		require.NoError(t, err)
+		require.NoError(t, key.DeleteValue(pathValueName))
+		require.NoError(t, key.Close())
+
+		entries, _, err := readUserPath()
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+
+		require.NoError(t, registerUserPath(shimDir))
+		found, err := userPathContains(shimDir)
+		require.NoError(t, err)
+		assert.True(t, found)
+	})
+}

--- a/internal/shim/shim_windows_test.go
+++ b/internal/shim/shim_windows_test.go
@@ -59,6 +59,7 @@ func TestShimManagerInstallWritesCmdShims(t *testing.T) {
 		assert.Contains(t, body, `set "PMG_RAW_ARGS=%*"`+"\r\n")
 		assert.Contains(t, body, fmt.Sprintf(`"%s" %s %%*`+"\r\n", strings.ReplaceAll(pmgBin, "%", "%%"), pm))
 		assert.Contains(t, body, fmt.Sprintf(`if not exist "%s" (`+"\r\n", strings.ReplaceAll(pmgBin, "%", "%%")))
+		assert.Contains(t, body, "or delete %~dp0 to remove the shims 1>&2\r\n")
 		assert.Contains(t, body, "  exit /b 127\r\n")
 		assert.True(t, strings.HasSuffix(body, "exit /b %ERRORLEVEL%\r\n"))
 	}

--- a/internal/shim/shim_windows_test.go
+++ b/internal/shim/shim_windows_test.go
@@ -18,7 +18,8 @@ import (
 // a test never edits the real HKCU\Environment.
 func isolateUserPath(t *testing.T) {
 	t.Helper()
-	keyPath := fmt.Sprintf(`Software\safedep\pmg-test\%s`, strings.ReplaceAll(t.Name(), "/", "_"))
+	// One flat key per test, so deleting it leaves no parent behind.
+	keyPath := `Software\pmg-test-` + strings.ReplaceAll(t.Name(), "/", "_")
 	key, _, err := registry.CreateKey(registry.CURRENT_USER, keyPath, registry.ALL_ACCESS)
 	require.NoError(t, err)
 	require.NoError(t, key.Close())
@@ -57,6 +58,8 @@ func TestShimManagerInstallWritesCmdShims(t *testing.T) {
 		assert.Contains(t, body, `set "PMG_SHIM_PATH=%~f0"`+"\r\n")
 		assert.Contains(t, body, `set "PMG_RAW_ARGS=%*"`+"\r\n")
 		assert.Contains(t, body, fmt.Sprintf(`"%s" %s %%*`+"\r\n", strings.ReplaceAll(pmgBin, "%", "%%"), pm))
+		assert.Contains(t, body, fmt.Sprintf(`if not exist "%s" (`+"\r\n", strings.ReplaceAll(pmgBin, "%", "%%")))
+		assert.Contains(t, body, "  exit /b 127\r\n")
 		assert.True(t, strings.HasSuffix(body, "exit /b %ERRORLEVEL%\r\n"))
 	}
 

--- a/internal/shim/shim_windows_test.go
+++ b/internal/shim/shim_windows_test.go
@@ -36,8 +36,10 @@ func TestShimManagerInstallWritesCmdShims(t *testing.T) {
 	isolateUserPath(t)
 	homeDir := t.TempDir()
 	binDir := filepath.Join(homeDir, "safedep", "pmg", "bin")
-	// A percent sign in the binary path must not start a batch expansion.
-	pmgBin := filepath.Join(homeDir, "100%", "pmg.exe")
+	// A percent sign in the binary path must not start a batch expansion. A
+	// closing parenthesis must not end the if block, and an ampersand must
+	// not start a second command.
+	pmgBin := filepath.Join(homeDir, "100% (x86) & co", "pmg.exe")
 
 	mgr := NewShimManager(ShimConfig{
 		BinDir:          binDir,
@@ -56,10 +58,11 @@ func TestShimManagerInstallWritesCmdShims(t *testing.T) {
 		assert.Contains(t, body, "rem "+shimScriptMarker+"\r\n")
 		assert.Contains(t, body, "setlocal DisableDelayedExpansion\r\n")
 		assert.Contains(t, body, `set "PMG_SHIM_PATH=%~f0"`+"\r\n")
-		assert.Contains(t, body, `set "PMG_RAW_ARGS=%*"`+"\r\n")
+		assert.Contains(t, body, "set PMG_RAW_ARGS=%*\r\n")
 		assert.Contains(t, body, fmt.Sprintf(`"%s" %s %%*`+"\r\n", strings.ReplaceAll(pmgBin, "%", "%%"), pm))
 		assert.Contains(t, body, fmt.Sprintf(`if not exist "%s" (`+"\r\n", strings.ReplaceAll(pmgBin, "%", "%%")))
-		assert.Contains(t, body, "or delete %~dp0 to remove the shims 1>&2\r\n")
+		assert.Contains(t, body, fmt.Sprintf(`PMG binary not found: "%s" 1>&2`+"\r\n", strings.ReplaceAll(pmgBin, "%", "%%")))
+		assert.Contains(t, body, `or delete "%~dp0" to remove the shims 1>&2`+"\r\n")
 		assert.Contains(t, body, "  exit /b 127\r\n")
 		assert.True(t, strings.HasSuffix(body, "exit /b %ERRORLEVEL%\r\n"))
 	}
@@ -141,5 +144,15 @@ func TestUserPathRegistry(t *testing.T) {
 		found, err := userPathContains(shimDir)
 		require.NoError(t, err)
 		assert.True(t, found)
+	})
+
+	t.Run("removing the only entry leaves no value behind", func(t *testing.T) {
+		require.NoError(t, unregisterUserPath(shimDir))
+
+		key, err := registry.OpenKey(registry.CURRENT_USER, userEnvironmentKey, registry.QUERY_VALUE)
+		require.NoError(t, err)
+		defer key.Close()
+		_, _, err = key.GetStringValue(pathValueName)
+		assert.ErrorIs(t, err, registry.ErrNotExist)
 	})
 }

--- a/internal/shim/system.go
+++ b/internal/shim/system.go
@@ -65,7 +65,7 @@ func NewSystemShimManager() (*ShimManager, error) {
 			BinDir:          SystemBinDir(),
 			PMGBin:          pmgBin,
 			PackageManagers: aliasCfg.PackageManagers,
-			SkipShellRc:     true,
+			SkipUserPath:    true,
 			SystemProfile:   true,
 		},
 	}, nil

--- a/internal/shim/system_unix_test.go
+++ b/internal/shim/system_unix_test.go
@@ -39,7 +39,7 @@ func TestSystemShimManagerInstallAndRemove(t *testing.T) {
 
 	mgr, err := NewSystemShimManager()
 	require.NoError(t, err)
-	assert.True(t, mgr.config.SkipShellRc)
+	assert.True(t, mgr.config.SkipUserPath)
 	assert.True(t, mgr.config.SystemProfile)
 	assert.Equal(t, SystemBinDir(), mgr.GetBinDir())
 

--- a/internal/shim/winpath_windows.go
+++ b/internal/shim/winpath_windows.go
@@ -56,7 +56,26 @@ func unregisterUserPath(dir string) error {
 			kept = append(kept, entry)
 		}
 	}
+	if len(kept) == 0 {
+		// The shim entry was the only one. Before the install there was no
+		// value, so leave none behind.
+		return deleteUserPath()
+	}
 	return writeUserPath(kept, expand)
+}
+
+func deleteUserPath() error {
+	key, err := registry.OpenKey(registry.CURRENT_USER, userEnvironmentKey, registry.SET_VALUE)
+	if err != nil {
+		return fmt.Errorf("failed to open HKCU\\%s for writing: %w", userEnvironmentKey, err)
+	}
+	defer key.Close()
+
+	if err := key.DeleteValue(pathValueName); err != nil && !errors.Is(err, registry.ErrNotExist) {
+		return fmt.Errorf("failed to delete the user PATH: %w", err)
+	}
+	broadcastEnvironmentChange()
+	return nil
 }
 
 func userPathContains(dir string) (bool, error) {

--- a/internal/shim/winpath_windows.go
+++ b/internal/shim/winpath_windows.go
@@ -5,6 +5,7 @@ package shim
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"unsafe"
 
@@ -139,8 +140,18 @@ func broadcastEnvironmentChange() {
 		return
 	}
 
+	// Find keeps Call from panicking on a build with no user32.dll, such as
+	// Nano Server.
+	if err := procSendMessageTimeoutW.Find(); err != nil {
+		log.Warnf("failed to broadcast the PATH change: %v", err)
+		return
+	}
+
 	r1, _, callErr := procSendMessageTimeoutW.Call(hwndBroadcast, wmSettingChange, 0,
 		uintptr(unsafe.Pointer(section)), smtoAbortIfHung, timeoutMillis, 0)
+	// LazyProc.Call is not the syscall form the compiler recognises, so the
+	// pointer needs an explicit hold until the call returns.
+	runtime.KeepAlive(section)
 	if r1 == 0 {
 		log.Warnf("failed to broadcast the PATH change: %v", callErr)
 	}

--- a/internal/shim/winpath_windows.go
+++ b/internal/shim/winpath_windows.go
@@ -1,0 +1,147 @@
+//go:build windows
+
+package shim
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/safedep/dry/log"
+	"github.com/safedep/pmg/internal/fsutil"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+// userEnvironmentKey is the HKCU subkey that holds the per-user PATH. Tests
+// point it at a scratch key. There is intentionally no env var or flag.
+var userEnvironmentKey = `Environment`
+
+const pathValueName = "Path"
+
+var (
+	user32                  = windows.NewLazySystemDLL("user32.dll")
+	procSendMessageTimeoutW = user32.NewProc("SendMessageTimeoutW")
+)
+
+// registerUserPath prepends dir to the user PATH in the registry. It writes
+// the registry directly rather than through setx, which truncates a value at
+// 1024 characters and would corrupt a developer's PATH.
+func registerUserPath(dir string) error {
+	entries, expand, err := readUserPath()
+	if err != nil {
+		return err
+	}
+	if containsPath(entries, dir) {
+		return nil
+	}
+	return writeUserPath(append([]string{dir}, entries...), expand)
+}
+
+// unregisterUserPath removes every entry that names dir from the user PATH.
+func unregisterUserPath(dir string) error {
+	entries, expand, err := readUserPath()
+	if err != nil {
+		return err
+	}
+	if !containsPath(entries, dir) {
+		return nil
+	}
+
+	kept := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !fsutil.SamePath(entry, dir) {
+			kept = append(kept, entry)
+		}
+	}
+	return writeUserPath(kept, expand)
+}
+
+func userPathContains(dir string) (bool, error) {
+	entries, _, err := readUserPath()
+	if err != nil {
+		return false, err
+	}
+	return containsPath(entries, dir), nil
+}
+
+func containsPath(entries []string, dir string) bool {
+	for _, entry := range entries {
+		if fsutil.SamePath(entry, dir) {
+			return true
+		}
+	}
+	return false
+}
+
+// readUserPath returns the raw PATH entries and whether the value is
+// REG_EXPAND_SZ. The raw form keeps %USERPROFILE% style references that
+// other tools wrote, so a write does not flatten them.
+func readUserPath() (entries []string, expand bool, err error) {
+	key, err := registry.OpenKey(registry.CURRENT_USER, userEnvironmentKey, registry.QUERY_VALUE)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to open HKCU\\%s: %w", userEnvironmentKey, err)
+	}
+	defer key.Close()
+
+	value, valueType, err := key.GetStringValue(pathValueName)
+	if errors.Is(err, registry.ErrNotExist) {
+		return nil, true, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read the user PATH: %w", err)
+	}
+
+	for _, entry := range strings.Split(value, ";") {
+		if entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries, valueType == registry.EXPAND_SZ, nil
+}
+
+func writeUserPath(entries []string, expand bool) error {
+	key, err := registry.OpenKey(registry.CURRENT_USER, userEnvironmentKey, registry.SET_VALUE)
+	if err != nil {
+		return fmt.Errorf("failed to open HKCU\\%s for writing: %w", userEnvironmentKey, err)
+	}
+	defer key.Close()
+
+	value := strings.Join(entries, ";")
+	if expand {
+		err = key.SetExpandStringValue(pathValueName, value)
+	} else {
+		err = key.SetStringValue(pathValueName, value)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to write the user PATH: %w", err)
+	}
+
+	broadcastEnvironmentChange()
+	return nil
+}
+
+// broadcastEnvironmentChange tells every top-level window that the
+// environment changed, so a new shell started from Explorer sees the PATH
+// without a sign-out. A failure only delays that until the next sign-in.
+func broadcastEnvironmentChange() {
+	const (
+		hwndBroadcast   = 0xffff
+		wmSettingChange = 0x001a
+		smtoAbortIfHung = 0x0002
+		timeoutMillis   = 5000
+	)
+
+	section, err := windows.UTF16PtrFromString("Environment")
+	if err != nil {
+		log.Warnf("failed to broadcast the PATH change: %v", err)
+		return
+	}
+
+	r1, _, callErr := procSendMessageTimeoutW.Call(hwndBroadcast, wmSettingChange, 0,
+		uintptr(unsafe.Pointer(section)), smtoAbortIfHung, timeoutMillis, 0)
+	if r1 == 0 {
+		log.Warnf("failed to broadcast the PATH change: %v", callErr)
+	}
+}

--- a/internal/ui/info.go
+++ b/internal/ui/info.go
@@ -25,9 +25,13 @@ func PrintInfoSection(title string, entries map[string]string) {
 	}
 }
 
+// PrintSetupInstallCmdInfo reports what setup wrote. aliasPath is empty on
+// Windows, where PMG installs no shell alias.
 func PrintSetupInstallCmdInfo(aliasPath, shimBinDir, configPath string) {
 	fmt.Printf("%s %s\n", Colors.Green("✓"), "PMG installed successfully")
-	fmt.Printf("   %s\n", Colors.Dim(fmt.Sprintf("Aliases: %s", aliasPath)))
+	if aliasPath != "" {
+		fmt.Printf("   %s\n", Colors.Dim(fmt.Sprintf("Aliases: %s", aliasPath)))
+	}
 	fmt.Printf("   %s\n", Colors.Dim(fmt.Sprintf("Shims:   %s", shimBinDir)))
 	fmt.Printf("   %s\n", Colors.Dim(fmt.Sprintf("Config:  %s", configPath)))
 	fmt.Printf("   %s\n", Colors.Dim("Restart your terminal for changes to take effect"))


### PR DESCRIPTION
## What this implements

Decision group 1 of [`2026-09-09-pmg-windows-support-design.md`](https://github.com/safedep/control-tower/blob/main/docs/specs/2026-09-09-pmg-windows-support-design.md): shims are the primary interception on Windows.

`pmg setup install` writes one `.cmd` file for each supported package manager into `%LOCALAPPDATA%\safedep\pmg\bin`, then prepends that directory to the user PATH in `HKCU\Environment`. `pmg setup remove` deletes the shim files and the PATH entry. Both Windows short-circuits in `cmd/setup/setup.go` are gone.

## Why this is a useful standalone increment

After this change a Windows developer runs `npm install` and the shim routes it through PMG, with no change to how they type, for every manager that a new shell resolves from the user PATH. Nothing else in the spec gives a Windows machine any protection. It also introduces `PMG_RAW_ARGS`, which the launch contract (decision group 2, #455) consumes.

## The shim body

```bat
@echo off
rem # PMG shim - do not edit, managed by pmg setup
setlocal DisableDelayedExpansion
if not exist "C:\...\pmg.exe" (
  echo [pmg] error: PMG binary not found: "C:\...\pmg.exe" 1>&2
  echo [pmg] error: reinstall PMG and run 'pmg setup install', or delete "%~dp0" to remove the shims 1>&2
  exit /b 127
)
set "PMG_SHIM_PATH=%~f0"
set PMG_RAW_ARGS=%*
"C:\...\pmg.exe" npm %*
exit /b %ERRORLEVEL%
```

Line by line: `DisableDelayedExpansion` is explicit so `!NAME!` never expands inside the captured tail whatever the parent shell enabled. The missing-binary guard fails closed with the same message as the sh shim, and quotes both paths because an unquoted `)` in `Program Files (x86)` would end the block. `PMG_SHIM_PATH` makes `FilterPMGFromPath` strip the shim directory. `PMG_RAW_ARGS` carries the tail byte for byte, and its `set` line has no wrapping quotes on purpose: `set "VAR=%*"` would make the user's own quotes close instead of open, so `install "lodash@>=4"` would write a file named `=4`. `pmg.exe` is named by absolute path, and a `%` in that path is doubled. The marker lives in a `rem` line so `shimsPresent`, `UserShimsInstalled`, `pmg setup info` and `pmg setup status` recognise a `.cmd` shim with no change.

## Known limits

Two are from review and are not fixed by a user-scope PATH entry:

- **The machine PATH sits ahead of the user PATH.** A manager that a machine-wide installer put on the machine PATH, such as `npm` from the Node.js MSI under `C:\Program Files\nodejs`, resolves before the shim. #454 makes `pmg setup install` warn which managers this affects and makes `pmg setup doctor` report it, with a test of the effective machine-then-user order. The fix that needs elevation is its own increment after #456: one `REG_EXPAND_SZ` entry, `%LOCALAPPDATA%\safedep\pmg\bin`, at the front of the machine PATH, which Windows expands per user, so nothing shared is writable.
- **Git Bash does not apply `PATHEXT`**, so it resolves `npm` to Node's own `npm` shell script and never runs a `.cmd`. Documented in #456. An extensionless sh shim next to the `.cmd` is the follow-up.

The shim's launch line still passes `%*`, so an argument with an unquoted `&` or `>` that reaches the batch file splits the line. This matches `npm.cmd`, which does the same. Tracked with #455.

## Files

| File | Owns |
|---|---|
| `internal/shim/script_windows.go` | The `.cmd` body and the `.cmd` extension |
| `internal/shim/script_unix.go` | The existing `#!/bin/sh` body, moved unchanged, and the rc-file PATH hooks |
| `internal/shim/winpath_windows.go` | Read and write of `Path` in `HKCU\Environment`, and the `WM_SETTINGCHANGE` broadcast |
| `internal/shim/shim.go` | Calls the platform hooks. No platform branch |
| `cmd/setup/setup.go` | Both Windows short-circuits removed. The alias layer runs off Windows only, because PMG installs no shell alias there |
| `internal/ui/info.go` | No `Aliases:` line when there is none |

The registry write keeps the value's `REG_EXPAND_SZ` type, so `%USERPROFILE%` style entries other tools wrote stay unexpanded. PMG does not call `setx`, which truncates at 1024 characters. `x/sys/windows` has no `SendMessageTimeout`, so the broadcast goes through `user32.dll` directly. A broadcast failure is logged, not returned: it only delays the new PATH until the next sign-in.

## Effect on macOS and Linux

None. The `#!/bin/sh` shim body moves from `shim.go` to `script_unix.go` byte for byte, and the rc-file PATH hooks it calls are the same functions under a platform-neutral name (`installPath`, `removePath`, `pathInstalled`). Every Windows piece sits in a `_windows.go` file. `cmd/setup` runs the alias layer exactly as before off Windows; the new branch only skips it on Windows. `PrintSetupInstallCmdInfo` prints the same lines when an alias path is given. The Unix shim tests moved to `shim_unix_test.go` unchanged and pass.

## What is intentionally left for later

- The launch contract that reads `PMG_RAW_ARGS` and starts a `.cmd` through `cmd.exe` (decision group 2). Until it lands, a shim invocation on Windows runs the same path as a direct `pmg npm ...` does today.
- The Windows forms of the doctor checks and the install-time shadowing warning (decision group 4, #454).
- Machine-scope shims (`--system`) stay a non-goal. The machine PATH entry that points at each user's own directory is a separate, smaller change.

## Tests and validation

- `internal/shim/shim_cmd_windows_test.go` (`//go:build windows`): the generated `.cmd` runs through a real `cmd.exe`, with the test binary as `pmg.exe` at a path that carries a space, a parenthesis, an ampersand and a percent sign. Six tails, `install "lodash@>=4"`, `"a & b"`, `"^1 || ^2"`, `100%`, `!x!` and empty, each asserting the exit code, the exact `PMG_RAW_ARGS`, the marker, and an empty working directory. One more removes `pmg.exe` and asserts exit 127 with the pmg message. This is the test that proves the two parse fixes from review.
- `internal/shim/shim_windows_test.go` (`//go:build windows`):
  - `TestShimManagerInstallWritesCmdShims`: every line of the body, with `100% (x86) & co\pmg.exe` as the binary path.
  - `TestShimManagerRemoveDeletesShimsAndPathEntry`.
  - `TestUserPathRegistry`: prepend once, keep `REG_EXPAND_SZ`, case-folded contains, remove only the shim entry, a missing `Path` value, and removing the only entry leaves no value behind.
  - Every test points the registry code at one flat scratch key, `HKCU\Software\pmg-test-<test>`, and deletes it after, so no test edits the runner's real PATH and nothing is left behind.
- `internal/shim/shim_unix_test.go`: the sh body and rc-file tests, moved from `shim_test.go`. The tests that stay in `shim_test.go` run on both platforms and call `isolateUserPath`, which is a no-op off Windows.
- `go test -count=1 ./internal/shim ./cmd/setup ./internal/ui ./internal/doctor` passes on darwin. `go build ./...`, `go vet`, `GOOS=windows go build ./...` and `GOOS=windows go vet ./...` pass.
- The Windows job on this pull request is green, and every test above ran on the runner.

## Dependencies

- Based on `main` after #449, #450 and #453. #450's case-folded `FilterPMGFromPath` is the guard that stops a `.cmd` shim from calling itself, so it had to land first.
- Blocks #454 (doctor), #455 (launch contract) and #456 (Windows e2e and docs), which are stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

