### PR TITLE
chore: bump ptyx and carry CmdLine through internal/pty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/posthog/posthog-go v1.5.12
 	github.com/rogpeppe/go-internal v1.14.1
 	github.com/safedep/dry v0.0.0-20260902122517-5c323129f964
-	github.com/safedep/ptyx v0.2.1-0.20260529140457-d1f745842a6a
+	github.com/safedep/ptyx v0.2.1-0.20260909105230-dd649ef656c4
 	github.com/sony/gobreaker/v2 v2.4.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safedep/dry v0.0.0-20260902122517-5c323129f964 h1:5ES217esJFa/YsWbdVU8cKKupzWV/F7rVQXIDU7NusU=
 github.com/safedep/dry v0.0.0-20260902122517-5c323129f964/go.mod h1:W/OgEQaB88bPxIKUHKZ2S9lYMtO7lsFlo/j1yNv8HDg=
-github.com/safedep/ptyx v0.2.1-0.20260529140457-d1f745842a6a h1:oJu4dgmz/weiU3CMhFKiXd5zwgvPwPsm20MzG/uAt0s=
-github.com/safedep/ptyx v0.2.1-0.20260529140457-d1f745842a6a/go.mod h1:fyt+PACz6dtEoqsnE0BPPv/lHpuBG/8zkDqeIVcyRY4=
+github.com/safedep/ptyx v0.2.1-0.20260909105230-dd649ef656c4 h1:LWDnKQ+lmWK5gZch0LPRpaHxH9ZHuXDSIlW/v23vcD8=
+github.com/safedep/ptyx v0.2.1-0.20260909105230-dd649ef656c4/go.mod h1:fyt+PACz6dtEoqsnE0BPPv/lHpuBG/8zkDqeIVcyRY4=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -79,6 +79,12 @@ type SessionConfig struct {
 	Command string
 	Args    []string
 	Env     []string
+
+	// CmdLine is the raw Windows command line, passed to ptyx and then to
+	// CreateProcess with no escaping. Set it when the CommandLineToArgvW
+	// rules that Args follows are the wrong rules, for example to start a
+	// batch file through cmd.exe. Windows only, and exclusive with Args.
+	CmdLine string
 }
 
 func NewSessionConfig(cmd string, args, env []string) SessionConfig {
@@ -92,8 +98,8 @@ func NewSessionConfig(cmd string, args, env []string) SessionConfig {
 // NewSession creates a new interactive PTY session.
 // The terminal is put into raw mode automatically.
 func NewSession(ctx context.Context, cfg SessionConfig) (InteractiveSession, error) {
-	if cfg.Command == "" {
-		return nil, fmt.Errorf("pty session requires command")
+	if err := cfg.validate(); err != nil {
+		return nil, err
 	}
 
 	// 1. Create console
@@ -116,13 +122,7 @@ func NewSession(ctx context.Context, cfg SessionConfig) (InteractiveSession, err
 	cols, rows := c.Size()
 
 	// 4. Spawn the process
-	s, err := ptyx.Spawn(ctx, ptyx.SpawnOpts{
-		Prog: cfg.Command,
-		Args: cfg.Args,
-		Cols: cols,
-		Rows: rows,
-		Env:  cfg.Env,
-	})
+	s, err := ptyx.Spawn(ctx, cfg.spawnOpts(cols, rows))
 	if err != nil {
 		// We are already in error state, restore and close is best effort.
 		_ = c.Restore(oldState)
@@ -140,6 +140,27 @@ func NewSession(ctx context.Context, cfg SessionConfig) (InteractiveSession, err
 	go sess.forwardResize()
 
 	return sess, nil
+}
+
+func (cfg SessionConfig) validate() error {
+	if cfg.Command == "" {
+		return fmt.Errorf("pty session requires command")
+	}
+	if cfg.CmdLine != "" && len(cfg.Args) > 0 {
+		return fmt.Errorf("pty session accepts CmdLine or Args, not both")
+	}
+	return nil
+}
+
+func (cfg SessionConfig) spawnOpts(cols, rows int) ptyx.SpawnOpts {
+	return ptyx.SpawnOpts{
+		Prog:    cfg.Command,
+		Args:    cfg.Args,
+		CmdLine: cfg.CmdLine,
+		Cols:    cols,
+		Rows:    rows,
+		Env:     cfg.Env,
+	}
 }
 
 // forwardResize passes terminal size changes to the child. A TUI agent

--- a/internal/pty/session_test.go
+++ b/internal/pty/session_test.go
@@ -1,9 +1,12 @@
 package pty
 
 import (
+	"context"
 	"testing"
 
+	"github.com/safedep/ptyx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsInteractiveTerminal(t *testing.T) {
@@ -46,4 +49,32 @@ func TestIsInteractiveTerminal(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// Without this the field can stop at the PMG layer and no other test notices.
+func TestSessionConfigCmdLineReachesSpawnOpts(t *testing.T) {
+	cfg := SessionConfig{
+		Command: `C:\Windows\System32\cmd.exe`,
+		CmdLine: `cmd.exe /d /s /v:off /c ""C:\npm.cmd" install lodash"`,
+		Env:     []string{"A=B"},
+	}
+
+	assert.Equal(t, ptyx.SpawnOpts{
+		Prog:    cfg.Command,
+		CmdLine: cfg.CmdLine,
+		Cols:    120,
+		Rows:    40,
+		Env:     cfg.Env,
+	}, cfg.spawnOpts(120, 40))
+}
+
+func TestNewSessionRejectsCmdLineWithArgs(t *testing.T) {
+	// The guard runs before the console opens, so this holds without a TTY.
+	_, err := NewSession(context.Background(), SessionConfig{
+		Command: "cmd.exe",
+		Args:    []string{"/c", "dir"},
+		CmdLine: `cmd.exe /c dir`,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CmdLine or Args, not both")
 }


### PR DESCRIPTION
## What this implements

The PMG half of the `ptyx` seam in [`2026-09-09-pmg-windows-support-design.md`](https://github.com/safedep/control-tower/blob/main/docs/specs/2026-09-09-pmg-windows-support-design.md), decision group 2: `go.mod` moves to the `ptyx` merge commit that carries `SpawnOpts.CmdLine` (safedep/ptyx#4), and `internal/pty.SessionConfig` carries the same field into `ptyx.SpawnOpts`.

## Why this is a useful standalone increment

The spec names one cross-repository ordering constraint: the `ptyx` change merges first, then PMG bumps the dependency. This is that bump, together with the one layer of plumbing between `internal/runner` and `ptyx`. Without it the launch contract can set `CmdLine` on `SessionConfig` and the value stops one layer short, and the spec says no other test would notice.

The change is inert until the launch contract sets the field. Every existing caller passes no `CmdLine`, and `spawnOpts` produces the same `ptyx.SpawnOpts` it did before.

## Changes

- `go.mod`, `go.sum`: `ptyx v0.2.1-0.20260909105230-dd649ef656c4`, a pseudo-version on the merge commit of safedep/ptyx#4. `go mod tidy` changes nothing else.
- `internal/pty/session.go`: `SessionConfig.CmdLine`, documented as Windows only and exclusive with `Args`. `NewSession` validates before it opens the console, so the guard holds on a machine with no TTY. `spawnOpts` maps the config to `ptyx.SpawnOpts`.

## Effect on macOS and Linux

None. No caller sets `CmdLine`, so `spawnOpts` builds the same `ptyx.SpawnOpts` as before. The `ptyx` diff between the two pinned commits is the `CmdLine` field, its guards and their tests. Off Windows `ptyx.Spawn` rejects a non-empty `CmdLine`, so a mistaken use fails loudly rather than behaving differently per platform.

## What is intentionally left for later

- Setting `CmdLine` from `internal/runner` when the resolved binary is a `.cmd` and `PMG_RAW_ARGS` is set (decision group 2, the launch contract).

## Tests and validation

- `TestSessionConfigCmdLineReachesSpawnOpts`: the field lands in `ptyx.SpawnOpts` unchanged, next to `Prog`, `Env`, `Cols` and `Rows`.
- `TestNewSessionRejectsCmdLineWithArgs`: the guard fires before any console work.
- `go test -count=1 ./internal/pty ./internal/runner` passes on darwin. `go build ./...`, `GOOS=windows go build ./...`, `go vet` and `GOOS=windows go vet ./internal/pty` pass.

## Dependencies

- safedep/ptyx#4, merged.
- Based on `main` after #449 and #450. Independent of #452.
- Blocks the launch contract (decision group 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)