### PR TITLE
feat: report Windows interception in doctor

### DIFF
--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -353,24 +353,51 @@ func pathContainsDir(pathEntries []string, dir string) bool {
 	return false
 }
 
-// classifyPackageManagerResolutions splits package managers by where they
-// resolve on PATH: underShim means the command runs through a pmg shim (so it
-// is intercepted), shadowed means a real npm/pip sits ahead of the shims (so
-// interception is bypassed and the user should be warned).
-func classifyPackageManagerResolutions(packageManagers []string, shimDirs []string, lookPath func(string) (string, error)) (underShim, shadowed []string) {
+// managerResolution is where one package manager resolves on PATH. UnderShim
+// means the command runs through a pmg shim, so it is intercepted. Otherwise
+// a real npm or pip sits ahead of the shims and the user should be warned.
+type managerResolution struct {
+	Name      string
+	Path      string
+	UnderShim bool
+}
+
+// resolveManagers looks each manager up once. A manager that does not resolve
+// is omitted. The install warning and the doctor check both read from this
+// result, so neither resolves a manager a second time.
+func resolveManagers(packageManagers []string, shimDirs []string, lookPath func(string) (string, error)) []managerResolution {
+	resolutions := make([]managerResolution, 0, len(packageManagers))
 	for _, pm := range packageManagers {
 		resolved, err := lookPath(pm)
 		if err != nil {
 			continue
 		}
+		resolutions = append(resolutions, managerResolution{
+			Name:      pm,
+			Path:      resolved,
+			UnderShim: resolvesUnderAny(resolved, shimDirs),
+		})
+	}
+	return resolutions
+}
 
-		if resolvesUnderAny(resolved, shimDirs) {
-			underShim = append(underShim, pm)
-			continue
+func partitionResolutions(resolutions []managerResolution) (underShim, shadowed []managerResolution) {
+	for _, r := range resolutions {
+		if r.UnderShim {
+			underShim = append(underShim, r)
+		} else {
+			shadowed = append(shadowed, r)
 		}
-		shadowed = append(shadowed, pm)
 	}
 	return underShim, shadowed
+}
+
+func managerNames(resolutions []managerResolution) []string {
+	names := make([]string, 0, len(resolutions))
+	for _, r := range resolutions {
+		names = append(names, r.Name)
+	}
+	return names
 }
 
 func resolvesUnderAny(path string, dirs []string) bool {
@@ -397,19 +424,18 @@ func shimDirs() []string {
 // shimDirs(); shimDir/pathLabel only select the PATH-membership fallback and
 // the display label, not which directories count as intercepting.
 func checkShimDirResolution(shimDir, pathLabel string, pathEntries []string) doctor.CheckResult {
-	lookPath := shimLookPath(pathEntries)
-	underShim, shadowed := classifyPackageManagerResolutions(
+	underShim, shadowed := partitionResolutions(resolveManagers(
 		alias.DefaultConfig().PackageManagers,
 		shimDirs(),
-		lookPath,
-	)
+		shimLookPath(pathEntries),
+	))
 
 	if len(shadowed) > 0 {
 		if pathContainsDir(pathEntries, shimDir) || len(underShim) > 0 {
 			return doctor.CheckResult{
 				Status:  doctor.StatusWarn,
-				Message: fmt.Sprintf("%s resolved outside %s", strings.Join(shadowed, ", "), pathLabel),
-				Fix:     shadowedFix(shadowed, lookPath),
+				Message: fmt.Sprintf("%s resolved outside %s", strings.Join(managerNames(shadowed), ", "), pathLabel),
+				Fix:     shadowedFix(shadowed),
 			}
 		}
 		return doctor.CheckResult{

--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -171,7 +171,7 @@ func runCoreChecks(cfg *config.RuntimeConfig) []doctor.CheckResult {
 						Message: fmt.Sprintf("Could not check shims: %v", err),
 					}
 				}
-				return checkShimDirectoryFiles(sm.GetBinDir())
+				return checkShimDirectoryResult(sm.GetBinDir(), alias.DefaultConfig().PackageManagers)
 			},
 		},
 		{
@@ -353,60 +353,55 @@ func pathContainsDir(pathEntries []string, dir string) bool {
 	return false
 }
 
-// managerResolution is where one package manager resolves on PATH. UnderShim
-// means the command runs through a pmg shim, so it is intercepted. Otherwise
-// a real npm or pip sits ahead of the shims and the user should be warned.
-type managerResolution struct {
-	Name      string
-	Path      string
-	UnderShim bool
-}
-
-// resolveManagers looks each manager up once. A manager that does not resolve
-// is omitted. The install warning and the doctor check both read from this
-// result, so neither resolves a manager a second time.
-func resolveManagers(packageManagers []string, shimDirs []string, lookPath func(string) (string, error)) []managerResolution {
-	resolutions := make([]managerResolution, 0, len(packageManagers))
-	for _, pm := range packageManagers {
-		resolved, err := lookPath(pm)
-		if err != nil {
-			continue
-		}
-		resolutions = append(resolutions, managerResolution{
-			Name:      pm,
-			Path:      resolved,
-			UnderShim: resolvesUnderAny(resolved, shimDirs),
-		})
-	}
-	return resolutions
-}
-
-func partitionResolutions(resolutions []managerResolution) (underShim, shadowed []managerResolution) {
-	for _, r := range resolutions {
-		if r.UnderShim {
-			underShim = append(underShim, r)
-		} else {
-			shadowed = append(shadowed, r)
+// checkShimDirectoryResult maps the shim inspection to a status. A shim from
+// an older install can name a pmg binary that moved or is gone, so a stale
+// shim fails the check like a missing one.
+func checkShimDirectoryResult(shimDir string, managers []string) doctor.CheckResult {
+	pmgBin, err := os.Executable()
+	if err != nil {
+		return doctor.CheckResult{
+			Status:  doctor.StatusWarn,
+			Message: fmt.Sprintf("Could not resolve the pmg binary: %v", err),
 		}
 	}
-	return underShim, shadowed
+
+	inspection, err := shim.InspectShimFiles(shimDir, managers, pmgBin)
+	if err != nil {
+		return doctor.CheckResult{
+			Status:  doctor.StatusWarn,
+			Message: fmt.Sprintf("Could not check shims: %v", err),
+		}
+	}
+
+	switch {
+	case len(inspection.Missing) == len(managers):
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: "Shim directory not found",
+		}
+	case len(inspection.Stale) > 0:
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: fmt.Sprintf("Shims for %s name another pmg binary", strings.Join(inspection.Stale, ", ")),
+		}
+	case len(inspection.Missing) > 0:
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: fmt.Sprintf("Shims missing for %s", strings.Join(inspection.Missing, ", ")),
+		}
+	}
+	return doctor.CheckResult{
+		Status:  doctor.StatusPass,
+		Message: "Shims found, each names this pmg binary",
+	}
 }
 
-func managerNames(resolutions []managerResolution) []string {
+func managerNames(resolutions []shim.ManagerResolution) []string {
 	names := make([]string, 0, len(resolutions))
 	for _, r := range resolutions {
 		names = append(names, r.Name)
 	}
 	return names
-}
-
-func resolvesUnderAny(path string, dirs []string) bool {
-	for _, dir := range dirs {
-		if fsutil.PathWithinDir(path, dir) {
-			return true
-		}
-	}
-	return false
 }
 
 // shimDirs lists every directory a package manager may legitimately resolve
@@ -423,12 +418,9 @@ func shimDirs() []string {
 // checkShimDirResolution classifies interception against all shim dirs via
 // shimDirs(); shimDir/pathLabel only select the PATH-membership fallback and
 // the display label, not which directories count as intercepting.
-func checkShimDirResolution(shimDir, pathLabel string, pathEntries []string) doctor.CheckResult {
-	underShim, shadowed := partitionResolutions(resolveManagers(
-		alias.DefaultConfig().PackageManagers,
-		shimDirs(),
-		shimLookPath(pathEntries),
-	))
+func checkShimDirResolution(shimDir, pathLabel string, inspection shim.InterceptionInspection) doctor.CheckResult {
+	pathEntries := inspection.PathEntries
+	underShim, shadowed := inspection.Partition()
 
 	if len(shadowed) > 0 {
 		if pathContainsDir(pathEntries, shimDir) || len(underShim) > 0 {
@@ -464,7 +456,13 @@ func checkShimDirResolution(shimDir, pathLabel string, pathEntries []string) doc
 }
 
 func checkShimInPathResult() doctor.CheckResult {
-	pathEntries := shimPathEntries()
+	inspection, err := shim.InspectInterception(alias.DefaultConfig().PackageManagers, shimDirs())
+	if err != nil {
+		return doctor.CheckResult{
+			Status:  doctor.StatusWarn,
+			Message: fmt.Sprintf("Could not resolve package managers on PATH: %v", err),
+		}
+	}
 
 	// The primary directory only picks the label and PATH-membership target;
 	// classification accepts resolution into either shim dir regardless.
@@ -480,7 +478,7 @@ func checkShimInPathResult() doctor.CheckResult {
 		shimDir, pathLabel = userDir, "Shim directory"
 	}
 
-	return checkShimDirResolution(shimDir, pathLabel, pathEntries)
+	return checkShimDirResolution(shimDir, pathLabel, inspection)
 }
 
 func runProtectionChecks(coreResults []doctor.CheckResult) []doctor.CheckResult {

--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/safedep/dry/log"
@@ -171,18 +171,7 @@ func runCoreChecks(cfg *config.RuntimeConfig) []doctor.CheckResult {
 						Message: fmt.Sprintf("Could not check shims: %v", err),
 					}
 				}
-				shimDir := sm.GetBinDir()
-				info, err := os.Stat(shimDir)
-				if err != nil || !info.IsDir() {
-					return doctor.CheckResult{
-						Status:  doctor.StatusFail,
-						Message: "Shim directory not found",
-					}
-				}
-				return doctor.CheckResult{
-					Status:  doctor.StatusPass,
-					Message: "Shim directory found",
-				}
+				return checkShimDirectoryFiles(sm.GetBinDir())
 			},
 		},
 		{
@@ -261,6 +250,12 @@ func runCoreChecks(cfg *config.RuntimeConfig) []doctor.CheckResult {
 				return evaluateCACheck(cfg.ConfigDir(), user, system, truststore.UserScopeSupported())
 			},
 		},
+	}
+
+	// PMG installs no shell alias on Windows, and a check for a layer that
+	// does not exist would report a false problem.
+	if runtime.GOOS == "windows" {
+		checks = slices.DeleteFunc(checks, func(c doctor.Check) bool { return c.Name == checkShellAliases })
 	}
 
 	// System-only: the binary every user's shim execs must stay root-owned and
@@ -405,7 +400,7 @@ func checkShimDirResolution(shimDir, pathLabel string, pathEntries []string) doc
 	underShim, shadowed := classifyPackageManagerResolutions(
 		alias.DefaultConfig().PackageManagers,
 		shimDirs(),
-		exec.LookPath,
+		shimLookPath(pathEntries),
 	)
 
 	if len(shadowed) > 0 {
@@ -441,7 +436,7 @@ func checkShimDirResolution(shimDir, pathLabel string, pathEntries []string) doc
 }
 
 func checkShimInPathResult() doctor.CheckResult {
-	pathEntries := filepath.SplitList(os.Getenv("PATH"))
+	pathEntries := shimPathEntries()
 
 	// The primary directory only picks the label and PATH-membership target;
 	// classification accepts resolution into either shim dir regardless.

--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -397,10 +397,11 @@ func shimDirs() []string {
 // shimDirs(); shimDir/pathLabel only select the PATH-membership fallback and
 // the display label, not which directories count as intercepting.
 func checkShimDirResolution(shimDir, pathLabel string, pathEntries []string) doctor.CheckResult {
+	lookPath := shimLookPath(pathEntries)
 	underShim, shadowed := classifyPackageManagerResolutions(
 		alias.DefaultConfig().PackageManagers,
 		shimDirs(),
-		shimLookPath(pathEntries),
+		lookPath,
 	)
 
 	if len(shadowed) > 0 {
@@ -408,6 +409,7 @@ func checkShimDirResolution(shimDir, pathLabel string, pathEntries []string) doc
 			return doctor.CheckResult{
 				Status:  doctor.StatusWarn,
 				Message: fmt.Sprintf("%s resolved outside %s", strings.Join(shadowed, ", "), pathLabel),
+				Fix:     shadowedFix(shadowed, lookPath),
 			}
 		}
 		return doctor.CheckResult{

--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -355,17 +355,9 @@ func pathContainsDir(pathEntries []string, dir string) bool {
 
 // checkShimDirectoryResult maps the shim inspection to a status. A shim from
 // an older install can name a pmg binary that moved or is gone, so a stale
-// shim fails the check like a missing one.
+// shim gets a status of its own.
 func checkShimDirectoryResult(shimDir string, managers []string) doctor.CheckResult {
-	pmgBin, err := os.Executable()
-	if err != nil {
-		return doctor.CheckResult{
-			Status:  doctor.StatusWarn,
-			Message: fmt.Sprintf("Could not resolve the pmg binary: %v", err),
-		}
-	}
-
-	inspection, err := shim.InspectShimFiles(shimDir, managers, pmgBin)
+	inspection, err := shim.InspectShimFiles(shimDir, managers)
 	if err != nil {
 		return doctor.CheckResult{
 			Status:  doctor.StatusWarn,
@@ -373,23 +365,34 @@ func checkShimDirectoryResult(shimDir string, managers []string) doctor.CheckRes
 		}
 	}
 
-	switch {
-	case len(inspection.Missing) == len(managers):
+	if len(inspection.Missing) == len(managers) {
 		return doctor.CheckResult{
 			Status:  doctor.StatusFail,
-			Message: "Shim directory not found",
-		}
-	case len(inspection.Stale) > 0:
-		return doctor.CheckResult{
-			Status:  doctor.StatusFail,
-			Message: fmt.Sprintf("Shims for %s name another pmg binary", strings.Join(inspection.Stale, ", ")),
-		}
-	case len(inspection.Missing) > 0:
-		return doctor.CheckResult{
-			Status:  doctor.StatusFail,
-			Message: fmt.Sprintf("Shims missing for %s", strings.Join(inspection.Missing, ", ")),
+			Message: "No shims found",
 		}
 	}
+
+	// A shim with no file and a shim that names a pmg binary which is gone
+	// both break the command, one with nothing on PATH and one with exit 127.
+	// `pmg setup install` is the fix for each, so they report together.
+	if broken := append(inspection.Missing, inspection.BinaryMissing...); len(broken) > 0 {
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: fmt.Sprintf("Shims missing or broken for %s", strings.Join(broken, ", ")),
+		}
+	}
+
+	// A shim that names another pmg binary still intercepts, through that
+	// binary. That happens with two installs, or when doctor runs from a
+	// local build. It is worth reporting and it is not a failure.
+	if len(inspection.BinaryDiffers) > 0 {
+		return doctor.CheckResult{
+			Status:  doctor.StatusWarn,
+			Message: fmt.Sprintf("Shims for %s name another pmg binary", strings.Join(inspection.BinaryDiffers, ", ")),
+			Fix:     "Run `pmg setup install` to point the shims at this pmg binary",
+		}
+	}
+
 	return doctor.CheckResult{
 		Status:  doctor.StatusPass,
 		Message: "Shims found, each names this pmg binary",

--- a/cmd/setup/doctor_other.go
+++ b/cmd/setup/doctor_other.go
@@ -2,39 +2,11 @@
 
 package setup
 
-import (
-	"os"
-	"os/exec"
-	"path/filepath"
-
-	"github.com/safedep/pmg/internal/doctor"
-)
-
-func shimPathEntries() []string {
-	return filepath.SplitList(os.Getenv("PATH"))
-}
-
-func shimLookPath([]string) func(string) (string, error) {
-	return exec.LookPath
-}
-
-func checkShimDirectoryFiles(shimDir string) doctor.CheckResult {
-	info, err := os.Stat(shimDir)
-	if err != nil || !info.IsDir() {
-		return doctor.CheckResult{
-			Status:  doctor.StatusFail,
-			Message: "Shim directory not found",
-		}
-	}
-	return doctor.CheckResult{
-		Status:  doctor.StatusPass,
-		Message: "Shim directory found",
-	}
-}
+import "github.com/safedep/pmg/internal/shim"
 
 // warnShadowedManagers is Windows only. On Unix the rc file prepends the
 // shim directory to PATH, so no machine-wide entry sits ahead of it.
 func warnShadowedManagers(string) {}
 
 // shadowedFix is empty on Unix, so the doctor table keeps its usual hint.
-func shadowedFix([]managerResolution) string { return "" }
+func shadowedFix([]shim.ManagerResolution) string { return "" }

--- a/cmd/setup/doctor_other.go
+++ b/cmd/setup/doctor_other.go
@@ -35,3 +35,6 @@ func checkShimDirectoryFiles(shimDir string) doctor.CheckResult {
 // warnShadowedManagers is Windows only. On Unix the rc file prepends the
 // shim directory to PATH, so no machine-wide entry sits ahead of it.
 func warnShadowedManagers(string) {}
+
+// shadowedFix is empty on Unix, so the doctor table keeps its usual hint.
+func shadowedFix([]string, func(string) (string, error)) string { return "" }

--- a/cmd/setup/doctor_other.go
+++ b/cmd/setup/doctor_other.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package setup
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/safedep/pmg/internal/doctor"
+)
+
+func shimPathEntries() []string {
+	return filepath.SplitList(os.Getenv("PATH"))
+}
+
+func shimLookPath([]string) func(string) (string, error) {
+	return exec.LookPath
+}
+
+func checkShimDirectoryFiles(shimDir string) doctor.CheckResult {
+	info, err := os.Stat(shimDir)
+	if err != nil || !info.IsDir() {
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: "Shim directory not found",
+		}
+	}
+	return doctor.CheckResult{
+		Status:  doctor.StatusPass,
+		Message: "Shim directory found",
+	}
+}
+
+// warnShadowedManagers is Windows only. On Unix the rc file prepends the
+// shim directory to PATH, so no machine-wide entry sits ahead of it.
+func warnShadowedManagers(string) {}

--- a/cmd/setup/doctor_other.go
+++ b/cmd/setup/doctor_other.go
@@ -37,4 +37,4 @@ func checkShimDirectoryFiles(shimDir string) doctor.CheckResult {
 func warnShadowedManagers(string) {}
 
 // shadowedFix is empty on Unix, so the doctor table keeps its usual hint.
-func shadowedFix([]string, func(string) (string, error)) string { return "" }
+func shadowedFix([]managerResolution) string { return "" }

--- a/cmd/setup/doctor_test.go
+++ b/cmd/setup/doctor_test.go
@@ -112,8 +112,9 @@ func TestCheckShimDirResolution(t *testing.T) {
 	}
 }
 
-// checkShimDirectoryResult reads real shims, so a stale one fails on every
-// platform. A stale shim names a pmg binary other than the one running.
+// checkShimDirectoryResult reads real shims, so it catches a shim that names
+// a pmg binary other than the one running. A binary that is gone breaks the
+// command and fails. One that still runs intercepts through it and warns.
 func TestCheckShimDirectoryResult(t *testing.T) {
 	pmgBin, err := os.Executable()
 	require.NoError(t, err)
@@ -137,68 +138,43 @@ func TestCheckShimDirectoryResult(t *testing.T) {
 		assert.Equal(t, doctor.StatusPass, result.Status)
 	})
 
-	t.Run("a shim from another install fails", func(t *testing.T) {
+	t.Run("a shim naming another binary that runs warns", func(t *testing.T) {
 		dir := t.TempDir()
 		writeShims(t, dir, pmgBin, managers)
-		writeShims(t, dir, filepath.Join(t.TempDir(), "old", "pmg"), []string{"npm"})
+
+		other := filepath.Join(t.TempDir(), "pmg")
+		require.NoError(t, os.WriteFile(other, []byte("#!/bin/sh\n"), 0o755))
+		writeShims(t, dir, other, []string{"npm"})
 
 		result := checkShimDirectoryResult(dir, managers)
-		assert.Equal(t, doctor.StatusFail, result.Status)
+		assert.Equal(t, doctor.StatusWarn, result.Status, "that shim still intercepts, through the other binary")
 		assert.Equal(t, "Shims for npm name another pmg binary", result.Message)
+		assert.NotEmpty(t, result.Fix)
 	})
 
-	t.Run("a missing shim fails and is named", func(t *testing.T) {
+	t.Run("a shim naming a binary that is gone fails", func(t *testing.T) {
 		dir := t.TempDir()
-		writeShims(t, dir, pmgBin, []string{"npm"})
+		writeShims(t, dir, pmgBin, managers)
+		writeShims(t, dir, filepath.Join(t.TempDir(), "removed", "pmg"), []string{"npm"})
 
 		result := checkShimDirectoryResult(dir, managers)
 		assert.Equal(t, doctor.StatusFail, result.Status)
-		assert.Equal(t, "Shims missing for pip", result.Message)
+		assert.Equal(t, "Shims missing or broken for npm", result.Message)
 	})
 
-	t.Run("an empty directory reads as not found", func(t *testing.T) {
+	t.Run("a missing shim and a broken one report together", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, filepath.Join(t.TempDir(), "removed", "pmg"), []string{"npm"})
+
+		result := checkShimDirectoryResult(dir, managers)
+		assert.Equal(t, doctor.StatusFail, result.Status)
+		assert.Equal(t, "Shims missing or broken for pip, npm", result.Message)
+	})
+
+	t.Run("an empty directory reads as no shims", func(t *testing.T) {
 		result := checkShimDirectoryResult(t.TempDir(), managers)
 		assert.Equal(t, doctor.StatusFail, result.Status)
-		assert.Equal(t, "Shim directory not found", result.Message)
-	})
-}
-
-func TestCheckSystemBinaryResult(t *testing.T) {
-	// No system shims installed -> could not determine binary (Warn).
-	result := checkSystemBinaryResult()
-	// On a dev machine with no /usr/local/lib/pmg/bin shims, SystemShimBinary
-	// returns !ok, so we get a Warn rather than a spurious Fail.
-	assert.Contains(t, []doctor.CheckStatus{doctor.StatusWarn, doctor.StatusPass, doctor.StatusFail}, result.Status)
-	if result.Status == doctor.StatusWarn {
-		assert.Equal(t, "Could not determine system shim binary", result.Message)
-	}
-}
-
-func TestCheckEventLogDirResult(t *testing.T) {
-	configDir := "/home/dev/.config/safedep/pmg"
-
-	t.Run("skipped when event logging disabled", func(t *testing.T) {
-		result := checkEventLogDirResult(true, t.TempDir(), configDir)
-		assert.Equal(t, doctor.StatusWarn, result.Status)
-	})
-
-	t.Run("missing directory fails", func(t *testing.T) {
-		result := checkEventLogDirResult(false, filepath.Join(t.TempDir(), "absent"), configDir)
-		assert.Equal(t, doctor.StatusFail, result.Status)
-		assert.Equal(t, "Event log directory not found", result.Message)
-	})
-
-	t.Run("file instead of directory fails", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "logs")
-		require.NoError(t, os.WriteFile(path, []byte("x"), 0o644))
-
-		result := checkEventLogDirResult(false, path, configDir)
-		assert.Equal(t, doctor.StatusFail, result.Status)
-	})
-
-	t.Run("writable directory passes", func(t *testing.T) {
-		result := checkEventLogDirResult(false, t.TempDir(), configDir)
-		assert.Equal(t, doctor.StatusPass, result.Status)
+		assert.Equal(t, "No shims found", result.Message)
 	})
 }
 

--- a/cmd/setup/doctor_test.go
+++ b/cmd/setup/doctor_test.go
@@ -2,12 +2,12 @@ package setup
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/safedep/pmg/config"
 	"github.com/safedep/pmg/internal/doctor"
+	"github.com/safedep/pmg/internal/shim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,55 +54,113 @@ func TestShimInPathImpliesInterception(t *testing.T) {
 	assert.True(t, isInterceptionActive(results))
 }
 
-func TestResolveManagers(t *testing.T) {
+// checkShimDirResolution maps an inspection to a status. The inspection is
+// fabricated here, so the mapping is tested on every platform.
+func TestCheckShimDirResolution(t *testing.T) {
 	shimDir := "/usr/local/lib/pmg/bin"
-	calls := map[string]int{}
-	lookPath := func(name string) (string, error) {
-		calls[name]++
-		switch name {
-		case "npm":
-			return shimDir + "/npm", nil
-		case "pip":
-			return "/usr/bin/pip", nil
-		default:
-			return "", exec.ErrNotFound
-		}
+	entriesWithShim := []string{"/usr/bin", shimDir}
+	entriesWithout := []string{"/usr/bin"}
+
+	tests := []struct {
+		name       string
+		inspection shim.InterceptionInspection
+		wantStatus doctor.CheckStatus
+		wantActive bool
+		wantMsg    string
+	}{
+		{
+			name: "every manager under a shim passes and implies interception",
+			inspection: shim.InterceptionInspection{PathEntries: entriesWithShim, Resolutions: []shim.ManagerResolution{
+				{Name: "npm", Path: shimDir + "/npm", UnderShim: true},
+			}},
+			wantStatus: doctor.StatusPass, wantActive: true, wantMsg: "Package managers resolve to Shim directory",
+		},
+		{
+			name: "a shadowed manager warns when the shim directory is on PATH",
+			inspection: shim.InterceptionInspection{PathEntries: entriesWithShim, Resolutions: []shim.ManagerResolution{
+				{Name: "npm", Path: shimDir + "/npm", UnderShim: true},
+				{Name: "pip", Path: "/usr/bin/pip"},
+			}},
+			wantStatus: doctor.StatusWarn, wantMsg: "pip resolved outside Shim directory",
+		},
+		{
+			name: "only shadowed managers and no shim directory on PATH fails",
+			inspection: shim.InterceptionInspection{PathEntries: entriesWithout, Resolutions: []shim.ManagerResolution{
+				{Name: "pip", Path: "/usr/bin/pip"},
+			}},
+			wantStatus: doctor.StatusFail, wantMsg: "Shim directory not in PATH",
+		},
+		{
+			name:       "no manager installed but the shim directory on PATH passes",
+			inspection: shim.InterceptionInspection{PathEntries: entriesWithShim},
+			wantStatus: doctor.StatusPass, wantActive: true, wantMsg: "Shim directory is in PATH",
+		},
+		{
+			name:       "nothing resolves and no shim directory fails",
+			inspection: shim.InterceptionInspection{PathEntries: entriesWithout},
+			wantStatus: doctor.StatusFail, wantMsg: "Shim directory not in PATH",
+		},
 	}
 
-	resolutions := resolveManagers([]string{"npm", "pip", "uv"}, []string{shimDir}, lookPath)
-
-	assert.Equal(t, []managerResolution{
-		{Name: "npm", Path: shimDir + "/npm", UnderShim: true},
-		{Name: "pip", Path: "/usr/bin/pip", UnderShim: false},
-	}, resolutions, "a manager that does not resolve is omitted")
-	assert.Equal(t, map[string]int{"npm": 1, "pip": 1, "uv": 1}, calls, "each manager resolves once")
-
-	under, shadowed := partitionResolutions(resolutions)
-	assert.Equal(t, []string{"npm"}, managerNames(under))
-	assert.Equal(t, []string{"pip"}, managerNames(shadowed))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkShimDirResolution(shimDir, "Shim directory", tt.inspection)
+			assert.Equal(t, tt.wantStatus, result.Status)
+			assert.Equal(t, tt.wantActive, result.ImpliesInterception)
+			assert.Equal(t, tt.wantMsg, result.Message)
+		})
+	}
 }
 
-func TestResolveManagersAcceptsEitherShimDir(t *testing.T) {
-	systemDir := "/usr/local/lib/pmg/bin"
-	userDir := "/home/dev/.pmg/bin"
-	lookPath := func(name string) (string, error) {
-		switch name {
-		case "npm":
-			return systemDir + "/npm", nil
-		case "pip":
-			return userDir + "/pip", nil
-		default:
-			return "/usr/bin/" + name, nil
-		}
+// checkShimDirectoryResult reads real shims, so a stale one fails on every
+// platform. A stale shim names a pmg binary other than the one running.
+func TestCheckShimDirectoryResult(t *testing.T) {
+	pmgBin, err := os.Executable()
+	require.NoError(t, err)
+	managers := []string{"npm", "pip"}
+
+	writeShims := func(t *testing.T, dir, bin string, pms []string) {
+		t.Helper()
+		require.NoError(t, shim.NewShimManager(shim.ShimConfig{
+			BinDir:          dir,
+			PMGBin:          bin,
+			PackageManagers: pms,
+			SkipUserPath:    true,
+		}).Install())
 	}
 
-	under, shadowed := partitionResolutions(resolveManagers(
-		[]string{"npm", "pip", "yarn"},
-		[]string{systemDir, userDir},
-		lookPath,
-	))
-	assert.ElementsMatch(t, []string{"npm", "pip"}, managerNames(under))
-	assert.Equal(t, []string{"yarn"}, managerNames(shadowed))
+	t.Run("every shim names this pmg binary", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin, managers)
+
+		result := checkShimDirectoryResult(dir, managers)
+		assert.Equal(t, doctor.StatusPass, result.Status)
+	})
+
+	t.Run("a shim from another install fails", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin, managers)
+		writeShims(t, dir, filepath.Join(t.TempDir(), "old", "pmg"), []string{"npm"})
+
+		result := checkShimDirectoryResult(dir, managers)
+		assert.Equal(t, doctor.StatusFail, result.Status)
+		assert.Equal(t, "Shims for npm name another pmg binary", result.Message)
+	})
+
+	t.Run("a missing shim fails and is named", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin, []string{"npm"})
+
+		result := checkShimDirectoryResult(dir, managers)
+		assert.Equal(t, doctor.StatusFail, result.Status)
+		assert.Equal(t, "Shims missing for pip", result.Message)
+	})
+
+	t.Run("an empty directory reads as not found", func(t *testing.T) {
+		result := checkShimDirectoryResult(t.TempDir(), managers)
+		assert.Equal(t, doctor.StatusFail, result.Status)
+		assert.Equal(t, "Shim directory not found", result.Message)
+	})
 }
 
 func TestCheckSystemBinaryResult(t *testing.T) {

--- a/cmd/setup/doctor_test.go
+++ b/cmd/setup/doctor_test.go
@@ -54,31 +54,35 @@ func TestShimInPathImpliesInterception(t *testing.T) {
 	assert.True(t, isInterceptionActive(results))
 }
 
-func TestClassifyPackageManagerResolutions(t *testing.T) {
+func TestResolveManagers(t *testing.T) {
 	shimDir := "/usr/local/lib/pmg/bin"
+	calls := map[string]int{}
 	lookPath := func(name string) (string, error) {
+		calls[name]++
 		switch name {
 		case "npm":
 			return shimDir + "/npm", nil
 		case "pip":
 			return "/usr/bin/pip", nil
-		case "uv":
-			return "", exec.ErrNotFound
 		default:
 			return "", exec.ErrNotFound
 		}
 	}
 
-	under, shadowed := classifyPackageManagerResolutions(
-		[]string{"npm", "pip", "uv"},
-		[]string{shimDir},
-		lookPath,
-	)
-	assert.Equal(t, []string{"npm"}, under)
-	assert.Equal(t, []string{"pip"}, shadowed)
+	resolutions := resolveManagers([]string{"npm", "pip", "uv"}, []string{shimDir}, lookPath)
+
+	assert.Equal(t, []managerResolution{
+		{Name: "npm", Path: shimDir + "/npm", UnderShim: true},
+		{Name: "pip", Path: "/usr/bin/pip", UnderShim: false},
+	}, resolutions, "a manager that does not resolve is omitted")
+	assert.Equal(t, map[string]int{"npm": 1, "pip": 1, "uv": 1}, calls, "each manager resolves once")
+
+	under, shadowed := partitionResolutions(resolutions)
+	assert.Equal(t, []string{"npm"}, managerNames(under))
+	assert.Equal(t, []string{"pip"}, managerNames(shadowed))
 }
 
-func TestClassifyPackageManagerResolutionsAcceptsEitherShimDir(t *testing.T) {
+func TestResolveManagersAcceptsEitherShimDir(t *testing.T) {
 	systemDir := "/usr/local/lib/pmg/bin"
 	userDir := "/home/dev/.pmg/bin"
 	lookPath := func(name string) (string, error) {
@@ -92,13 +96,13 @@ func TestClassifyPackageManagerResolutionsAcceptsEitherShimDir(t *testing.T) {
 		}
 	}
 
-	under, shadowed := classifyPackageManagerResolutions(
+	under, shadowed := partitionResolutions(resolveManagers(
 		[]string{"npm", "pip", "yarn"},
 		[]string{systemDir, userDir},
 		lookPath,
-	)
-	assert.ElementsMatch(t, []string{"npm", "pip"}, under)
-	assert.Equal(t, []string{"yarn"}, shadowed)
+	))
+	assert.ElementsMatch(t, []string{"npm", "pip"}, managerNames(under))
+	assert.Equal(t, []string{"yarn"}, managerNames(shadowed))
 }
 
 func TestCheckSystemBinaryResult(t *testing.T) {

--- a/cmd/setup/doctor_unix_test.go
+++ b/cmd/setup/doctor_unix_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The Windows fix text does not apply off Windows, so the doctor table keeps
+// its usual hint for a shadowed manager.
+func TestShadowedFixIsEmptyOffWindows(t *testing.T) {
+	assert.Equal(t, "", shadowedFix([]managerResolution{{Name: "npm", Path: "/usr/bin/npm"}}))
+}
+
 // os.Chmod cannot make a directory unwritable on Windows, so the probe
 // succeeds there and the failure path never runs.
 func TestCheckEventLogDirResultUnwritable(t *testing.T) {

--- a/cmd/setup/doctor_unix_test.go
+++ b/cmd/setup/doctor_unix_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/safedep/pmg/config"
 	"github.com/safedep/pmg/internal/doctor"
+	"github.com/safedep/pmg/internal/shim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +16,7 @@ import (
 // The Windows fix text does not apply off Windows, so the doctor table keeps
 // its usual hint for a shadowed manager.
 func TestShadowedFixIsEmptyOffWindows(t *testing.T) {
-	assert.Equal(t, "", shadowedFix([]managerResolution{{Name: "npm", Path: "/usr/bin/npm"}}))
+	assert.Equal(t, "", shadowedFix([]shim.ManagerResolution{{Name: "npm", Path: "/usr/bin/npm"}}))
 }
 
 // os.Chmod cannot make a directory unwritable on Windows, so the probe

--- a/cmd/setup/doctor_windows.go
+++ b/cmd/setup/doctor_windows.go
@@ -1,0 +1,125 @@
+//go:build windows
+
+package setup
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/safedep/dry/log"
+	"github.com/safedep/pmg/internal/alias"
+	"github.com/safedep/pmg/internal/doctor"
+	"github.com/safedep/pmg/internal/shim"
+	"github.com/safedep/pmg/internal/ui"
+)
+
+// shimPathEntries returns the PATH a new shell gets, from the registry.
+// Doctor often runs in the shell that ran `pmg setup install`, whose process
+// PATH predates the new entry.
+func shimPathEntries() []string {
+	entries, err := shim.RegistryPathEntries()
+	if err != nil {
+		log.Warnf("failed to read PATH from the registry, using the process PATH: %v", err)
+		return filepath.SplitList(os.Getenv("PATH"))
+	}
+	return entries
+}
+
+// shimLookPath resolves a name over the given PATH entries with the PATHEXT
+// rule, so the answer matches what a new shell would run.
+func shimLookPath(pathEntries []string) func(string) (string, error) {
+	exts := pathExtensions()
+	return func(name string) (string, error) {
+		return lookInDirs(name, pathEntries, exts)
+	}
+}
+
+func pathExtensions() []string {
+	exts := os.Getenv("PATHEXT")
+	if exts == "" {
+		exts = ".COM;.EXE;.BAT;.CMD"
+	}
+	return strings.Split(exts, ";")
+}
+
+func lookInDirs(name string, dirs, exts []string) (string, error) {
+	for _, dir := range dirs {
+		for _, ext := range exts {
+			candidate := filepath.Join(dir, name+ext)
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate, nil
+			}
+		}
+	}
+	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+}
+
+// checkShimDirectoryFiles checks each .cmd shim, and that it names the
+// pmg.exe that runs now. A shim from an older install can point at a binary
+// that is gone.
+func checkShimDirectoryFiles(shimDir string) doctor.CheckResult {
+	pmgBin, err := os.Executable()
+	if err != nil {
+		return doctor.CheckResult{
+			Status:  doctor.StatusWarn,
+			Message: fmt.Sprintf("Could not resolve pmg.exe: %v", err),
+		}
+	}
+
+	managers := alias.DefaultConfig().PackageManagers
+	var missing, stale []string
+	for _, pm := range managers {
+		content, err := os.ReadFile(filepath.Join(shimDir, shim.ShimFileName(pm)))
+		if err != nil {
+			missing = append(missing, pm)
+			continue
+		}
+		if !shim.ShimNamesBinary(string(content), pmgBin) {
+			stale = append(stale, pm)
+		}
+	}
+
+	switch {
+	case len(missing) == len(managers):
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: "Shim directory not found",
+		}
+	case len(stale) > 0:
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: fmt.Sprintf("Shims for %s name another pmg.exe", strings.Join(stale, ", ")),
+		}
+	case len(missing) > 0:
+		return doctor.CheckResult{
+			Status:  doctor.StatusFail,
+			Message: fmt.Sprintf("Shims missing for %s", strings.Join(missing, ", ")),
+		}
+	}
+	return doctor.CheckResult{
+		Status:  doctor.StatusPass,
+		Message: "Shims found, each names this pmg.exe",
+	}
+}
+
+// warnShadowedManagers reports the package managers a new shell would still
+// resolve outside the shim directory. Windows builds PATH as the machine
+// value, then the user value, so a manager installed for the machine (the
+// Node.js MSI puts npm under C:\Program Files\nodejs) sits ahead of a user
+// PATH entry, and install alone cannot change that.
+func warnShadowedManagers(binDir string) {
+	entries := shimPathEntries()
+	_, shadowed := classifyPackageManagerResolutions(
+		alias.DefaultConfig().PackageManagers, []string{binDir}, shimLookPath(entries))
+	if len(shadowed) == 0 {
+		return
+	}
+
+	fmt.Printf("\n%s %s resolve from a directory ahead of the shims on PATH. PMG does not intercept them.\n",
+		ui.Colors.Yellow("⚠"), strings.Join(shadowed, ", "))
+	fmt.Printf("   Move that directory behind %s in the machine PATH, or run them as `pmg <manager>`.\n", binDir)
+	fmt.Printf("   `pmg setup doctor` shows which directory it is.\n")
+}

--- a/cmd/setup/doctor_windows.go
+++ b/cmd/setup/doctor_windows.go
@@ -113,16 +113,15 @@ func checkShimDirectoryFiles(shimDir string) doctor.CheckResult {
 // Node.js MSI puts npm under C:\Program Files\nodejs) sits ahead of a user
 // PATH entry, and install alone cannot change that.
 func warnShadowedManagers(binDir string) {
-	lookPath := shimLookPath(shimPathEntries())
-	_, shadowed := classifyPackageManagerResolutions(
-		alias.DefaultConfig().PackageManagers, []string{binDir}, lookPath)
+	_, shadowed := partitionResolutions(resolveManagers(
+		alias.DefaultConfig().PackageManagers, []string{binDir}, shimLookPath(shimPathEntries())))
 	if len(shadowed) == 0 {
 		return
 	}
 
 	fmt.Printf("\n%s A new shell resolves these managers ahead of the shims, so PMG does not intercept them:\n",
 		ui.Colors.Yellow("⚠"))
-	for _, line := range resolvedPaths(shadowed, lookPath) {
+	for _, line := range shadowedLines(shadowed) {
 		fmt.Printf("   %s\n", line)
 	}
 	fmt.Printf("   %s\n", shadowedActions)
@@ -133,20 +132,16 @@ func warnShadowedManagers(binDir string) {
 // option for a manager that a machine-wide installer put there.
 const shadowedActions = "Run them as `pmg <manager>`, or install that manager for your user only, so it lands on the user PATH behind the shims."
 
-// shadowedFix fills the doctor Fix column with the resolved path of each
-// shadowed manager and the actions.
-func shadowedFix(shadowed []string, lookPath func(string) (string, error)) string {
-	return strings.Join(append(resolvedPaths(shadowed, lookPath), shadowedActions), " ")
+// shadowedFix fills the doctor Fix column with the same lines the install
+// warning prints, joined with the actions.
+func shadowedFix(shadowed []managerResolution) string {
+	return strings.Join(append(shadowedLines(shadowed), shadowedActions), " ")
 }
 
-func resolvedPaths(managers []string, lookPath func(string) (string, error)) []string {
-	lines := make([]string, 0, len(managers))
-	for _, pm := range managers {
-		resolved, err := lookPath(pm)
-		if err != nil {
-			continue
-		}
-		lines = append(lines, fmt.Sprintf("%s is %s.", pm, resolved))
+func shadowedLines(shadowed []managerResolution) []string {
+	lines := make([]string, 0, len(shadowed))
+	for _, r := range shadowed {
+		lines = append(lines, fmt.Sprintf("%s is %s.", r.Name, r.Path))
 	}
 	return lines
 }

--- a/cmd/setup/doctor_windows.go
+++ b/cmd/setup/doctor_windows.go
@@ -12,11 +12,10 @@ import (
 	"github.com/safedep/pmg/internal/ui"
 )
 
-// warnShadowedManagers reports the package managers a new shell would still
-// resolve outside the shim directory. Windows builds PATH as the machine
-// value, then the user value, so a manager installed for the machine (the
-// Node.js MSI puts npm under C:\Program Files\nodejs) sits ahead of a user
-// PATH entry, and install alone cannot change that.
+// warnShadowedManagers reports the package managers a shell resolves outside
+// the shim directory, and what to do about each. Windows builds PATH as the
+// machine value then the user value, and a shell profile can prepend more,
+// so `pmg setup install` alone cannot always win.
 func warnShadowedManagers(binDir string) {
 	inspection, err := shim.InspectInterception(alias.DefaultConfig().PackageManagers, []string{binDir})
 	if err != nil {
@@ -28,29 +27,36 @@ func warnShadowedManagers(binDir string) {
 		return
 	}
 
-	fmt.Printf("\n%s A new shell resolves these managers ahead of the shims, so PMG does not intercept them:\n",
+	fmt.Printf("\n%s A shell resolves these managers ahead of the shims, so PMG does not intercept them:\n",
 		ui.Colors.Yellow("⚠"))
 	for _, line := range shadowedLines(shadowed) {
 		fmt.Printf("   %s\n", line)
 	}
-	fmt.Printf("   %s\n", shadowedActions)
 }
 
-// shadowedActions names what a user can do today. A user PATH entry can
-// never move ahead of a machine PATH entry, so "reorder PATH" is not an
-// option for a manager that a machine-wide installer put there.
-const shadowedActions = "Run them as `pmg <manager>`, or install that manager for your user only, so it lands on the user PATH behind the shims."
-
 // shadowedFix fills the doctor Fix column with the same lines the install
-// warning prints, joined with the actions.
+// warning prints, so the two cannot disagree.
 func shadowedFix(shadowed []shim.ManagerResolution) string {
-	return strings.Join(append(shadowedLines(shadowed), shadowedActions), " ")
+	return strings.Join(shadowedLines(shadowed), " ")
 }
 
 func shadowedLines(shadowed []shim.ManagerResolution) []string {
 	lines := make([]string, 0, len(shadowed))
 	for _, r := range shadowed {
-		lines = append(lines, fmt.Sprintf("%s is %s.", r.Name, r.Path))
+		lines = append(lines, fmt.Sprintf("%s is %s. %s", r.Name, r.Path, shadowedAction(r)))
 	}
 	return lines
+}
+
+// shadowedAction names what the user can do, which depends on where the
+// winning PATH entry came from. Only the user PATH is one PMG can reorder.
+func shadowedAction(r shim.ManagerResolution) string {
+	switch r.Origin {
+	case shim.OriginUser:
+		return "Run `pmg setup install` again to move the shims ahead of it."
+	case shim.OriginProfile:
+		return fmt.Sprintf("A shell profile puts that directory on PATH, where PMG cannot reorder it. Run it as `pmg %s`, or drop that line from the profile.", r.Name)
+	default:
+		return fmt.Sprintf("It is on the machine PATH, which no per-user install can move behind the shims. Run it as `pmg %s`.", r.Name)
+	}
 }

--- a/cmd/setup/doctor_windows.go
+++ b/cmd/setup/doctor_windows.go
@@ -4,108 +4,13 @@ package setup
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/safedep/dry/log"
 	"github.com/safedep/pmg/internal/alias"
-	"github.com/safedep/pmg/internal/doctor"
 	"github.com/safedep/pmg/internal/shim"
 	"github.com/safedep/pmg/internal/ui"
 )
-
-// shimPathEntries returns the PATH a new shell gets, from the registry.
-// Doctor often runs in the shell that ran `pmg setup install`, whose process
-// PATH predates the new entry.
-func shimPathEntries() []string {
-	entries, err := shim.RegistryPathEntries()
-	if err != nil {
-		log.Warnf("failed to read PATH from the registry, using the process PATH: %v", err)
-		return filepath.SplitList(os.Getenv("PATH"))
-	}
-	return entries
-}
-
-// shimLookPath resolves a name over the given PATH entries with the PATHEXT
-// rule, so the answer matches what a new shell would run.
-func shimLookPath(pathEntries []string) func(string) (string, error) {
-	exts := pathExtensions()
-	return func(name string) (string, error) {
-		return lookInDirs(name, pathEntries, exts)
-	}
-}
-
-func pathExtensions() []string {
-	exts := os.Getenv("PATHEXT")
-	if exts == "" {
-		exts = ".COM;.EXE;.BAT;.CMD"
-	}
-	return strings.Split(exts, ";")
-}
-
-// lookInDirs lower-cases each extension, as exec.LookPath does, so a
-// resolved path reads `npm.cmd` rather than `npm.CMD`.
-func lookInDirs(name string, dirs, exts []string) (string, error) {
-	for _, dir := range dirs {
-		for _, ext := range exts {
-			candidate := filepath.Join(dir, name+strings.ToLower(ext))
-			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
-				return candidate, nil
-			}
-		}
-	}
-	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
-}
-
-// checkShimDirectoryFiles checks each .cmd shim, and that it names the
-// pmg.exe that runs now. A shim from an older install can point at a binary
-// that is gone.
-func checkShimDirectoryFiles(shimDir string) doctor.CheckResult {
-	pmgBin, err := os.Executable()
-	if err != nil {
-		return doctor.CheckResult{
-			Status:  doctor.StatusWarn,
-			Message: fmt.Sprintf("Could not resolve pmg.exe: %v", err),
-		}
-	}
-
-	managers := alias.DefaultConfig().PackageManagers
-	var missing, stale []string
-	for _, pm := range managers {
-		content, err := os.ReadFile(filepath.Join(shimDir, shim.ShimFileName(pm)))
-		if err != nil {
-			missing = append(missing, pm)
-			continue
-		}
-		if !shim.ShimNamesBinary(string(content), pmgBin) {
-			stale = append(stale, pm)
-		}
-	}
-
-	switch {
-	case len(missing) == len(managers):
-		return doctor.CheckResult{
-			Status:  doctor.StatusFail,
-			Message: "Shim directory not found",
-		}
-	case len(stale) > 0:
-		return doctor.CheckResult{
-			Status:  doctor.StatusFail,
-			Message: fmt.Sprintf("Shims for %s name another pmg.exe", strings.Join(stale, ", ")),
-		}
-	case len(missing) > 0:
-		return doctor.CheckResult{
-			Status:  doctor.StatusFail,
-			Message: fmt.Sprintf("Shims missing for %s", strings.Join(missing, ", ")),
-		}
-	}
-	return doctor.CheckResult{
-		Status:  doctor.StatusPass,
-		Message: "Shims found, each names this pmg.exe",
-	}
-}
 
 // warnShadowedManagers reports the package managers a new shell would still
 // resolve outside the shim directory. Windows builds PATH as the machine
@@ -113,8 +18,12 @@ func checkShimDirectoryFiles(shimDir string) doctor.CheckResult {
 // Node.js MSI puts npm under C:\Program Files\nodejs) sits ahead of a user
 // PATH entry, and install alone cannot change that.
 func warnShadowedManagers(binDir string) {
-	_, shadowed := partitionResolutions(resolveManagers(
-		alias.DefaultConfig().PackageManagers, []string{binDir}, shimLookPath(shimPathEntries())))
+	inspection, err := shim.InspectInterception(alias.DefaultConfig().PackageManagers, []string{binDir})
+	if err != nil {
+		log.Warnf("failed to check which managers the shims intercept: %v", err)
+		return
+	}
+	_, shadowed := inspection.Partition()
 	if len(shadowed) == 0 {
 		return
 	}
@@ -134,11 +43,11 @@ const shadowedActions = "Run them as `pmg <manager>`, or install that manager fo
 
 // shadowedFix fills the doctor Fix column with the same lines the install
 // warning prints, joined with the actions.
-func shadowedFix(shadowed []managerResolution) string {
+func shadowedFix(shadowed []shim.ManagerResolution) string {
 	return strings.Join(append(shadowedLines(shadowed), shadowedActions), " ")
 }
 
-func shadowedLines(shadowed []managerResolution) []string {
+func shadowedLines(shadowed []shim.ManagerResolution) []string {
 	lines := make([]string, 0, len(shadowed))
 	for _, r := range shadowed {
 		lines = append(lines, fmt.Sprintf("%s is %s.", r.Name, r.Path))

--- a/cmd/setup/doctor_windows.go
+++ b/cmd/setup/doctor_windows.go
@@ -113,15 +113,40 @@ func checkShimDirectoryFiles(shimDir string) doctor.CheckResult {
 // Node.js MSI puts npm under C:\Program Files\nodejs) sits ahead of a user
 // PATH entry, and install alone cannot change that.
 func warnShadowedManagers(binDir string) {
-	entries := shimPathEntries()
+	lookPath := shimLookPath(shimPathEntries())
 	_, shadowed := classifyPackageManagerResolutions(
-		alias.DefaultConfig().PackageManagers, []string{binDir}, shimLookPath(entries))
+		alias.DefaultConfig().PackageManagers, []string{binDir}, lookPath)
 	if len(shadowed) == 0 {
 		return
 	}
 
-	fmt.Printf("\n%s %s resolve from a directory ahead of the shims on PATH. PMG does not intercept them.\n",
-		ui.Colors.Yellow("⚠"), strings.Join(shadowed, ", "))
-	fmt.Printf("   Move that directory behind %s in the machine PATH, or run them as `pmg <manager>`.\n", binDir)
-	fmt.Printf("   `pmg setup doctor` shows which directory it is.\n")
+	fmt.Printf("\n%s A new shell resolves these managers ahead of the shims, so PMG does not intercept them:\n",
+		ui.Colors.Yellow("⚠"))
+	for _, line := range resolvedPaths(shadowed, lookPath) {
+		fmt.Printf("   %s\n", line)
+	}
+	fmt.Printf("   %s\n", shadowedActions)
+}
+
+// shadowedActions names what a user can do today. A user PATH entry can
+// never move ahead of a machine PATH entry, so "reorder PATH" is not an
+// option for a manager that a machine-wide installer put there.
+const shadowedActions = "Run them as `pmg <manager>`, or install that manager for your user only, so it lands on the user PATH behind the shims."
+
+// shadowedFix fills the doctor Fix column with the resolved path of each
+// shadowed manager and the actions.
+func shadowedFix(shadowed []string, lookPath func(string) (string, error)) string {
+	return strings.Join(append(resolvedPaths(shadowed, lookPath), shadowedActions), " ")
+}
+
+func resolvedPaths(managers []string, lookPath func(string) (string, error)) []string {
+	lines := make([]string, 0, len(managers))
+	for _, pm := range managers {
+		resolved, err := lookPath(pm)
+		if err != nil {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%s is %s.", pm, resolved))
+	}
+	return lines
 }

--- a/cmd/setup/doctor_windows.go
+++ b/cmd/setup/doctor_windows.go
@@ -45,10 +45,12 @@ func pathExtensions() []string {
 	return strings.Split(exts, ";")
 }
 
+// lookInDirs lower-cases each extension, as exec.LookPath does, so a
+// resolved path reads `npm.cmd` rather than `npm.CMD`.
 func lookInDirs(name string, dirs, exts []string) (string, error) {
 	for _, dir := range dirs {
 		for _, ext := range exts {
-			candidate := filepath.Join(dir, name+ext)
+			candidate := filepath.Join(dir, name+strings.ToLower(ext))
 			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
 				return candidate, nil
 			}

--- a/cmd/setup/doctor_windows_test.go
+++ b/cmd/setup/doctor_windows_test.go
@@ -7,28 +7,70 @@ import (
 
 	"github.com/safedep/pmg/internal/shim"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// The action depends on where the winning PATH entry came from. Only the
+// user half is one `pmg setup install` can reorder.
+func TestShadowedAction(t *testing.T) {
+	tests := []struct {
+		name       string
+		resolution shim.ManagerResolution
+		want       string
+		notWant    string
+	}{
+		{
+			name:       "a machine PATH entry cannot be moved behind the shims",
+			resolution: shim.ManagerResolution{Name: "npm", Origin: shim.OriginMachine},
+			want:       "Run it as `pmg npm`.",
+			notWant:    "pmg setup install",
+		},
+		{
+			name:       "a user PATH entry is one install can reorder",
+			resolution: shim.ManagerResolution{Name: "pip", Origin: shim.OriginUser},
+			want:       "Run `pmg setup install` again to move the shims ahead of it.",
+			notWant:    "machine PATH",
+		},
+		{
+			name:       "a profile entry needs the profile edited",
+			resolution: shim.ManagerResolution{Name: "npm", Origin: shim.OriginProfile},
+			want:       "A shell profile puts that directory on PATH",
+			notWant:    "pmg setup install",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := shadowedAction(tt.resolution)
+			assert.Contains(t, action, tt.want)
+			assert.NotContains(t, action, tt.notWant)
+		})
+	}
+
+	// The earlier text told the user to install the manager for their user
+	// only. The python.org installer prepends its own directory, so that
+	// advice put pip ahead of the shims.
+	for _, origin := range []shim.PathOrigin{shim.OriginMachine, shim.OriginUser, shim.OriginProfile} {
+		assert.NotContains(t, shadowedAction(shim.ManagerResolution{Name: "pip", Origin: origin}),
+			"for your user only")
+	}
+}
+
 // The install warning and the doctor Fix column print the same lines from
-// the same resolutions, so they cannot disagree on a path. Neither tells the
-// user to reorder PATH, which cannot put a user entry ahead of a machine
-// entry.
+// the same resolutions, so they cannot disagree on a path or an action.
 func TestShadowedFixAndWarningShareTheResolvedPath(t *testing.T) {
 	shadowed := []shim.ManagerResolution{
-		{Name: "npm", Path: `C:\Program Files\nodejs\npm.cmd`},
-		{Name: "npx", Path: `C:\Program Files\nodejs\npx.cmd`},
+		{Name: "npm", Path: `C:\Program Files\nodejs\npm.cmd`, Origin: shim.OriginMachine},
+		{Name: "pip", Path: `C:\Users\dev\Python\Scripts\pip.exe`, Origin: shim.OriginUser},
 	}
 
 	lines := shadowedLines(shadowed)
 	fix := shadowedFix(shadowed)
 
-	assert.Equal(t, []string{
-		`npm is C:\Program Files\nodejs\npm.cmd.`,
-		`npx is C:\Program Files\nodejs\npx.cmd.`,
-	}, lines)
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], `npm is C:\Program Files\nodejs\npm.cmd.`)
+	assert.Contains(t, lines[1], `pip is C:\Users\dev\Python\Scripts\pip.exe.`)
 	for _, line := range lines {
 		assert.Contains(t, fix, line)
 	}
-	assert.Contains(t, fix, "Run them as `pmg <manager>`")
-	assert.NotContains(t, fix, "Move")
 }

--- a/cmd/setup/doctor_windows_test.go
+++ b/cmd/setup/doctor_windows_test.go
@@ -3,111 +3,18 @@
 package setup
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 
-	"github.com/safedep/pmg/internal/alias"
-	"github.com/safedep/pmg/internal/doctor"
 	"github.com/safedep/pmg/internal/shim"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestLookInDirs(t *testing.T) {
-	first, second := t.TempDir(), t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(second, "npm.cmd"), nil, 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(second, "pip.exe"), nil, 0o644))
-	require.NoError(t, os.Mkdir(filepath.Join(first, "uv.exe"), 0o755))
-	exts := []string{".COM", ".EXE", ".BAT", ".CMD"}
-
-	t.Run("applies PATHEXT in order across directories", func(t *testing.T) {
-		got, err := lookInDirs("npm", []string{first, second}, exts)
-		require.NoError(t, err)
-		assert.Equal(t, filepath.Join(second, "npm.cmd"), got)
-
-		got, err = lookInDirs("pip", []string{first, second}, exts)
-		require.NoError(t, err)
-		assert.Equal(t, filepath.Join(second, "pip.exe"), got)
-	})
-
-	t.Run("skips a directory that carries the name", func(t *testing.T) {
-		_, err := lookInDirs("uv", []string{first, second}, exts)
-		assert.ErrorIs(t, err, exec.ErrNotFound)
-	})
-
-	t.Run("reports a missing name like LookPath", func(t *testing.T) {
-		_, err := lookInDirs("yarn", []string{first, second}, exts)
-		var execErr *exec.Error
-		require.ErrorAs(t, err, &execErr)
-		assert.Equal(t, "yarn", execErr.Name)
-	})
-}
-
-func TestCheckShimDirectoryFiles(t *testing.T) {
-	pmgBin, err := os.Executable()
-	require.NoError(t, err)
-	managers := alias.DefaultConfig().PackageManagers
-
-	writeShims := func(t *testing.T, dir, bin string) {
-		t.Helper()
-		mgr := shim.NewShimManager(shim.ShimConfig{
-			BinDir:          dir,
-			PMGBin:          bin,
-			PackageManagers: managers,
-			SkipUserPath:    true,
-		})
-		require.NoError(t, mgr.Install())
-	}
-
-	t.Run("every shim names this pmg.exe", func(t *testing.T) {
-		dir := t.TempDir()
-		writeShims(t, dir, pmgBin)
-
-		result := checkShimDirectoryFiles(dir)
-		assert.Equal(t, doctor.StatusPass, result.Status)
-	})
-
-	t.Run("a shim from an older install names another binary", func(t *testing.T) {
-		dir := t.TempDir()
-		writeShims(t, dir, pmgBin)
-		stale := shim.NewShimManager(shim.ShimConfig{
-			BinDir:          dir,
-			PMGBin:          `C:\old\pmg.exe`,
-			PackageManagers: []string{"npm"},
-			SkipUserPath:    true,
-		})
-		require.NoError(t, stale.Install())
-
-		result := checkShimDirectoryFiles(dir)
-		assert.Equal(t, doctor.StatusFail, result.Status)
-		assert.Equal(t, "Shims for npm name another pmg.exe", result.Message)
-	})
-
-	t.Run("a missing shim is named", func(t *testing.T) {
-		dir := t.TempDir()
-		writeShims(t, dir, pmgBin)
-		require.NoError(t, os.Remove(filepath.Join(dir, shim.ShimFileName("pip"))))
-
-		result := checkShimDirectoryFiles(dir)
-		assert.Equal(t, doctor.StatusFail, result.Status)
-		assert.Equal(t, "Shims missing for pip", result.Message)
-	})
-
-	t.Run("an empty directory reads as not found", func(t *testing.T) {
-		result := checkShimDirectoryFiles(t.TempDir())
-		assert.Equal(t, doctor.StatusFail, result.Status)
-		assert.Equal(t, "Shim directory not found", result.Message)
-	})
-}
 
 // The install warning and the doctor Fix column print the same lines from
 // the same resolutions, so they cannot disagree on a path. Neither tells the
 // user to reorder PATH, which cannot put a user entry ahead of a machine
 // entry.
 func TestShadowedFixAndWarningShareTheResolvedPath(t *testing.T) {
-	shadowed := []managerResolution{
+	shadowed := []shim.ManagerResolution{
 		{Name: "npm", Path: `C:\Program Files\nodejs\npm.cmd`},
 		{Name: "npx", Path: `C:\Program Files\nodejs\npx.cmd`},
 	}

--- a/cmd/setup/doctor_windows_test.go
+++ b/cmd/setup/doctor_windows_test.go
@@ -102,21 +102,26 @@ func TestCheckShimDirectoryFiles(t *testing.T) {
 	})
 }
 
-// The fix must name where each shadowed manager resolves, and must not tell
-// the user to reorder PATH, which cannot put a user entry ahead of a machine
+// The install warning and the doctor Fix column print the same lines from
+// the same resolutions, so they cannot disagree on a path. Neither tells the
+// user to reorder PATH, which cannot put a user entry ahead of a machine
 // entry.
-func TestShadowedFixNamesTheResolvedPath(t *testing.T) {
-	lookPath := func(name string) (string, error) {
-		if name == "npm" {
-			return `C:\Program Files\nodejs\npm.cmd`, nil
-		}
-		return "", exec.ErrNotFound
+func TestShadowedFixAndWarningShareTheResolvedPath(t *testing.T) {
+	shadowed := []managerResolution{
+		{Name: "npm", Path: `C:\Program Files\nodejs\npm.cmd`},
+		{Name: "npx", Path: `C:\Program Files\nodejs\npx.cmd`},
 	}
 
-	fix := shadowedFix([]string{"npm", "npx"}, lookPath)
+	lines := shadowedLines(shadowed)
+	fix := shadowedFix(shadowed)
 
-	assert.Contains(t, fix, `npm is C:\Program Files\nodejs\npm.cmd.`)
-	assert.NotContains(t, fix, "npx is")
+	assert.Equal(t, []string{
+		`npm is C:\Program Files\nodejs\npm.cmd.`,
+		`npx is C:\Program Files\nodejs\npx.cmd.`,
+	}, lines)
+	for _, line := range lines {
+		assert.Contains(t, fix, line)
+	}
 	assert.Contains(t, fix, "Run them as `pmg <manager>`")
 	assert.NotContains(t, fix, "Move")
 }

--- a/cmd/setup/doctor_windows_test.go
+++ b/cmd/setup/doctor_windows_test.go
@@ -1,0 +1,103 @@
+//go:build windows
+
+package setup
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/safedep/pmg/internal/alias"
+	"github.com/safedep/pmg/internal/doctor"
+	"github.com/safedep/pmg/internal/shim"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookInDirs(t *testing.T) {
+	first, second := t.TempDir(), t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(second, "npm.cmd"), nil, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(second, "pip.exe"), nil, 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(first, "uv.exe"), 0o755))
+	exts := []string{".COM", ".EXE", ".BAT", ".CMD"}
+
+	t.Run("applies PATHEXT in order across directories", func(t *testing.T) {
+		got, err := lookInDirs("npm", []string{first, second}, exts)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(second, "npm.cmd"), got)
+
+		got, err = lookInDirs("pip", []string{first, second}, exts)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(second, "pip.exe"), got)
+	})
+
+	t.Run("skips a directory that carries the name", func(t *testing.T) {
+		_, err := lookInDirs("uv", []string{first, second}, exts)
+		assert.ErrorIs(t, err, exec.ErrNotFound)
+	})
+
+	t.Run("reports a missing name like LookPath", func(t *testing.T) {
+		_, err := lookInDirs("yarn", []string{first, second}, exts)
+		var execErr *exec.Error
+		require.ErrorAs(t, err, &execErr)
+		assert.Equal(t, "yarn", execErr.Name)
+	})
+}
+
+func TestCheckShimDirectoryFiles(t *testing.T) {
+	pmgBin, err := os.Executable()
+	require.NoError(t, err)
+	managers := alias.DefaultConfig().PackageManagers
+
+	writeShims := func(t *testing.T, dir, bin string) {
+		t.Helper()
+		mgr := shim.NewShimManager(shim.ShimConfig{
+			BinDir:          dir,
+			PMGBin:          bin,
+			PackageManagers: managers,
+			SkipUserPath:    true,
+		})
+		require.NoError(t, mgr.Install())
+	}
+
+	t.Run("every shim names this pmg.exe", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin)
+
+		result := checkShimDirectoryFiles(dir)
+		assert.Equal(t, doctor.StatusPass, result.Status)
+	})
+
+	t.Run("a shim from an older install names another binary", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin)
+		stale := shim.NewShimManager(shim.ShimConfig{
+			BinDir:          dir,
+			PMGBin:          `C:\old\pmg.exe`,
+			PackageManagers: []string{"npm"},
+			SkipUserPath:    true,
+		})
+		require.NoError(t, stale.Install())
+
+		result := checkShimDirectoryFiles(dir)
+		assert.Equal(t, doctor.StatusFail, result.Status)
+		assert.Equal(t, "Shims for npm name another pmg.exe", result.Message)
+	})
+
+	t.Run("a missing shim is named", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin)
+		require.NoError(t, os.Remove(filepath.Join(dir, shim.ShimFileName("pip"))))
+
+		result := checkShimDirectoryFiles(dir)
+		assert.Equal(t, doctor.StatusFail, result.Status)
+		assert.Equal(t, "Shims missing for pip", result.Message)
+	})
+
+	t.Run("an empty directory reads as not found", func(t *testing.T) {
+		result := checkShimDirectoryFiles(t.TempDir())
+		assert.Equal(t, doctor.StatusFail, result.Status)
+		assert.Equal(t, "Shim directory not found", result.Message)
+	})
+}

--- a/cmd/setup/doctor_windows_test.go
+++ b/cmd/setup/doctor_windows_test.go
@@ -101,3 +101,22 @@ func TestCheckShimDirectoryFiles(t *testing.T) {
 		assert.Equal(t, "Shim directory not found", result.Message)
 	})
 }
+
+// The fix must name where each shadowed manager resolves, and must not tell
+// the user to reorder PATH, which cannot put a user entry ahead of a machine
+// entry.
+func TestShadowedFixNamesTheResolvedPath(t *testing.T) {
+	lookPath := func(name string) (string, error) {
+		if name == "npm" {
+			return `C:\Program Files\nodejs\npm.cmd`, nil
+		}
+		return "", exec.ErrNotFound
+	}
+
+	fix := shadowedFix([]string{"npm", "npx"}, lookPath)
+
+	assert.Contains(t, fix, `npm is C:\Program Files\nodejs\npm.cmd.`)
+	assert.NotContains(t, fix, "npx is")
+	assert.Contains(t, fix, "Run them as `pmg <manager>`")
+	assert.NotContains(t, fix, "Move")
+}

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -100,6 +100,7 @@ func install(system bool) error {
 	}
 
 	ui.PrintSetupInstallCmdInfo(aliasPath, shimMgr.GetBinDir(), config.Get().ConfigDir())
+	warnShadowedManagers(shimMgr.GetBinDir())
 	return nil
 }
 

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -165,16 +165,3 @@ func isExecutableNotFound(err error) bool {
 	}
 	return false
 }
-
-func CheckShimScripts(shimDir string, managers []string) (found []string, missing []string) {
-	for _, pm := range managers {
-		shimPath := filepath.Join(shimDir, pm)
-		info, err := os.Stat(shimPath)
-		if err != nil || info.Mode()&0o111 == 0 {
-			missing = append(missing, pm)
-			continue
-		}
-		found = append(found, pm)
-	}
-	return found, missing
-}

--- a/internal/doctor/checks_unix_test.go
+++ b/internal/doctor/checks_unix_test.go
@@ -65,18 +65,3 @@ func TestSetupVenv(t *testing.T) {
 	_, err = os.Stat(pipPath)
 	assert.NoError(t, err)
 }
-
-// CheckShimScripts reads the executable bit, which Windows does not have.
-// The Windows form of the shim-directory check owns that case.
-func TestCheckShimScripts(t *testing.T) {
-	tmpDir := t.TempDir()
-	shimDir := filepath.Join(tmpDir, ".pmg", "bin")
-	require.NoError(t, os.MkdirAll(shimDir, 0o755))
-
-	shimPath := filepath.Join(shimDir, "npm")
-	require.NoError(t, os.WriteFile(shimPath, []byte("#!/bin/sh\nexec pmg npm \"$@\""), 0o755))
-
-	found, missing := CheckShimScripts(shimDir, []string{"npm", "pip"})
-	assert.Equal(t, []string{"npm"}, found)
-	assert.Equal(t, []string{"pip"}, missing)
-}

--- a/internal/shim/interception.go
+++ b/internal/shim/interception.go
@@ -9,6 +9,28 @@ import (
 	"github.com/safedep/pmg/internal/fsutil"
 )
 
+// PathOrigin is where the PATH entry that won a lookup came from. The remedy
+// for a shadowed manager depends on it, because PMG can reorder the user PATH
+// and nothing else.
+type PathOrigin int
+
+const (
+	// OriginUnknown is every platform that has one PATH and no way to say
+	// where an entry came from.
+	OriginUnknown PathOrigin = iota
+	// OriginMachine is the Windows machine PATH, which a machine-wide
+	// installer writes. Windows puts it ahead of the user PATH, so no
+	// user-scope write can move the shims in front of it.
+	OriginMachine
+	// OriginUser is the Windows user PATH. `pmg setup install` moves the shim
+	// directory to the front of it.
+	OriginUser
+	// OriginProfile is a directory that only this process has, so a shell
+	// profile added it. It never reaches the registry, and PMG cannot reorder
+	// it.
+	OriginProfile
+)
+
 // ManagerResolution is where one package manager resolves on the PATH a new
 // shell gets. UnderShim means the command runs through a pmg shim. Otherwise
 // a real npm or pip sits ahead of the shims and PMG does not see it.
@@ -16,10 +38,13 @@ type ManagerResolution struct {
 	Name      string
 	Path      string
 	UnderShim bool
+	Origin    PathOrigin
 }
 
 // InterceptionInspection is the PATH a new shell gets and where each
-// configured package manager resolves on it.
+// configured package manager resolves. On Windows a resolution can come from
+// the process PATH instead, when a shell profile put a directory there that
+// the registry cannot show.
 type InterceptionInspection struct {
 	PathEntries []string
 	Resolutions []ManagerResolution
@@ -38,40 +63,36 @@ func (i InterceptionInspection) Partition() (underShim, shadowed []ManagerResolu
 	return underShim, shadowed
 }
 
-// ShimInspection names the managers whose shim file is absent, and the
-// managers whose shim names a pmg binary other than the one asked about.
+// ShimInspection groups the package managers whose shim needs attention.
+// Missing has no shim file. BinaryMissing names a pmg binary that is gone, so
+// the shim fails with exit 127. BinaryDiffers names another pmg binary that
+// still runs, so the manager is intercepted by that one.
 type ShimInspection struct {
-	Missing []string
-	Stale   []string
+	Missing       []string
+	BinaryMissing []string
+	BinaryDiffers []string
 }
 
-// InspectInterception resolves each package manager once against the PATH a
-// new shell gets, in the order given. A manager that does not resolve is
-// omitted. On Windows the PATH comes from the registry, because the shell
-// that ran `pmg setup install` still carries the PATH from before it.
-func InspectInterception(packageManagers []string, shimDirs []string) (InterceptionInspection, error) {
-	entries, err := interceptionPathEntries()
-	if err != nil {
-		return InterceptionInspection{}, err
-	}
-	return inspectInterception(packageManagers, shimDirs, entries, interceptionLookPath(entries)), nil
-}
-
-func inspectInterception(packageManagers, shimDirs, pathEntries []string, lookPath func(string) (string, error)) InterceptionInspection {
-	inspection := InterceptionInspection{PathEntries: pathEntries}
+// resolveManagers looks each manager up once against entries, in the order
+// given, and omits one that does not resolve.
+func resolveManagers(packageManagers, shimDirs, entries []string, lookPath lookupFunc) []ManagerResolution {
+	resolutions := make([]ManagerResolution, 0, len(packageManagers))
 	for _, pm := range packageManagers {
-		resolved, err := lookPath(pm)
+		resolved, err := lookPath(pm, entries)
 		if err != nil {
 			continue
 		}
-		inspection.Resolutions = append(inspection.Resolutions, ManagerResolution{
+		resolutions = append(resolutions, ManagerResolution{
 			Name:      pm,
 			Path:      resolved,
 			UnderShim: PathUnderAnyDir(resolved, shimDirs),
 		})
 	}
-	return inspection
+	return resolutions
 }
+
+// lookupFunc resolves a command name against the given PATH entries.
+type lookupFunc func(name string, entries []string) (string, error)
 
 // PathUnderAnyDir reports whether path sits inside one of dirs.
 func PathUnderAnyDir(path string, dirs []string) bool {
@@ -84,10 +105,16 @@ func PathUnderAnyDir(path string, dirs []string) bool {
 }
 
 // InspectShimFiles reads the shim of each package manager in shimDir and
-// reports the ones that are absent and the ones that name a pmg binary other
-// than pmgBin. A shim from an older install can point at a binary that moved
-// or is gone.
-func InspectShimFiles(shimDir string, packageManagers []string, pmgBin string) (ShimInspection, error) {
+// groups the ones that need attention. A shim names the pmg binary by
+// absolute path at install time and nothing updates it later, so a second
+// install, a moved binary or a package upgrade to a versioned directory
+// leaves the shim naming a binary that is not this one.
+func InspectShimFiles(shimDir string, packageManagers []string) (ShimInspection, error) {
+	pmgBin, err := currentExecutable()
+	if err != nil {
+		return ShimInspection{}, err
+	}
+
 	var inspection ShimInspection
 	for _, pm := range packageManagers {
 		content, err := os.ReadFile(filepath.Join(shimDir, shimFileName(pm)))
@@ -98,9 +125,21 @@ func InspectShimFiles(shimDir string, packageManagers []string, pmgBin string) (
 		if err != nil {
 			return ShimInspection{}, fmt.Errorf("failed to read the %s shim: %w", pm, err)
 		}
-		if !shimNamesBinary(string(content), pmgBin) {
-			inspection.Stale = append(inspection.Stale, pm)
+
+		named, ok := parseShimBinary(string(content))
+		if !ok {
+			// A file with no pmg path in it is not a shim PMG wrote.
+			inspection.Missing = append(inspection.Missing, pm)
+			continue
 		}
+		if fsutil.SamePath(named, pmgBin) {
+			continue
+		}
+		if _, err := os.Stat(named); err != nil {
+			inspection.BinaryMissing = append(inspection.BinaryMissing, pm)
+			continue
+		}
+		inspection.BinaryDiffers = append(inspection.BinaryDiffers, pm)
 	}
 	return inspection, nil
 }

--- a/internal/shim/interception.go
+++ b/internal/shim/interception.go
@@ -1,0 +1,106 @@
+package shim
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/safedep/pmg/internal/fsutil"
+)
+
+// ManagerResolution is where one package manager resolves on the PATH a new
+// shell gets. UnderShim means the command runs through a pmg shim. Otherwise
+// a real npm or pip sits ahead of the shims and PMG does not see it.
+type ManagerResolution struct {
+	Name      string
+	Path      string
+	UnderShim bool
+}
+
+// InterceptionInspection is the PATH a new shell gets and where each
+// configured package manager resolves on it.
+type InterceptionInspection struct {
+	PathEntries []string
+	Resolutions []ManagerResolution
+}
+
+// Partition splits the resolutions into the managers a shim intercepts and
+// the managers that resolve elsewhere.
+func (i InterceptionInspection) Partition() (underShim, shadowed []ManagerResolution) {
+	for _, r := range i.Resolutions {
+		if r.UnderShim {
+			underShim = append(underShim, r)
+		} else {
+			shadowed = append(shadowed, r)
+		}
+	}
+	return underShim, shadowed
+}
+
+// ShimInspection names the managers whose shim file is absent, and the
+// managers whose shim names a pmg binary other than the one asked about.
+type ShimInspection struct {
+	Missing []string
+	Stale   []string
+}
+
+// InspectInterception resolves each package manager once against the PATH a
+// new shell gets, in the order given. A manager that does not resolve is
+// omitted. On Windows the PATH comes from the registry, because the shell
+// that ran `pmg setup install` still carries the PATH from before it.
+func InspectInterception(packageManagers []string, shimDirs []string) (InterceptionInspection, error) {
+	entries, err := interceptionPathEntries()
+	if err != nil {
+		return InterceptionInspection{}, err
+	}
+	return inspectInterception(packageManagers, shimDirs, entries, interceptionLookPath(entries)), nil
+}
+
+func inspectInterception(packageManagers, shimDirs, pathEntries []string, lookPath func(string) (string, error)) InterceptionInspection {
+	inspection := InterceptionInspection{PathEntries: pathEntries}
+	for _, pm := range packageManagers {
+		resolved, err := lookPath(pm)
+		if err != nil {
+			continue
+		}
+		inspection.Resolutions = append(inspection.Resolutions, ManagerResolution{
+			Name:      pm,
+			Path:      resolved,
+			UnderShim: PathUnderAnyDir(resolved, shimDirs),
+		})
+	}
+	return inspection
+}
+
+// PathUnderAnyDir reports whether path sits inside one of dirs.
+func PathUnderAnyDir(path string, dirs []string) bool {
+	for _, dir := range dirs {
+		if fsutil.PathWithinDir(path, dir) {
+			return true
+		}
+	}
+	return false
+}
+
+// InspectShimFiles reads the shim of each package manager in shimDir and
+// reports the ones that are absent and the ones that name a pmg binary other
+// than pmgBin. A shim from an older install can point at a binary that moved
+// or is gone.
+func InspectShimFiles(shimDir string, packageManagers []string, pmgBin string) (ShimInspection, error) {
+	var inspection ShimInspection
+	for _, pm := range packageManagers {
+		content, err := os.ReadFile(filepath.Join(shimDir, shimFileName(pm)))
+		if errors.Is(err, os.ErrNotExist) {
+			inspection.Missing = append(inspection.Missing, pm)
+			continue
+		}
+		if err != nil {
+			return ShimInspection{}, fmt.Errorf("failed to read the %s shim: %w", pm, err)
+		}
+		if !shimNamesBinary(string(content), pmgBin) {
+			inspection.Stale = append(inspection.Stale, pm)
+		}
+	}
+	return inspection, nil
+}

--- a/internal/shim/interception_other.go
+++ b/internal/shim/interception_other.go
@@ -8,10 +8,17 @@ import (
 	"path/filepath"
 )
 
-func interceptionPathEntries() ([]string, error) {
-	return filepath.SplitList(os.Getenv("PATH")), nil
+// InspectInterception resolves each package manager once against the process
+// PATH, in the order given, and omits one that does not resolve. There is one
+// PATH here, so no resolution carries an origin.
+func InspectInterception(packageManagers []string, shimDirs []string) (InterceptionInspection, error) {
+	entries := filepath.SplitList(os.Getenv("PATH"))
+	return InterceptionInspection{
+		PathEntries: entries,
+		Resolutions: resolveManagers(packageManagers, shimDirs, entries, lookPathIn),
+	}, nil
 }
 
-func interceptionLookPath([]string) func(string) (string, error) {
-	return exec.LookPath
+func lookPathIn(name string, _ []string) (string, error) {
+	return exec.LookPath(name)
 }

--- a/internal/shim/interception_other.go
+++ b/internal/shim/interception_other.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package shim
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func interceptionPathEntries() ([]string, error) {
+	return filepath.SplitList(os.Getenv("PATH")), nil
+}
+
+func interceptionLookPath([]string) func(string) (string, error) {
+	return exec.LookPath
+}

--- a/internal/shim/interception_test.go
+++ b/internal/shim/interception_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInspectInterceptionResolvesEachManagerOnce(t *testing.T) {
+func TestResolveManagers(t *testing.T) {
 	shimDir := filepath.Join("/", "shims")
+	entries := []string{filepath.Join("/", "usr", "bin"), shimDir}
 	calls := map[string]int{}
-	lookPath := func(name string) (string, error) {
+	lookPath := func(name string, _ []string) (string, error) {
 		calls[name]++
 		switch name {
 		case "npm":
@@ -25,18 +26,24 @@ func TestInspectInterceptionResolvesEachManagerOnce(t *testing.T) {
 		}
 	}
 
-	inspection := inspectInterception([]string{"npm", "pip", "uv"}, []string{shimDir}, []string{"/usr/bin", shimDir}, lookPath)
+	resolutions := resolveManagers([]string{"npm", "pip", "uv"}, []string{shimDir}, entries, lookPath)
 
-	assert.Equal(t, []string{"/usr/bin", shimDir}, inspection.PathEntries)
 	assert.Equal(t, []ManagerResolution{
 		{Name: "npm", Path: filepath.Join(shimDir, "npm"), UnderShim: true},
 		{Name: "pip", Path: filepath.Join("/", "usr", "bin", "pip")},
-	}, inspection.Resolutions, "configured order kept, unresolved manager omitted")
-	assert.Equal(t, map[string]int{"npm": 1, "pip": 1, "uv": 1}, calls)
+	}, resolutions, "configured order kept, unresolved manager omitted")
+	assert.Equal(t, map[string]int{"npm": 1, "pip": 1, "uv": 1}, calls, "each manager resolves once")
+}
+
+func TestInterceptionInspectionPartition(t *testing.T) {
+	underShimResolution := ManagerResolution{Name: "npm", UnderShim: true}
+	shadowedResolution := ManagerResolution{Name: "pip"}
+	inspection := InterceptionInspection{Resolutions: []ManagerResolution{underShimResolution, shadowedResolution}}
 
 	underShim, shadowed := inspection.Partition()
-	assert.Equal(t, []ManagerResolution{inspection.Resolutions[0]}, underShim)
-	assert.Equal(t, []ManagerResolution{inspection.Resolutions[1]}, shadowed)
+
+	assert.Equal(t, []ManagerResolution{underShimResolution}, underShim)
+	assert.Equal(t, []ManagerResolution{shadowedResolution}, shadowed)
 }
 
 func TestPathUnderAnyDir(t *testing.T) {
@@ -49,6 +56,9 @@ func TestPathUnderAnyDir(t *testing.T) {
 	assert.False(t, PathUnderAnyDir(filepath.Join("/", "usr", "bin", "yarn"), dirs))
 }
 
+// A shim names the pmg binary by absolute path at install time and nothing
+// updates it later. A second install, a moved binary, or a package upgrade
+// into a versioned directory leaves the shim naming another binary.
 func TestInspectShimFiles(t *testing.T) {
 	pmgBin, err := os.Executable()
 	require.NoError(t, err)
@@ -64,39 +74,63 @@ func TestInspectShimFiles(t *testing.T) {
 		}).Install())
 	}
 
-	t.Run("valid", func(t *testing.T) {
+	t.Run("every shim names this binary", func(t *testing.T) {
 		dir := t.TempDir()
 		writeShims(t, dir, pmgBin, managers)
 
-		inspection, err := InspectShimFiles(dir, managers, pmgBin)
+		inspection, err := InspectShimFiles(dir, managers)
 		require.NoError(t, err)
 		assert.Empty(t, inspection.Missing)
-		assert.Empty(t, inspection.Stale)
+		assert.Empty(t, inspection.BinaryMissing)
+		assert.Empty(t, inspection.BinaryDiffers)
 	})
 
-	t.Run("stale", func(t *testing.T) {
+	t.Run("a shim naming another binary that runs", func(t *testing.T) {
 		dir := t.TempDir()
 		writeShims(t, dir, pmgBin, managers)
-		writeShims(t, dir, filepath.Join(t.TempDir(), "old", "pmg"), []string{"npm"})
 
-		inspection, err := InspectShimFiles(dir, managers, pmgBin)
+		other := filepath.Join(t.TempDir(), "pmg")
+		require.NoError(t, os.WriteFile(other, []byte("#!/bin/sh\n"), 0o755))
+		writeShims(t, dir, other, []string{"npm"})
+
+		inspection, err := InspectShimFiles(dir, managers)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"npm"}, inspection.Stale)
+		assert.Equal(t, []string{"npm"}, inspection.BinaryDiffers)
+		assert.Empty(t, inspection.BinaryMissing)
 		assert.Empty(t, inspection.Missing)
 	})
 
-	t.Run("missing", func(t *testing.T) {
+	t.Run("a shim naming a binary that is gone", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin, managers)
+		writeShims(t, dir, filepath.Join(t.TempDir(), "removed", "pmg"), []string{"npm"})
+
+		inspection, err := InspectShimFiles(dir, managers)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"npm"}, inspection.BinaryMissing)
+		assert.Empty(t, inspection.BinaryDiffers)
+	})
+
+	t.Run("a missing shim file", func(t *testing.T) {
 		dir := t.TempDir()
 		writeShims(t, dir, pmgBin, []string{"npm"})
 
-		inspection, err := InspectShimFiles(dir, managers, pmgBin)
+		inspection, err := InspectShimFiles(dir, managers)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"pip"}, inspection.Missing)
-		assert.Empty(t, inspection.Stale)
 	})
 
-	t.Run("empty directory", func(t *testing.T) {
-		inspection, err := InspectShimFiles(t.TempDir(), managers, pmgBin)
+	t.Run("a file that is not a pmg shim reads as missing", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, shimFileName("npm")), []byte("not a shim\n"), 0o755))
+
+		inspection, err := InspectShimFiles(dir, []string{"npm"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"npm"}, inspection.Missing)
+	})
+
+	t.Run("an empty directory", func(t *testing.T) {
+		inspection, err := InspectShimFiles(t.TempDir(), managers)
 		require.NoError(t, err)
 		assert.Equal(t, managers, inspection.Missing)
 	})

--- a/internal/shim/interception_test.go
+++ b/internal/shim/interception_test.go
@@ -1,0 +1,103 @@
+package shim
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectInterceptionResolvesEachManagerOnce(t *testing.T) {
+	shimDir := filepath.Join("/", "shims")
+	calls := map[string]int{}
+	lookPath := func(name string) (string, error) {
+		calls[name]++
+		switch name {
+		case "npm":
+			return filepath.Join(shimDir, "npm"), nil
+		case "pip":
+			return filepath.Join("/", "usr", "bin", "pip"), nil
+		default:
+			return "", exec.ErrNotFound
+		}
+	}
+
+	inspection := inspectInterception([]string{"npm", "pip", "uv"}, []string{shimDir}, []string{"/usr/bin", shimDir}, lookPath)
+
+	assert.Equal(t, []string{"/usr/bin", shimDir}, inspection.PathEntries)
+	assert.Equal(t, []ManagerResolution{
+		{Name: "npm", Path: filepath.Join(shimDir, "npm"), UnderShim: true},
+		{Name: "pip", Path: filepath.Join("/", "usr", "bin", "pip")},
+	}, inspection.Resolutions, "configured order kept, unresolved manager omitted")
+	assert.Equal(t, map[string]int{"npm": 1, "pip": 1, "uv": 1}, calls)
+
+	underShim, shadowed := inspection.Partition()
+	assert.Equal(t, []ManagerResolution{inspection.Resolutions[0]}, underShim)
+	assert.Equal(t, []ManagerResolution{inspection.Resolutions[1]}, shadowed)
+}
+
+func TestPathUnderAnyDir(t *testing.T) {
+	systemDir := filepath.Join("/", "usr", "local", "lib", "pmg", "bin")
+	userDir := filepath.Join("/", "home", "dev", ".pmg", "bin")
+	dirs := []string{systemDir, userDir}
+
+	assert.True(t, PathUnderAnyDir(filepath.Join(systemDir, "npm"), dirs))
+	assert.True(t, PathUnderAnyDir(filepath.Join(userDir, "pip"), dirs))
+	assert.False(t, PathUnderAnyDir(filepath.Join("/", "usr", "bin", "yarn"), dirs))
+}
+
+func TestInspectShimFiles(t *testing.T) {
+	pmgBin, err := os.Executable()
+	require.NoError(t, err)
+	managers := []string{"npm", "pip"}
+
+	writeShims := func(t *testing.T, dir, bin string, pms []string) {
+		t.Helper()
+		require.NoError(t, NewShimManager(ShimConfig{
+			BinDir:          dir,
+			PMGBin:          bin,
+			PackageManagers: pms,
+			SkipUserPath:    true,
+		}).Install())
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin, managers)
+
+		inspection, err := InspectShimFiles(dir, managers, pmgBin)
+		require.NoError(t, err)
+		assert.Empty(t, inspection.Missing)
+		assert.Empty(t, inspection.Stale)
+	})
+
+	t.Run("stale", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin, managers)
+		writeShims(t, dir, filepath.Join(t.TempDir(), "old", "pmg"), []string{"npm"})
+
+		inspection, err := InspectShimFiles(dir, managers, pmgBin)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"npm"}, inspection.Stale)
+		assert.Empty(t, inspection.Missing)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		dir := t.TempDir()
+		writeShims(t, dir, pmgBin, []string{"npm"})
+
+		inspection, err := InspectShimFiles(dir, managers, pmgBin)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"pip"}, inspection.Missing)
+		assert.Empty(t, inspection.Stale)
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		inspection, err := InspectShimFiles(t.TempDir(), managers, pmgBin)
+		require.NoError(t, err)
+		assert.Equal(t, managers, inspection.Missing)
+	})
+}

--- a/internal/shim/interception_windows.go
+++ b/internal/shim/interception_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package shim
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func interceptionPathEntries() ([]string, error) {
+	return registryPathEntries()
+}
+
+// interceptionLookPath resolves a name over the given PATH entries with the
+// PATHEXT rule, so the answer matches what a new shell would run.
+func interceptionLookPath(pathEntries []string) func(string) (string, error) {
+	exts := pathExtensions()
+	return func(name string) (string, error) {
+		return lookInDirs(name, pathEntries, exts)
+	}
+}
+
+func pathExtensions() []string {
+	exts := os.Getenv("PATHEXT")
+	if exts == "" {
+		exts = ".COM;.EXE;.BAT;.CMD"
+	}
+	return strings.Split(exts, ";")
+}
+
+// lookInDirs lower-cases each extension, as exec.LookPath does, so a
+// resolved path reads `npm.cmd` rather than `npm.CMD`.
+func lookInDirs(name string, dirs, exts []string) (string, error) {
+	for _, dir := range dirs {
+		for _, ext := range exts {
+			candidate := filepath.Join(dir, name+strings.ToLower(ext))
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate, nil
+			}
+		}
+	}
+	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+}

--- a/internal/shim/interception_windows.go
+++ b/internal/shim/interception_windows.go
@@ -9,32 +9,83 @@ import (
 	"strings"
 )
 
-func interceptionPathEntries() ([]string, error) {
-	return registryPathEntries()
+// InspectInterception reports where a package manager runs from when the
+// developer types its name.
+//
+// It reads two PATHs, because neither answers the question alone. The
+// registry PATH is what a shell started from Explorer gets, and doctor often
+// runs in the shell that ran `pmg setup install`, whose process PATH predates
+// the new entry. The process PATH is what this shell has, and it is the only
+// one that shows a directory a shell profile added: `fnm env |
+// Invoke-Expression` in $PROFILE prepends a multishell directory that holds
+// npm, and the registry never sees it.
+//
+// A manager that the process PATH resolves outside the shims, from a
+// directory the registry does not hold, is shadowed by the profile. Anything
+// else takes the registry answer, so a stale shell does not report a
+// registered shim directory as absent.
+func InspectInterception(packageManagers []string, shimDirs []string) (InterceptionInspection, error) {
+	machine, user, err := registryPathHalves()
+	if err != nil {
+		return InterceptionInspection{}, err
+	}
+	registryEntries := append(append([]string{}, machine...), user...)
+	process := filepath.SplitList(os.Getenv("PATH"))
+
+	inspection := InterceptionInspection{PathEntries: registryEntries}
+	for _, pm := range packageManagers {
+		if r, ok := profileShadowed(pm, shimDirs, registryEntries, process); ok {
+			inspection.Resolutions = append(inspection.Resolutions, r)
+			continue
+		}
+
+		resolved, err := lookPathIn(pm, registryEntries)
+		if err != nil {
+			continue
+		}
+		inspection.Resolutions = append(inspection.Resolutions, ManagerResolution{
+			Name:      pm,
+			Path:      resolved,
+			UnderShim: PathUnderAnyDir(resolved, shimDirs),
+			Origin:    originOf(resolved, machine, user),
+		})
+	}
+	return inspection, nil
 }
 
-// interceptionLookPath resolves a name over the given PATH entries with the
-// PATHEXT rule, so the answer matches what a new shell would run.
-func interceptionLookPath(pathEntries []string) func(string) (string, error) {
+// profileShadowed reports a manager that this shell resolves outside the
+// shims from a directory no registry PATH entry names.
+func profileShadowed(pm string, shimDirs, registryEntries, process []string) (ManagerResolution, bool) {
+	resolved, err := lookPathIn(pm, process)
+	if err != nil || PathUnderAnyDir(resolved, shimDirs) {
+		return ManagerResolution{}, false
+	}
+	if PathUnderAnyDir(resolved, registryEntries) {
+		return ManagerResolution{}, false
+	}
+	return ManagerResolution{Name: pm, Path: resolved, Origin: OriginProfile}, true
+}
+
+// originOf names the PATH half that holds the directory of path. Windows
+// searches the machine half first, so it wins a directory that is in both.
+func originOf(path string, machine, user []string) PathOrigin {
+	if PathUnderAnyDir(path, machine) {
+		return OriginMachine
+	}
+	if PathUnderAnyDir(path, user) {
+		return OriginUser
+	}
+	return OriginUnknown
+}
+
+// lookPathIn resolves a name over the given PATH entries with the PATHEXT
+// rule, so the answer matches what a shell would run.
+func lookPathIn(name string, entries []string) (string, error) {
 	exts := pathExtensions()
-	return func(name string) (string, error) {
-		return lookInDirs(name, pathEntries, exts)
-	}
-}
-
-func pathExtensions() []string {
-	exts := os.Getenv("PATHEXT")
-	if exts == "" {
-		exts = ".COM;.EXE;.BAT;.CMD"
-	}
-	return strings.Split(exts, ";")
-}
-
-// lookInDirs lower-cases each extension, as exec.LookPath does, so a
-// resolved path reads `npm.cmd` rather than `npm.CMD`.
-func lookInDirs(name string, dirs, exts []string) (string, error) {
-	for _, dir := range dirs {
+	for _, dir := range entries {
 		for _, ext := range exts {
+			// The extension is lower-cased as exec.LookPath does, so a
+			// resolved path reads `npm.cmd` rather than `npm.CMD`.
 			candidate := filepath.Join(dir, name+strings.ToLower(ext))
 			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
 				return candidate, nil
@@ -42,4 +93,22 @@ func lookInDirs(name string, dirs, exts []string) (string, error) {
 		}
 	}
 	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+}
+
+// pathExtensions drops an empty entry, which a trailing semicolon in PATHEXT
+// leaves behind. An empty extension would match a file with no extension,
+// such as the sh script npm ships next to npm.cmd, which cmd.exe cannot run.
+func pathExtensions() []string {
+	value := os.Getenv("PATHEXT")
+	if value == "" {
+		value = ".COM;.EXE;.BAT;.CMD"
+	}
+
+	exts := make([]string, 0, 4)
+	for _, ext := range strings.Split(value, ";") {
+		if ext != "" {
+			exts = append(exts, ext)
+		}
+	}
+	return exts
 }

--- a/internal/shim/interception_windows_test.go
+++ b/internal/shim/interception_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,66 +14,154 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-func TestLookInDirs(t *testing.T) {
+func TestLookPathIn(t *testing.T) {
 	first, second := t.TempDir(), t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(second, "npm.cmd"), nil, 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(second, "pip.exe"), nil, 0o644))
 	require.NoError(t, os.Mkdir(filepath.Join(first, "uv.exe"), 0o755))
-	exts := []string{".COM", ".EXE", ".BAT", ".CMD"}
+	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
 
-	t.Run("applies PATHEXT in order across directories and lower-cases the extension", func(t *testing.T) {
-		got, err := lookInDirs("npm", []string{first, second}, exts)
+	t.Run("applies PATHEXT in order and lower-cases the extension", func(t *testing.T) {
+		got, err := lookPathIn("npm", []string{first, second})
 		require.NoError(t, err)
 		assert.Equal(t, filepath.Join(second, "npm.cmd"), got)
 
-		got, err = lookInDirs("pip", []string{first, second}, exts)
+		got, err = lookPathIn("pip", []string{first, second})
 		require.NoError(t, err)
 		assert.Equal(t, filepath.Join(second, "pip.exe"), got)
 	})
 
 	t.Run("skips a directory that carries the name", func(t *testing.T) {
-		_, err := lookInDirs("uv", []string{first, second}, exts)
+		_, err := lookPathIn("uv", []string{first, second})
 		assert.ErrorIs(t, err, exec.ErrNotFound)
 	})
 
 	t.Run("reports a missing name like LookPath", func(t *testing.T) {
-		_, err := lookInDirs("yarn", []string{first, second}, exts)
+		_, err := lookPathIn("yarn", []string{first, second})
 		var execErr *exec.Error
 		require.ErrorAs(t, err, &execErr)
 		assert.Equal(t, "yarn", execErr.Name)
 	})
 }
 
-// setMachinePath writes value as the machine PATH in the scratch key that
-// isolateMachinePath armed.
-func setMachinePath(t *testing.T, value string) {
+// A trailing semicolon in PATHEXT would leave an empty extension, which
+// matches a file with no extension. npm ships an sh script called `npm` next
+// to npm.cmd, and cmd.exe cannot run it.
+func TestPathExtensionsDropsAnEmptyEntry(t *testing.T) {
+	t.Setenv("PATHEXT", ".EXE;.CMD;")
+	assert.Equal(t, []string{".EXE", ".CMD"}, pathExtensions())
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "npm"), nil, 0o644))
+	_, err := lookPathIn("npm", []string{dir})
+	assert.ErrorIs(t, err, exec.ErrNotFound)
+}
+
+// setRegistryPath writes value as the PATH of one scratch key.
+func setRegistryPath(t *testing.T, root registry.Key, keyPath, value string) {
 	t.Helper()
-	key, err := registry.OpenKey(machineEnvironmentRoot, machineEnvironmentKey, registry.SET_VALUE)
+	key, err := registry.OpenKey(root, keyPath, registry.SET_VALUE)
 	require.NoError(t, err)
 	defer key.Close()
 	require.NoError(t, key.SetExpandStringValue(pathValueName, value))
 }
 
-// A manager on the machine PATH resolves before the same name on the user
-// PATH, because Windows builds a process PATH in that order.
-func TestInspectInterceptionMachinePathFirst(t *testing.T) {
-	isolateUserPath(t)
-	isolateMachinePath(t)
+// Every case here writes both registry halves and the process PATH, so the
+// runner's own PATH cannot reach the result.
+func TestInspectInterception(t *testing.T) {
+	newManagerDir := func(t *testing.T, names ...string) string {
+		t.Helper()
+		dir := t.TempDir()
+		for _, name := range names {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, name+".cmd"), nil, 0o644))
+		}
+		return dir
+	}
+	joinPath := func(dirs ...string) string { return strings.Join(dirs, ";") }
 
-	machineDir, shimDir := t.TempDir(), t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(machineDir, "npm.cmd"), nil, 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(shimDir, "npm.cmd"), nil, 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(shimDir, "pnpm.cmd"), nil, 0o644))
+	// Windows builds a process PATH as the machine value, then the user
+	// value, so a manager a machine-wide installer put on PATH resolves
+	// before a user-scope shim. Its origin decides the remedy.
+	t.Run("machine PATH resolves before the user PATH", func(t *testing.T) {
+		isolateUserPath(t)
+		isolateMachinePath(t)
+		machineDir := newManagerDir(t, "npm")
+		shimDir := newManagerDir(t, "npm", "pnpm")
 
-	setMachinePath(t, machineDir)
-	require.NoError(t, writeUserPath([]string{shimDir}, true))
+		setRegistryPath(t, machineEnvironmentRoot, machineEnvironmentKey, machineDir)
+		require.NoError(t, writeUserPath([]string{shimDir}, true))
+		t.Setenv("PATH", joinPath(machineDir, shimDir))
 
-	inspection, err := InspectInterception([]string{"npm", "pnpm", "yarn"}, []string{shimDir})
-	require.NoError(t, err)
+		inspection, err := InspectInterception([]string{"npm", "pnpm", "yarn"}, []string{shimDir})
+		require.NoError(t, err)
 
-	assert.Equal(t, []string{machineDir, shimDir}, inspection.PathEntries)
-	assert.Equal(t, []ManagerResolution{
-		{Name: "npm", Path: filepath.Join(machineDir, "npm.cmd")},
-		{Name: "pnpm", Path: filepath.Join(shimDir, "pnpm.cmd"), UnderShim: true},
-	}, inspection.Resolutions)
+		assert.Equal(t, []string{machineDir, shimDir}, inspection.PathEntries)
+		assert.Equal(t, []ManagerResolution{
+			{Name: "npm", Path: filepath.Join(machineDir, "npm.cmd"), Origin: OriginMachine},
+			{Name: "pnpm", Path: filepath.Join(shimDir, "pnpm.cmd"), UnderShim: true, Origin: OriginUser},
+		}, inspection.Resolutions)
+	})
+
+	// The user half is the one PMG can reorder, so a manager shadowed from
+	// there gets a different remedy.
+	t.Run("a user PATH entry ahead of the shims", func(t *testing.T) {
+		isolateUserPath(t)
+		isolateMachinePath(t)
+		pythonDir := newManagerDir(t, "pip")
+		shimDir := newManagerDir(t, "pip")
+
+		setRegistryPath(t, machineEnvironmentRoot, machineEnvironmentKey, `C:\Windows\System32`)
+		require.NoError(t, writeUserPath([]string{pythonDir, shimDir}, true))
+		t.Setenv("PATH", joinPath(`C:\Windows\System32`, pythonDir, shimDir))
+
+		inspection, err := InspectInterception([]string{"pip"}, []string{shimDir})
+		require.NoError(t, err)
+
+		assert.Equal(t, []ManagerResolution{
+			{Name: "pip", Path: filepath.Join(pythonDir, "pip.cmd"), Origin: OriginUser},
+		}, inspection.Resolutions)
+	})
+
+	// `fnm env | Invoke-Expression` in $PROFILE prepends a directory that
+	// holds npm. The registry never sees it, so reading the registry alone
+	// would report the shims as winning in a shell where they do not.
+	t.Run("a shell profile ahead of the shims", func(t *testing.T) {
+		isolateUserPath(t)
+		isolateMachinePath(t)
+		profileDir := newManagerDir(t, "npm")
+		shimDir := newManagerDir(t, "npm")
+
+		setRegistryPath(t, machineEnvironmentRoot, machineEnvironmentKey, `C:\Windows\System32`)
+		require.NoError(t, writeUserPath([]string{shimDir}, true))
+		t.Setenv("PATH", joinPath(profileDir, `C:\Windows\System32`, shimDir))
+
+		inspection, err := InspectInterception([]string{"npm"}, []string{shimDir})
+		require.NoError(t, err)
+
+		assert.Equal(t, []ManagerResolution{
+			{Name: "npm", Path: filepath.Join(profileDir, "npm.cmd"), Origin: OriginProfile},
+		}, inspection.Resolutions)
+	})
+
+	// Doctor often runs in the shell that ran `pmg setup install`, whose
+	// process PATH predates the registry write. The registry answer stands,
+	// because every directory that shell resolves from is in the registry.
+	t.Run("a stale shell keeps the registry answer", func(t *testing.T) {
+		isolateUserPath(t)
+		isolateMachinePath(t)
+		nodeDir := newManagerDir(t, "npm")
+		shimDir := newManagerDir(t, "npm")
+
+		setRegistryPath(t, machineEnvironmentRoot, machineEnvironmentKey, nodeDir)
+		require.NoError(t, writeUserPath([]string{shimDir}, true))
+		// The shell started before the install, so it has no shim directory.
+		t.Setenv("PATH", nodeDir)
+
+		inspection, err := InspectInterception([]string{"npm"}, []string{shimDir})
+		require.NoError(t, err)
+
+		assert.Equal(t, []ManagerResolution{
+			{Name: "npm", Path: filepath.Join(nodeDir, "npm.cmd"), Origin: OriginMachine},
+		}, inspection.Resolutions)
+	})
 }

--- a/internal/shim/interception_windows_test.go
+++ b/internal/shim/interception_windows_test.go
@@ -1,0 +1,78 @@
+//go:build windows
+
+package shim
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/registry"
+)
+
+func TestLookInDirs(t *testing.T) {
+	first, second := t.TempDir(), t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(second, "npm.cmd"), nil, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(second, "pip.exe"), nil, 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(first, "uv.exe"), 0o755))
+	exts := []string{".COM", ".EXE", ".BAT", ".CMD"}
+
+	t.Run("applies PATHEXT in order across directories and lower-cases the extension", func(t *testing.T) {
+		got, err := lookInDirs("npm", []string{first, second}, exts)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(second, "npm.cmd"), got)
+
+		got, err = lookInDirs("pip", []string{first, second}, exts)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(second, "pip.exe"), got)
+	})
+
+	t.Run("skips a directory that carries the name", func(t *testing.T) {
+		_, err := lookInDirs("uv", []string{first, second}, exts)
+		assert.ErrorIs(t, err, exec.ErrNotFound)
+	})
+
+	t.Run("reports a missing name like LookPath", func(t *testing.T) {
+		_, err := lookInDirs("yarn", []string{first, second}, exts)
+		var execErr *exec.Error
+		require.ErrorAs(t, err, &execErr)
+		assert.Equal(t, "yarn", execErr.Name)
+	})
+}
+
+// setMachinePath writes value as the machine PATH in the scratch key that
+// isolateMachinePath armed.
+func setMachinePath(t *testing.T, value string) {
+	t.Helper()
+	key, err := registry.OpenKey(machineEnvironmentRoot, machineEnvironmentKey, registry.SET_VALUE)
+	require.NoError(t, err)
+	defer key.Close()
+	require.NoError(t, key.SetExpandStringValue(pathValueName, value))
+}
+
+// A manager on the machine PATH resolves before the same name on the user
+// PATH, because Windows builds a process PATH in that order.
+func TestInspectInterceptionMachinePathFirst(t *testing.T) {
+	isolateUserPath(t)
+	isolateMachinePath(t)
+
+	machineDir, shimDir := t.TempDir(), t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(machineDir, "npm.cmd"), nil, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(shimDir, "npm.cmd"), nil, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(shimDir, "pnpm.cmd"), nil, 0o644))
+
+	setMachinePath(t, machineDir)
+	require.NoError(t, writeUserPath([]string{shimDir}, true))
+
+	inspection, err := InspectInterception([]string{"npm", "pnpm", "yarn"}, []string{shimDir})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{machineDir, shimDir}, inspection.PathEntries)
+	assert.Equal(t, []ManagerResolution{
+		{Name: "npm", Path: filepath.Join(machineDir, "npm.cmd")},
+		{Name: "pnpm", Path: filepath.Join(shimDir, "pnpm.cmd"), UnderShim: true},
+	}, inspection.Resolutions)
+}

