### PR TITLE
fix: stop PMG hanging after an install in a Windows terminal

### DIFF
--- a/internal/runner/execute.go
+++ b/internal/runner/execute.go
@@ -33,6 +33,24 @@ const (
 // after the child exits before forcing it to stop.
 const outputDrainGrace = 2 * time.Second
 
+// inputDrainGrace bounds how long we wait for the PTY input reader to notice
+// cancellation. A read on the Windows console cannot be cancelled, so an
+// unbounded wait held the process open until the developer pressed a key.
+const inputDrainGrace = 200 * time.Millisecond
+
+// waitForInputReader waits for the stdin reader to return, but never past the
+// grace. The reader owns nothing the process needs at exit, so leaving it
+// parked on a read that cannot be cancelled is the right trade against a
+// teardown that never finishes. On Unix the read is a poll loop that ends
+// within its own timeout, so the grace does not fire.
+func waitForInputReader(inputDone <-chan struct{}) {
+	select {
+	case <-inputDone:
+	case <-time.After(inputDrainGrace):
+		log.Debugf("input drain grace exceeded, leaving the stdin reader to exit with the process")
+	}
+}
+
 type ExecuteOptions struct {
 	PackageManagerName string
 	DryRun             bool
@@ -243,7 +261,7 @@ func runPTY(
 	}()
 	defer func() {
 		cancelInput()
-		<-inputDone
+		waitForInputReader(inputDone)
 	}()
 
 	if beforeWait != nil {

--- a/internal/runner/execute.go
+++ b/internal/runner/execute.go
@@ -33,24 +33,6 @@ const (
 // after the child exits before forcing it to stop.
 const outputDrainGrace = 2 * time.Second
 
-// inputDrainGrace bounds how long we wait for the PTY input reader to notice
-// cancellation. A read on the Windows console cannot be cancelled, so an
-// unbounded wait held the process open until the developer pressed a key.
-const inputDrainGrace = 200 * time.Millisecond
-
-// waitForInputReader waits for the stdin reader to return, but never past the
-// grace. The reader owns nothing the process needs at exit, so leaving it
-// parked on a read that cannot be cancelled is the right trade against a
-// teardown that never finishes. On Unix the read is a poll loop that ends
-// within its own timeout, so the grace does not fire.
-func waitForInputReader(inputDone <-chan struct{}) {
-	select {
-	case <-inputDone:
-	case <-time.After(inputDrainGrace):
-		log.Debugf("input drain grace exceeded, leaving the stdin reader to exit with the process")
-	}
-}
-
 type ExecuteOptions struct {
 	PackageManagerName string
 	DryRun             bool

--- a/internal/runner/input_drain_other.go
+++ b/internal/runner/input_drain_other.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package runner
+
+import (
+	"time"
+
+	"github.com/safedep/dry/log"
+)
+
+// inputDrainGrace bounds the wait for the stdin reader. The reader is a poll
+// loop with its own short timeout, so it notices the cancelled context and
+// returns. The bound is a safety net against a reader that does not, never
+// the expected path.
+const inputDrainGrace = 200 * time.Millisecond
+
+func waitForInputReader(inputDone <-chan struct{}) {
+	select {
+	case <-inputDone:
+	case <-time.After(inputDrainGrace):
+		log.Debugf("input drain grace exceeded, leaving the stdin reader to exit with the process")
+	}
+}

--- a/internal/runner/input_drain_other_test.go
+++ b/internal/runner/input_drain_other_test.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The stdin reader here ends on its own within its poll timeout, so PMG waits
+// for it rather than abandoning it, and the grace only bounds that wait.
+func TestWaitForInputReaderWaitsForTheReader(t *testing.T) {
+	readerRuntime := 20 * time.Millisecond
+	inputDone := make(chan struct{})
+	go func() {
+		time.Sleep(readerRuntime)
+		close(inputDone)
+	}()
+
+	start := time.Now()
+	waitForInputReader(inputDone)
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, readerRuntime, "it waits for the reader to finish")
+	assert.Less(t, elapsed, inputDrainGrace, "and returns before the grace expires")
+}

--- a/internal/runner/input_drain_test.go
+++ b/internal/runner/input_drain_test.go
@@ -1,0 +1,43 @@
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A read on the Windows console cannot be cancelled, so the stdin reader can
+// still be parked when runPTY tears down. The wait has to end anyway, or the
+// process stays alive until the developer presses a key. A regression here
+// shows up as this test timing out, not as a user report.
+func TestWaitForInputReader(t *testing.T) {
+	t.Run("returns as soon as the reader ends", func(t *testing.T) {
+		inputDone := make(chan struct{})
+		close(inputDone)
+
+		start := time.Now()
+		waitForInputReader(inputDone)
+
+		assert.Less(t, time.Since(start), inputDrainGrace,
+			"a reader that already ended must not cost the grace")
+	})
+
+	t.Run("returns when the reader stays parked", func(t *testing.T) {
+		// Never closed, which is a reader blocked in a read that no
+		// cancellation can reach.
+		inputDone := make(chan struct{})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			waitForInputReader(inputDone)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(10 * inputDrainGrace):
+			t.Fatal("waitForInputReader did not return, so PMG would hang until a key is pressed")
+		}
+	})
+}

--- a/internal/runner/input_drain_test.go
+++ b/internal/runner/input_drain_test.go
@@ -7,37 +7,44 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// A read on the Windows console cannot be cancelled, so the stdin reader can
-// still be parked when runPTY tears down. The wait has to end anyway, or the
-// process stays alive until the developer presses a key. A regression here
-// shows up as this test timing out, not as a user report.
-func TestWaitForInputReader(t *testing.T) {
-	t.Run("returns as soon as the reader ends", func(t *testing.T) {
-		inputDone := make(chan struct{})
-		close(inputDone)
+// waitForInputReader has to return whether or not the stdin reader ever ends.
+// On Windows the reader is blocked in a read that no cancellation can reach,
+// so it never ends. Waiting for it is what held `pmg npm install` open until
+// the developer pressed a key.
+func TestWaitForInputReaderAlwaysReturns(t *testing.T) {
+	parked := make(chan struct{})
+	finished := make(chan struct{})
+	close(finished)
 
-		start := time.Now()
+	tests := []struct {
+		name      string
+		inputDone chan struct{}
+	}{
+		{"a reader parked in a read that cannot be cancelled", parked},
+		{"a reader that already ended", finished},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, returnsWithin(t, tt.inputDone, 5*time.Second),
+				"PMG would hang until a key is pressed")
+		})
+	}
+}
+
+func returnsWithin(t *testing.T, inputDone <-chan struct{}, limit time.Duration) bool {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
 		waitForInputReader(inputDone)
+	}()
 
-		assert.Less(t, time.Since(start), inputDrainGrace,
-			"a reader that already ended must not cost the grace")
-	})
-
-	t.Run("returns when the reader stays parked", func(t *testing.T) {
-		// Never closed, which is a reader blocked in a read that no
-		// cancellation can reach.
-		inputDone := make(chan struct{})
-
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			waitForInputReader(inputDone)
-		}()
-
-		select {
-		case <-done:
-		case <-time.After(10 * inputDrainGrace):
-			t.Fatal("waitForInputReader did not return, so PMG would hang until a key is pressed")
-		}
-	})
+	select {
+	case <-done:
+		return true
+	case <-time.After(limit):
+		return false
+	}
 }