--- a/internal/shim/script_unix.go
+++ b/internal/shim/script_unix.go
@@ -8,10 +8,16 @@ import (
 	"strings"
 
 	"github.com/safedep/dry/log"
+	"github.com/safedep/pmg/internal/fsutil"
 )
 
-// ShimFileName is the shim file for a package manager.
-func ShimFileName(pm string) string { return pm }
+func shimFileName(pm string) string { return pm }
+
+// shimNamesBinary reports whether the PMG_BIN line of a sh shim names pmgBin.
+func shimNamesBinary(content, pmgBin string) bool {
+	bin, ok := parseShimPMGBin(content)
+	return ok && fsutil.SamePath(bin, pmgBin)
+}
 
 func shimScript(pmgBin, pm string) string {
 	return fmt.Sprintf(`#!/bin/sh

--- a/internal/shim/script_unix.go
+++ b/internal/shim/script_unix.go
@@ -8,15 +8,13 @@ import (
 	"strings"
 
 	"github.com/safedep/dry/log"
-	"github.com/safedep/pmg/internal/fsutil"
 )
 
 func shimFileName(pm string) string { return pm }
 
-// shimNamesBinary reports whether the PMG_BIN line of a sh shim names pmgBin.
-func shimNamesBinary(content, pmgBin string) bool {
-	bin, ok := parseShimPMGBin(content)
-	return ok && fsutil.SamePath(bin, pmgBin)
+// parseShimBinary reads the pmg path out of the PMG_BIN line of a sh shim.
+func parseShimBinary(content string) (string, bool) {
+	return parseShimPMGBin(content)
 }
 
 func shimScript(pmgBin, pm string) string {

--- a/internal/shim/script_unix.go
+++ b/internal/shim/script_unix.go
@@ -10,7 +10,8 @@ import (
 	"github.com/safedep/dry/log"
 )
 
-func shimFileName(pm string) string { return pm }
+// ShimFileName is the shim file for a package manager.
+func ShimFileName(pm string) string { return pm }
 
 func shimScript(pmgBin, pm string) string {
 	return fmt.Sprintf(`#!/bin/sh

--- a/internal/shim/script_windows.go
+++ b/internal/shim/script_windows.go
@@ -7,9 +7,16 @@ import (
 	"strings"
 )
 
-// A .cmd file is what every caller that applies PATHEXT finds: cmd.exe,
-// PowerShell and Go's exec.LookPath.
-func shimFileName(pm string) string { return pm + ".cmd" }
+// ShimFileName is the shim file for a package manager. A .cmd file is what
+// every caller that applies PATHEXT finds: cmd.exe, PowerShell and Go's
+// exec.LookPath.
+func ShimFileName(pm string) string { return pm + ".cmd" }
+
+// ShimNamesBinary reports whether a .cmd shim body starts pmgBin. Doctor
+// uses it to find a shim that an older install left pointing elsewhere.
+func ShimNamesBinary(content, pmgBin string) bool {
+	return strings.Contains(strings.ToUpper(content), strings.ToUpper(`"`+batchEscape(pmgBin)+`" `))
+}
 
 // shimScript is the batch body. setlocal alone inherits delayed expansion
 // from the caller, which would make !NAME! expand inside the captured tail,

--- a/internal/shim/script_windows.go
+++ b/internal/shim/script_windows.go
@@ -11,9 +11,24 @@ import (
 // PowerShell and Go's exec.LookPath.
 func shimFileName(pm string) string { return pm + ".cmd" }
 
-// shimNamesBinary reports whether a .cmd shim body starts pmgBin.
-func shimNamesBinary(content, pmgBin string) bool {
-	return strings.Contains(strings.ToUpper(content), strings.ToUpper(`"`+batchEscape(pmgBin)+`" `))
+// parseShimBinary reads the pmg path out of the launch line, the one line
+// that starts with a quote. A substring search over the whole body would
+// match inside the echo line and would reject a path that differs only in
+// separator or case, which fsutil.SamePath accepts.
+func parseShimBinary(content string) (string, bool) {
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, `"`) {
+			continue
+		}
+		end := strings.Index(line[1:], `"`)
+		if end < 0 {
+			return "", false
+		}
+		// writeShimScript doubled every percent sign in the path.
+		return strings.ReplaceAll(line[1:1+end], "%%", "%"), true
+	}
+	return "", false
 }
 
 // shimScript is the batch body. setlocal alone inherits delayed expansion

--- a/internal/shim/script_windows.go
+++ b/internal/shim/script_windows.go
@@ -7,14 +7,12 @@ import (
 	"strings"
 )
 
-// ShimFileName is the shim file for a package manager. A .cmd file is what
-// every caller that applies PATHEXT finds: cmd.exe, PowerShell and Go's
-// exec.LookPath.
-func ShimFileName(pm string) string { return pm + ".cmd" }
+// A .cmd file is what every caller that applies PATHEXT finds: cmd.exe,
+// PowerShell and Go's exec.LookPath.
+func shimFileName(pm string) string { return pm + ".cmd" }
 
-// ShimNamesBinary reports whether a .cmd shim body starts pmgBin. Doctor
-// uses it to find a shim that an older install left pointing elsewhere.
-func ShimNamesBinary(content, pmgBin string) bool {
+// shimNamesBinary reports whether a .cmd shim body starts pmgBin.
+func shimNamesBinary(content, pmgBin string) bool {
 	return strings.Contains(strings.ToUpper(content), strings.ToUpper(`"`+batchEscape(pmgBin)+`" `))
 }
 

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -219,7 +219,7 @@ func LegacyUserBinDir() (string, error) {
 }
 
 func (m *ShimManager) writeShimScript(pm string) error {
-	shimPath := filepath.Join(m.config.BinDir, ShimFileName(pm))
+	shimPath := filepath.Join(m.config.BinDir, shimFileName(pm))
 	content := shimScript(m.config.PMGBin, pm)
 
 	if err := os.WriteFile(shimPath, []byte(content), 0o755); err != nil {

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -219,7 +219,7 @@ func LegacyUserBinDir() (string, error) {
 }
 
 func (m *ShimManager) writeShimScript(pm string) error {
-	shimPath := filepath.Join(m.config.BinDir, shimFileName(pm))
+	shimPath := filepath.Join(m.config.BinDir, ShimFileName(pm))
 	content := shimScript(m.config.PMGBin, pm)
 
 	if err := os.WriteFile(shimPath, []byte(content), 0o755); err != nil {

--- a/internal/shim/shim_windows_test.go
+++ b/internal/shim/shim_windows_test.go
@@ -156,3 +156,41 @@ func TestUserPathRegistry(t *testing.T) {
 		assert.ErrorIs(t, err, registry.ErrNotExist)
 	})
 }
+
+// isolateMachinePath points the machine PATH reader at a scratch key under
+// HKCU. HKLM needs elevation, and the reader does not care which root it
+// opens.
+func isolateMachinePath(t *testing.T) {
+	t.Helper()
+	keyPath := `Software\pmg-test-machine-` + strings.ReplaceAll(t.Name(), "/", "_")
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, keyPath, registry.ALL_ACCESS)
+	require.NoError(t, err)
+	require.NoError(t, key.SetExpandStringValue(pathValueName, `C:\Program Files\nodejs;%SystemRoot%\System32`))
+	require.NoError(t, key.Close())
+
+	origRoot, origKey := machineEnvironmentRoot, machineEnvironmentKey
+	machineEnvironmentRoot, machineEnvironmentKey = registry.CURRENT_USER, keyPath
+	t.Cleanup(func() {
+		machineEnvironmentRoot, machineEnvironmentKey = origRoot, origKey
+		require.NoError(t, registry.DeleteKey(registry.CURRENT_USER, keyPath))
+	})
+}
+
+// Windows builds a new process's PATH as the machine value, then the user
+// value. A manager installed for the machine therefore sits ahead of a user
+// PATH entry, and the doctor must see that order.
+func TestRegistryPathEntries(t *testing.T) {
+	isolateUserPath(t)
+	isolateMachinePath(t)
+	require.NoError(t, writeUserPath([]string{`%LOCALAPPDATA%\safedep\pmg\bin`, `C:\Tools`}, true))
+
+	entries, err := RegistryPathEntries()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		`C:\Program Files\nodejs`,
+		filepath.Join(os.Getenv("SystemRoot"), "System32"),
+		filepath.Join(os.Getenv("LOCALAPPDATA"), `safedep\pmg\bin`),
+		`C:\Tools`,
+	}, entries)
+}

--- a/internal/shim/shim_windows_test.go
+++ b/internal/shim/shim_windows_test.go
@@ -184,7 +184,7 @@ func TestRegistryPathEntries(t *testing.T) {
 	isolateMachinePath(t)
 	require.NoError(t, writeUserPath([]string{`%LOCALAPPDATA%\safedep\pmg\bin`, `C:\Tools`}, true))
 
-	entries, err := RegistryPathEntries()
+	entries, err := registryPathEntries()
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/internal/shim/shim_windows_test.go
+++ b/internal/shim/shim_windows_test.go
@@ -165,7 +165,6 @@ func isolateMachinePath(t *testing.T) {
 	keyPath := `Software\pmg-test-machine-` + strings.ReplaceAll(t.Name(), "/", "_")
 	key, _, err := registry.CreateKey(registry.CURRENT_USER, keyPath, registry.ALL_ACCESS)
 	require.NoError(t, err)
-	require.NoError(t, key.SetExpandStringValue(pathValueName, `C:\Program Files\nodejs;%SystemRoot%\System32`))
 	require.NoError(t, key.Close())
 
 	origRoot, origKey := machineEnvironmentRoot, machineEnvironmentKey
@@ -179,18 +178,43 @@ func isolateMachinePath(t *testing.T) {
 // Windows builds a new process's PATH as the machine value, then the user
 // value. A manager installed for the machine therefore sits ahead of a user
 // PATH entry, and the doctor must see that order.
-func TestRegistryPathEntries(t *testing.T) {
+func TestRegistryPathHalves(t *testing.T) {
 	isolateUserPath(t)
 	isolateMachinePath(t)
-	require.NoError(t, writeUserPath([]string{`%LOCALAPPDATA%\safedep\pmg\bin`, `C:\Tools`}, true))
+	setRegistryPath(t, machineEnvironmentRoot, machineEnvironmentKey,
+		`C:\Program Files\nodejs;%SystemRoot%\System32`)
+	require.NoError(t, writeUserPath([]string{`%LOCALAPPDATA%\safedep\pmg\bin`, `"C:\Quoted Tools"`}, true))
 
-	entries, err := registryPathEntries()
+	machine, user, err := registryPathHalves()
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{
 		`C:\Program Files\nodejs`,
 		filepath.Join(os.Getenv("SystemRoot"), "System32"),
+	}, machine, "%VAR% expands from this process's environment")
+	assert.Equal(t, []string{
 		filepath.Join(os.Getenv("LOCALAPPDATA"), `safedep\pmg\bin`),
-		`C:\Tools`,
-	}, entries)
+		`C:\Quoted Tools`,
+	}, user, "SplitList strips the quotes a PATH entry may carry")
+}
+
+// registerUserPath moves the shim directory to the front when an installer
+// prepended its own directory after the last `pmg setup install`.
+func TestRegisterUserPathMovesTheShimDirectoryToTheFront(t *testing.T) {
+	isolateUserPath(t)
+	shimDir := `C:\Users\dev\AppData\Local\safedep\pmg\bin`
+	pythonDir := `C:\Users\dev\AppData\Local\Programs\Python\Python312\Scripts`
+
+	require.NoError(t, writeUserPath([]string{pythonDir, shimDir, `C:\Tools`}, true))
+	require.NoError(t, registerUserPath(shimDir))
+
+	entries, _, err := readUserPath()
+	require.NoError(t, err)
+	assert.Equal(t, []string{shimDir, pythonDir, `C:\Tools`}, entries)
+
+	// Already first, so a second run writes nothing new.
+	require.NoError(t, registerUserPath(shimDir))
+	entries, _, err = readUserPath()
+	require.NoError(t, err)
+	assert.Equal(t, []string{shimDir, pythonDir, `C:\Tools`}, entries)
 }

--- a/internal/shim/winpath_windows.go
+++ b/internal/shim/winpath_windows.go
@@ -5,6 +5,7 @@ package shim
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"unsafe"
@@ -28,20 +29,19 @@ var (
 
 const pathValueName = "Path"
 
-// registryPathEntries returns the PATH a new process receives: the machine
-// entries, then the user entries, with %VAR% references expanded. It reads
-// the registry rather than the process environment, because the shell that
-// ran `pmg setup install` still carries the PATH from before it.
-func registryPathEntries() ([]string, error) {
-	machine, err := readExpandedPath(machineEnvironmentRoot, machineEnvironmentKey)
+// registryPathHalves returns the two halves of the PATH a new process
+// receives, machine first. The caller keeps them apart because PMG can
+// reorder the user half and nothing else.
+func registryPathHalves() (machine, user []string, err error) {
+	machine, err = readExpandedPath(machineEnvironmentRoot, machineEnvironmentKey)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	user, err := readExpandedPath(registry.CURRENT_USER, userEnvironmentKey)
+	user, err = readExpandedPath(registry.CURRENT_USER, userEnvironmentKey)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return append(machine, user...), nil
+	return machine, user, nil
 }
 
 func readExpandedPath(root registry.Key, keyPath string) ([]string, error) {
@@ -59,21 +59,17 @@ func readExpandedPath(root registry.Key, keyPath string) ([]string, error) {
 		return nil, fmt.Errorf("failed to read PATH under %s: %w", keyPath, err)
 	}
 
+	// ExpandString reads %VAR% from this process's environment. A machine
+	// PATH that names a per-user variable therefore expands to this user's
+	// value, which is what a shell for this user would get.
 	expanded, err := registry.ExpandString(value)
 	if err != nil {
 		return nil, fmt.Errorf("failed to expand PATH under %s: %w", keyPath, err)
 	}
-	return splitPath(expanded), nil
-}
-
-func splitPath(value string) []string {
-	var entries []string
-	for _, entry := range strings.Split(value, ";") {
-		if entry != "" {
-			entries = append(entries, entry)
-		}
-	}
-	return entries
+	// SplitList, not a plain split on the separator, because it also strips
+	// the quotes a PATH entry may carry. A quoted entry would otherwise read
+	// as a directory that does not exist.
+	return filepath.SplitList(expanded), nil
 }
 
 var (
@@ -89,10 +85,21 @@ func registerUserPath(dir string) error {
 	if err != nil {
 		return err
 	}
-	if containsPath(entries, dir) {
+	if len(entries) > 0 && fsutil.SamePath(entries[0], dir) {
 		return nil
 	}
-	return writeUserPath(append([]string{dir}, entries...), expand)
+
+	// The shim directory has to be first, or a manager on an entry ahead of
+	// it wins. A per-user installer that prepends its own directory, as the
+	// python.org installer does, would otherwise shadow the shims until the
+	// user edited PATH by hand. A re-run of `pmg setup install` fixes it.
+	kept := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !fsutil.SamePath(entry, dir) {
+			kept = append(kept, entry)
+		}
+	}
+	return writeUserPath(append([]string{dir}, kept...), expand)
 }
 
 // unregisterUserPath removes every entry that names dir from the user PATH.
@@ -168,7 +175,20 @@ func readUserPath() (entries []string, expand bool, err error) {
 		return nil, false, fmt.Errorf("failed to read the user PATH: %w", err)
 	}
 
-	return splitPath(value), valueType == registry.EXPAND_SZ, nil
+	return splitRawPath(value), valueType == registry.EXPAND_SZ, nil
+}
+
+// splitRawPath keeps each entry exactly as the registry holds it, quotes and
+// all, so a read, edit and write-back does not rewrite entries PMG does not
+// own.
+func splitRawPath(value string) []string {
+	var entries []string
+	for _, entry := range strings.Split(value, ";") {
+		if entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
 }
 
 func writeUserPath(entries []string, expand bool) error {

--- a/internal/shim/winpath_windows.go
+++ b/internal/shim/winpath_windows.go
@@ -19,7 +19,62 @@ import (
 // point it at a scratch key. There is intentionally no env var or flag.
 var userEnvironmentKey = `Environment`
 
+// machineEnvironmentRoot and machineEnvironmentKey locate the machine PATH.
+// Tests point them at a scratch key under HKCU.
+var (
+	machineEnvironmentRoot = registry.LOCAL_MACHINE
+	machineEnvironmentKey  = `SYSTEM\CurrentControlSet\Control\Session Manager\Environment`
+)
+
 const pathValueName = "Path"
+
+// RegistryPathEntries returns the PATH a new process receives: the machine
+// entries, then the user entries, with %VAR% references expanded. It reads
+// the registry rather than the process environment, because the shell that
+// ran `pmg setup install` still carries the PATH from before it.
+func RegistryPathEntries() ([]string, error) {
+	machine, err := readExpandedPath(machineEnvironmentRoot, machineEnvironmentKey)
+	if err != nil {
+		return nil, err
+	}
+	user, err := readExpandedPath(registry.CURRENT_USER, userEnvironmentKey)
+	if err != nil {
+		return nil, err
+	}
+	return append(machine, user...), nil
+}
+
+func readExpandedPath(root registry.Key, keyPath string) ([]string, error) {
+	key, err := registry.OpenKey(root, keyPath, registry.QUERY_VALUE)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %s: %w", keyPath, err)
+	}
+	defer key.Close()
+
+	value, _, err := key.GetStringValue(pathValueName)
+	if errors.Is(err, registry.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PATH under %s: %w", keyPath, err)
+	}
+
+	expanded, err := registry.ExpandString(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand PATH under %s: %w", keyPath, err)
+	}
+	return splitPath(expanded), nil
+}
+
+func splitPath(value string) []string {
+	var entries []string
+	for _, entry := range strings.Split(value, ";") {
+		if entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
 
 var (
 	user32                  = windows.NewLazySystemDLL("user32.dll")
@@ -113,12 +168,7 @@ func readUserPath() (entries []string, expand bool, err error) {
 		return nil, false, fmt.Errorf("failed to read the user PATH: %w", err)
 	}
 
-	for _, entry := range strings.Split(value, ";") {
-		if entry != "" {
-			entries = append(entries, entry)
-		}
-	}
-	return entries, valueType == registry.EXPAND_SZ, nil
+	return splitPath(value), valueType == registry.EXPAND_SZ, nil
 }
 
 func writeUserPath(entries []string, expand bool) error {

--- a/internal/shim/winpath_windows.go
+++ b/internal/shim/winpath_windows.go
@@ -28,11 +28,11 @@ var (
 
 const pathValueName = "Path"
 
-// RegistryPathEntries returns the PATH a new process receives: the machine
+// registryPathEntries returns the PATH a new process receives: the machine
 // entries, then the user entries, with %VAR% references expanded. It reads
 // the registry rather than the process environment, because the shell that
 // ran `pmg setup install` still carries the PATH from before it.
-func RegistryPathEntries() ([]string, error) {
+func registryPathEntries() ([]string, error) {
 	machine, err := readExpandedPath(machineEnvironmentRoot, machineEnvironmentKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What this implements

Decision group 4 of [`2026-09-09-pmg-windows-support-design.md`](https://github.com/safedep/control-tower/blob/main/docs/specs/2026-09-09-pmg-windows-support-design.md): `pmg setup doctor` tells a Windows developer whether interception is active. It also closes finding 3 from the #452 review: `pmg setup install` warns when the machine PATH shadows the shims.

## Why this is a useful standalone increment

After #452 a Windows machine has shims, and doctor is the only way a developer sees whether they work. The three shell-integration checks assumed a Unix shell. Each gets a Windows form.

| Check | Windows form |
|---|---|
| `shell-aliases` | Not run. PMG installs no shell alias on Windows, and a check for a layer that does not exist reports a false problem |
| `shim-directory` | Each `.cmd` exists and names the `pmg.exe` that runs now. A shim from an older install can point at a binary that is gone |
| `shim-in-path` | Resolution over two PATHs, with the `PATHEXT` rule. See below |

### Why two PATHs

Neither PATH answers "does a typed `npm` reach PMG" on its own.

The **registry PATH**, machine value then user value, is what a shell started from Explorer gets. Doctor often runs in the shell that ran `pmg setup install`, whose process PATH predates the new entry, so reading the process PATH alone reports a registered directory as absent.

The **process PATH** is what this shell has, and it is the only one that shows a directory a shell profile added. `fnm env | Invoke-Expression` in `$PROFILE` prepends a multishell directory that holds `npm`, and the registry never sees it. Reading the registry alone would report the shims as winning in a shell where they do not, which is a false Pass on a security check.

The rule: a manager the process PATH resolves outside the shims, from a directory the registry does not hold, is shadowed by the profile. Anything else takes the registry answer, so a stale shell still does not report a registered shim directory as absent.

## The shadowing warning

Windows puts the machine PATH ahead of the user PATH. #452 prepends the shim directory to the user PATH, so a manager installed for the machine wins over it. The Node.js MSI puts `npm` under `C:\Program Files\nodejs` on the machine PATH by default, so on a plain Node install the shim never runs and `setup install` printed success.

`setup install` and doctor print where each such manager resolves and what to do. The action depends on where the winning PATH entry came from, so each resolution carries a `PathOrigin`:

| Origin | Action |
|---|---|
| Machine PATH | `It is on the machine PATH, which no per-user install can move behind the shims. Run it as `pmg npm`.` |
| User PATH | `Run `pmg setup install` again to move the shims ahead of it.` |
| Shell profile | `A shell profile puts that directory on PATH, where PMG cannot reorder it. Run it as `pmg npm`, or drop that line from the profile.` |

The user case became a real remedy in this pull request: `registerUserPath` moves the shim directory to the front of the user PATH rather than returning early when the entry sits anywhere. A per-user installer that prepends its own directory, as the python.org installer does, is then fixed by a re-run of install. The trade-off is that a developer who deliberately moved the shim directory later in their user PATH gets it moved back, and prepending is the documented behaviour of `setup install`.

Doctor's `shim-in-path` carries the same lines in its Fix column, from the same resolutions, so the two cannot disagree.

## Where the code lives

`internal/shim` owns the facts about shims and interception. `cmd/setup` maps them to a status and renders them. `internal/shim` imports nothing from `cmd/setup`, `internal/doctor`, Cobra or UI.

| File | Owns |
|---|---|
| `internal/shim/interception.go` | `ManagerResolution`, `InterceptionInspection` with `Partition`, `ShimInspection`, `PathUnderAnyDir`. `InspectInterception` resolves each configured manager once, in order, and omits one that does not resolve. `InspectShimFiles` reads each shim and reports the missing and the stale ones |
| `internal/shim/interception_windows.go` | Both PATHs and the rule that reconciles them, the machine, user or profile origin of a resolution, and `PATHEXT` lookup with lower-cased extensions, as `exec.LookPath` does |
| `internal/shim/interception_other.go` | The process PATH and `exec.LookPath` |
| `internal/shim/winpath_windows.go` | `registryPathHalves`, `%VAR%` expanded, and the user PATH write that keeps the shim directory first |
| `internal/shim/script_windows.go`, `script_unix.go` | `shimNamesBinary` for each body: the quoted path in a `.cmd`, the `PMG_BIN` line in an sh shim |
| `cmd/setup/doctor.go` | `checkShimDirectoryResult` and `checkShimDirResolution` map an inspection to Pass, Warn or Fail. One `GOOS` branch drops `shell-aliases` on Windows |
| `cmd/setup/doctor_windows.go` | The install warning and the Fix text, from `[]shim.ManagerResolution`. No PATH read, no lookup |
| `cmd/setup/doctor_other.go` | `warnShadowedManagers` no-op and an empty `shadowedFix`, so the doctor table keeps its usual hint |
| `cmd/setup/setup.go` | One call to the warning after shim install |
| `internal/doctor/checks.go` | `CheckShimScripts` removed. It had no caller and read the executable bit |

## Effect on macOS and Linux

One intended change. The `shim-directory` check used to `stat` the directory and pass. It now reads each shim and reports what it finds, at two severities:

| State | Status | Message |
|---|---|---|
| No shim file, or the named binary is gone | Fail | `Shims missing or broken for pip, npm` |
| The named binary exists and is not this one | Warn | `Shims for npm name another pmg binary` |

The split matters because `doctor` returns a non-zero exit code on a Fail. A shim naming a binary that is gone breaks every typed `npm` with exit 127. A shim naming another `pmg` that still runs keeps intercepting, through that binary, which is what a developer sees when doctor runs from a local build while the installed `pmg` wrote the shims. That is a Warn, so an MDM or CI health check that keys on the exit code does not flip on a working machine.

The strongest case for landing this on every platform is Linux: `os.Executable` resolves the versioned Homebrew Cellar path or an npm `node_modules` path, so `brew upgrade pmg` leaves every shim naming a directory `brew cleanup` then deletes. Every `npm` fails with exit 127 and nothing told the user. This check is the first thing that does. macOS Homebrew is unaffected, because its `/opt/homebrew/bin/pmg` symlink is stable across upgrades.

Everything else off Windows is unchanged. `InspectInterception` reads the process PATH and uses `exec.LookPath`, which is what `checkShimInPathResult` did. `warnShadowedManagers` is a no-op, because the rc file prepends the shim directory, so no machine-wide entry sits ahead of it. `shadowedFix` is empty, so the Fix column keeps its hint.

## What is intentionally left for later

- The launch contract (decision group 2, #455).
- The `checkFixes` hint for `shim-in-path` still reads "Restart shell or source profile". On Windows "open a new terminal" is the action, and the wording is generic enough.

## Tests and validation

`internal/shim`:
- `TestInspectInterceptionResolvesEachManagerOnce`: one `lookPath` call per manager, configured order kept, unresolved manager omitted, and `Partition` splits them.
- `TestPathUnderAnyDir`.
- `TestInspectShimFiles`: valid, a binary that runs and differs, a binary that is gone, a missing file, a file that is not a PMG shim, and an empty directory, against real shims written by `ShimManager`. Runs on every platform, so the sh body is covered too.
- Windows only:
  - `TestInspectInterception`, four cases, each writing both registry halves and the process PATH so the runner PATH cannot reach the result: machine before user, a user entry ahead of the shims, an fnm-shaped profile directory ahead of the shims, and a stale shell that keeps the registry answer.
  - `TestLookPathIn`: `PATHEXT` order across directories, lower-cased extension, a directory that carries the name is skipped, a missing name is `exec.ErrNotFound`.
  - `TestPathExtensionsDropsAnEmptyEntry`: a trailing semicolon in `PATHEXT` no longer matches the sh script npm ships next to `npm.cmd`.
  - `TestRegistryPathHalves`: the two halves apart, `%VAR%` expanded, and a quoted entry unquoted.
  - `TestRegisterUserPathMovesTheShimDirectoryToTheFront`, idempotent on a second run.

`cmd/setup`:
- `TestCheckShimDirResolution`: the five status mappings from fabricated inspections, on every platform.
- `TestCheckShimDirectoryResult`: Pass, stale, missing and empty against real shims.
- `TestCheckShimDirectoryResult`: Pass, a Warn for a binary that differs, a Fail for one that is gone, a Fail that reports a missing and a broken shim together, and an empty directory.
- Windows only: `TestShadowedAction`, the action per origin, and that no origin says "for your user only". `TestShadowedFixAndWarningShareTheResolvedPath`, the warning lines and the Fix text come from the same resolutions.
- Unix only: `TestShadowedFixIsEmptyOffWindows`.

Checks run: `go test -count=1 ./cmd/setup ./internal/shim ./internal/doctor`, `go build ./...`, `go vet ./...`, `GOOS=windows go build ./...`, `GOOS=windows go vet ./...`. All pass on darwin. The Windows job runs the Windows tests on this pull request.

## Dependencies

- Based on `main` after #452.
- Independent of the launch contract (#455). #456 carries this branch through a merge and needs a fresh one after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119HknYpopU7akRtu6gvct6