--- a/internal/runner/input_drain_windows.go
+++ b/internal/runner/input_drain_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package runner
+
+// waitForInputReader does not wait. PMG selects the PTY mode only when stdin
+// is a terminal, so the stdin reader is always blocked in a read on a console
+// handle, and a read on the Windows console cannot be cancelled. The reader
+// can therefore never see the cancelled context, and any wait here would add
+// its full length to the exit of every interactive run and change nothing.
+//
+// Leaving the reader parked is safe. The child has already exited by the time
+// PMG tears the session down, so the reader has no work left, it owns nothing
+// the process needs, and it dies with the process. Waiting for it is what held
+// `pmg npm install` open until the developer pressed a key.
+func waitForInputReader(<-chan struct{}) {}

--- a/internal/runner/input_drain_windows_test.go
+++ b/internal/runner/input_drain_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// PMG selects the PTY mode only when stdin is a terminal, so the stdin reader
+// is always parked in a read on a console handle and can never notice the
+// cancelled context. Any wait would add its full length to the exit of every
+// interactive run.
+func TestWaitForInputReaderDoesNotWait(t *testing.T) {
+	// Never closed, which is what the reader always looks like here.
+	inputDone := make(chan struct{})
+
+	start := time.Now()
+	waitForInputReader(inputDone)
+
+	assert.Less(t, time.Since(start), 10*time.Millisecond, "the exit must not pay for a reader that cannot end")
+}


### PR DESCRIPTION
## The bug

On Windows, `pmg npm install lodash` in a real terminal does the whole job, prints its summary, and then does not exit. It exits when the developer presses a key.

Reported from manual testing of the current release. It is not part of the Windows support series and does not depend on any of it.

## Cause

`runPTY` starts a goroutine that reads stdin and routes it to the child. On teardown it cancels that goroutine and waits for it:

```go
inputCtx, cancelInput := context.WithCancel(ctx)
inputDone := make(chan struct{})
go func() {
    defer close(inputDone)
    inputRouter.ReadLoopContext(inputCtx, os.Stdin)
}()
defer func() {
    cancelInput()
    <-inputDone      // unbounded
}()
```

The two platform readers behave differently:

```go
// internal/pty/input_read_unix.go — a poll(2) loop, 100ms timeout, re-checks ctx
n, err := unix.Poll(pollFds, 100)

// internal/pty/input_read_windows.go
select {
case <-ctx.Done():
    return 0, ctx.Err()
default:
    return src.Read(buf)   // blocks; cancelling the context cannot reach it
}
```

The context is read *before* the blocking call. Once the goroutine is inside `src.Read`, cancellation does nothing. `<-inputDone` then waits for a keystroke, which is the stall.

Two details that match the report. Defers run last-registered-first, so this block runs before `sess.Close()` restores the console. The terminal is still in raw mode, so *any* key releases it, and Enter is simply what people press. And it is the only unbounded wait in `runPTY`: the output copy has `outputDrainGrace` with a forced stop, and the prompt pipe closes cannot block.

## Why nothing caught it

`IsInteractiveTerminal()` needs both stdin and stdout to be terminals. Every CI job pipes stdin, so every automated run has taken the Direct path, which starts no input goroutine. Confirmed by hand on the released binary: `echo "" | pmg npm install lodash` exits clean, the interactive run stalls.

The spec for Windows support lists this as open question 2, "`conpty` behaviour under `ptyx` is unverified for PMG's prompt flow". The differential argv test in #455 is the first thing that ever forced PTY mode on Windows, and it hangs on this.

## The fix

The wait goes behind the platform split, because the two platforms differ in whether waiting is even possible.

**Windows does not wait.** PMG selects the PTY mode only when stdin is a terminal, so the reader is always parked in a read on a console handle, and a read there cannot be cancelled. The reader can never see the cancelled context, so any wait would add its full length to the exit of every interactive run and change nothing.

```go
// internal/runner/input_drain_windows.go
func waitForInputReader(<-chan struct{}) {}
```

**Unix keeps the wait, bounded.** Its reader is a `poll(2)` loop with a 100ms timeout, so it does notice cancellation and return. The bound is a safety net, not the expected path.

```go
// internal/runner/input_drain_other.go
const inputDrainGrace = 200 * time.Millisecond

func waitForInputReader(inputDone <-chan struct{}) {
    select {
    case <-inputDone:
    case <-time.After(inputDrainGrace):
        log.Debugf("input drain grace exceeded, leaving the stdin reader to exit with the process")
    }
}
```

Teardown is now bounded by construction on both, and Windows pays nothing for it.

Leaving the reader parked is safe, and I checked each part:

- **Nothing reads `os.Stdin` after `runPTY` returns.** `internal/ui` reads stdin for the malware prompt, but in PTY mode that prompt goes through the PTY router's pipe.
- **One `Execute` per pmg invocation.** The call sites in `internal/flows/proxy_flow.go` are mutually exclusive returns, so no later PTY session competes for stdin.
- **The persistent proxy is not involved.** `internal/proxyserver` references neither `internal/runner` nor `internal/pty`, a daemonised process gets `cmd.Stdin = nil`, and `--daemon` is refused on Windows anyway.
- **A prompt is never cut short.** This runs in a `defer`, so it is reached only after `sess.Wait()` returns, and that waits on the child process handle with `INFINITE`. However long the developer takes at an npm prompt, the reader is doing real work and no timer is running. The wait only begins once the child has exited and the reader has nothing left to deliver to.

## Why not make the read cancellable

The tempting fix is `WaitForSingleObject` on the stdin handle, mirroring the Unix poll loop. It is not reliable. `term.MakeRaw` on Windows clears only three flags:

```go
raw := st &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT)
```

`ENABLE_MOUSE_INPUT` stays set, and it is on by default. A mouse move or a window resize puts a record in the console input buffer, which signals the handle. `ReadConsoleW` then discards the non-key record and blocks again. That trades a deterministic stall for a rare one, which is worse.

Doing it properly means replacing the reader with `ReadConsoleInput`, filtering to key events, and translating them to bytes including VT sequences for arrows, function keys and modifiers, plus a fallback for piped stdin. That is a terminal-input implementation, not a bug fix. `CancelIoEx` is a dead end too: console handles are synchronous, and `CancelSynchronousIo` needs an OS thread handle a goroutine does not give you.

## Effect on macOS and Linux

None. The `poll(2)` loop returns within its own 100ms timeout of cancellation, so the `<-inputDone` case always wins and the grace never fires.

## Tests and validation

- `TestWaitForInputReaderAlwaysReturns`, on every platform: a parked reader and a finished reader both return. The parked case is the original bug, and a regression shows up as this test timing out rather than as a user report.
- `TestWaitForInputReaderWaitsForTheReader`, off Windows: it waits for a reader that ends after 20ms, and returns before the grace expires. That proves Unix still joins its reader rather than abandoning it.
- `TestWaitForInputReaderDoesNotWait`, on Windows: a never-ending reader costs less than 10ms, so the exit does not pay for a reader that cannot end.
- `go test -count=1 -race ./internal/runner` passes. `./internal/pty`, `./internal/flows` and `./cmd/setup` pass.
- `go build ./...`, `GOOS=windows go build ./...`, `go vet ./...` and `GOOS=windows go vet ./...` pass.

The integration-level proof is `TestArgvDifferential` in #455, which drives `runPTY` under a real conpty. It times out today and should pass with this in.

## Release

This is a defect in the released binary for any Windows developer who types `pmg npm install` in a terminal. It stands alone and is a candidate for a patch release ahead of the Windows series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119HknYpopU7akRtu6gvct6
