### PR TITLE
feat: register the shim directory on the machine PATH when elevated

### DIFF
--- a/cmd/setup/doctor.go
+++ b/cmd/setup/doctor.go
@@ -430,7 +430,7 @@ func checkShimDirResolution(shimDir, pathLabel string, inspection shim.Intercept
 			return doctor.CheckResult{
 				Status:  doctor.StatusWarn,
 				Message: fmt.Sprintf("%s resolved outside %s", strings.Join(managerNames(shadowed), ", "), pathLabel),
-				Fix:     shadowedFix(shadowed),
+				Fix:     shadowedFix(shimDir, shadowed),
 			}
 		}
 		return doctor.CheckResult{

--- a/cmd/setup/doctor_other.go
+++ b/cmd/setup/doctor_other.go
@@ -8,5 +8,8 @@ import "github.com/safedep/pmg/internal/shim"
 // shim directory to PATH, so no machine-wide entry sits ahead of it.
 func warnShadowedManagers(string) {}
 
+// warnMachinePathLeft is Windows only. Unix has no machine PATH entry.
+func warnMachinePathLeft(string) {}
+
 // shadowedFix is empty on Unix, so the doctor table keeps its usual hint.
-func shadowedFix([]shim.ManagerResolution) string { return "" }
+func shadowedFix(string, []shim.ManagerResolution) string { return "" }

--- a/cmd/setup/doctor_unix_test.go
+++ b/cmd/setup/doctor_unix_test.go
@@ -16,7 +16,7 @@ import (
 // The Windows fix text does not apply off Windows, so the doctor table keeps
 // its usual hint for a shadowed manager.
 func TestShadowedFixIsEmptyOffWindows(t *testing.T) {
-	assert.Equal(t, "", shadowedFix([]shim.ManagerResolution{{Name: "npm", Path: "/usr/bin/npm"}}))
+	assert.Equal(t, "", shadowedFix("/usr/local/lib/pmg/bin", []shim.ManagerResolution{{Name: "npm", Path: "/usr/bin/npm"}}))
 }
 
 // os.Chmod cannot make a directory unwritable on Windows, so the probe

--- a/cmd/setup/doctor_windows.go
+++ b/cmd/setup/doctor_windows.go
@@ -29,34 +29,59 @@ func warnShadowedManagers(binDir string) {
 
 	fmt.Printf("\n%s A shell resolves these managers ahead of the shims, so PMG does not intercept them:\n",
 		ui.Colors.Yellow("⚠"))
-	for _, line := range shadowedLines(shadowed) {
+	for _, line := range shadowedLines(shadowed, machinePathRegistered(binDir)) {
 		fmt.Printf("   %s\n", line)
 	}
 }
 
-// shadowedFix fills the doctor Fix column with the same lines the install
-// warning prints, so the two cannot disagree.
-func shadowedFix(shadowed []shim.ManagerResolution) string {
-	return strings.Join(shadowedLines(shadowed), " ")
+// warnMachinePathLeft tells a user who ran `pmg setup remove` without
+// elevation that the machine PATH entry is still there.
+func warnMachinePathLeft(binDir string) {
+	if !machinePathRegistered(binDir) {
+		return
+	}
+	fmt.Printf("%s %s\n", ui.Colors.Yellow("⚠"),
+		"The shim directory is still on the machine PATH. Run `pmg setup remove` from a terminal started as administrator to delete that entry.")
 }
 
-func shadowedLines(shadowed []shim.ManagerResolution) []string {
+// machinePathRegistered reads as false on a read failure, which yields the
+// stricter advice.
+func machinePathRegistered(binDir string) bool {
+	registered, err := shim.MachinePathRegistered(binDir)
+	if err != nil {
+		log.Warnf("failed to read the machine PATH: %v", err)
+		return false
+	}
+	return registered
+}
+
+// shadowedFix fills the doctor Fix column with the same lines the install
+// warning prints, so the two cannot disagree.
+func shadowedFix(binDir string, shadowed []shim.ManagerResolution) string {
+	return strings.Join(shadowedLines(shadowed, machinePathRegistered(binDir)), " ")
+}
+
+func shadowedLines(shadowed []shim.ManagerResolution, machineRegistered bool) []string {
 	lines := make([]string, 0, len(shadowed))
 	for _, r := range shadowed {
-		lines = append(lines, fmt.Sprintf("%s is %s. %s", r.Name, r.Path, shadowedAction(r)))
+		lines = append(lines, fmt.Sprintf("%s is %s. %s", r.Name, r.Path, shadowedAction(r, machineRegistered)))
 	}
 	return lines
 }
 
 // shadowedAction names what the user can do, which depends on where the
-// winning PATH entry came from. Only the user PATH is one PMG can reorder.
-func shadowedAction(r shim.ManagerResolution) string {
+// winning PATH entry came from. PMG reorders the user PATH on its own and
+// the machine PATH only when elevated.
+func shadowedAction(r shim.ManagerResolution, machineRegistered bool) string {
 	switch r.Origin {
 	case shim.OriginUser:
 		return "Run `pmg setup install` again to move the shims ahead of it."
 	case shim.OriginProfile:
 		return fmt.Sprintf("A shell profile puts that directory on PATH, where PMG cannot reorder it. Run it as `pmg %s`, or drop that line from the profile.", r.Name)
 	default:
-		return fmt.Sprintf("It is on the machine PATH, which no per-user install can move behind the shims. Run it as `pmg %s`.", r.Name)
+		if machineRegistered {
+			return "It is on the machine PATH, and the shim directory is now registered ahead of it. Open a new terminal."
+		}
+		return "It is on the machine PATH, ahead of the user PATH. Run `pmg setup install` from a terminal started as administrator to put the shims ahead of it."
 	}
 }

--- a/cmd/setup/doctor_windows_test.go
+++ b/cmd/setup/doctor_windows_test.go
@@ -10,20 +10,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The action depends on where the winning PATH entry came from. Only the
-// user half is one `pmg setup install` can reorder.
+// The action depends on where the winning PATH entry came from, and for the
+// machine PATH on whether an elevated install already registered the shims.
 func TestShadowedAction(t *testing.T) {
 	tests := []struct {
-		name       string
-		resolution shim.ManagerResolution
-		want       string
-		notWant    string
+		name              string
+		resolution        shim.ManagerResolution
+		machineRegistered bool
+		want              string
+		notWant           string
 	}{
 		{
-			name:       "a machine PATH entry cannot be moved behind the shims",
+			name:       "a machine PATH entry needs an elevated install",
 			resolution: shim.ManagerResolution{Name: "npm", Origin: shim.OriginMachine},
-			want:       "Run it as `pmg npm`.",
-			notWant:    "pmg setup install",
+			want:       "Run `pmg setup install` from a terminal started as administrator",
+			notWant:    "Open a new terminal",
+		},
+		{
+			name:              "a machine PATH entry already behind the registered shims needs a new terminal",
+			resolution:        shim.ManagerResolution{Name: "npm", Origin: shim.OriginMachine},
+			machineRegistered: true,
+			want:              "Open a new terminal.",
+			notWant:           "administrator",
 		},
 		{
 			name:       "a user PATH entry is one install can reorder",
@@ -41,7 +49,7 @@ func TestShadowedAction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			action := shadowedAction(tt.resolution)
+			action := shadowedAction(tt.resolution, tt.machineRegistered)
 			assert.Contains(t, action, tt.want)
 			assert.NotContains(t, action, tt.notWant)
 		})
@@ -51,7 +59,7 @@ func TestShadowedAction(t *testing.T) {
 	// only. The python.org installer prepends its own directory, so that
 	// advice put pip ahead of the shims.
 	for _, origin := range []shim.PathOrigin{shim.OriginMachine, shim.OriginUser, shim.OriginProfile} {
-		assert.NotContains(t, shadowedAction(shim.ManagerResolution{Name: "pip", Origin: origin}),
+		assert.NotContains(t, shadowedAction(shim.ManagerResolution{Name: "pip", Origin: origin}, false),
 			"for your user only")
 	}
 }
@@ -64,8 +72,8 @@ func TestShadowedFixAndWarningShareTheResolvedPath(t *testing.T) {
 		{Name: "pip", Path: `C:\Users\dev\Python\Scripts\pip.exe`, Origin: shim.OriginUser},
 	}
 
-	lines := shadowedLines(shadowed)
-	fix := shadowedFix(shadowed)
+	lines := shadowedLines(shadowed, false)
+	fix := shadowedFix(t.TempDir(), shadowed)
 
 	require.Len(t, lines, 2)
 	assert.Contains(t, lines[0], `npm is C:\Program Files\nodejs\npm.cmd.`)

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -186,6 +186,7 @@ func remove(system, removeConfig bool) error {
 	}
 
 	fmt.Printf("%s %s\n", ui.Colors.Green("✓"), "PMG aliases and shims removed. Restart your terminal for changes to take effect")
+	warnMachinePathLeft(shimMgr.GetBinDir())
 	return nil
 }
 

--- a/internal/shim/script_windows.go
+++ b/internal/shim/script_windows.go
@@ -77,9 +77,27 @@ func batchEscape(value string) string {
 }
 
 // The shim directory reaches PATH through HKCU\Environment, which every new
-// shell reads.
-func (m *ShimManager) installPath() error { return registerUserPath(m.config.BinDir) }
+// shell reads. Windows puts the machine PATH ahead of that, so an elevated
+// install registers the directory there too, as a per-user variable
+// reference. Without elevation the user PATH is all PMG can write.
+func (m *ShimManager) installPath() error {
+	if err := registerUserPath(m.config.BinDir); err != nil {
+		return err
+	}
+	if !isElevated() {
+		return nil
+	}
+	return registerMachinePath(machinePathEntry(m.config.BinDir))
+}
 
-func (m *ShimManager) removePath() error { return unregisterUserPath(m.config.BinDir) }
+func (m *ShimManager) removePath() error {
+	if err := unregisterUserPath(m.config.BinDir); err != nil {
+		return err
+	}
+	if !isElevated() {
+		return nil
+	}
+	return unregisterMachinePath(machinePathEntry(m.config.BinDir))
+}
 
 func (m *ShimManager) pathInstalled() (bool, error) { return userPathContains(m.config.BinDir) }

--- a/internal/shim/shim_windows_test.go
+++ b/internal/shim/shim_windows_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 // isolateUserPath points the user PATH code at a throwaway registry key, so
-// a test never edits the real HKCU\Environment.
+// a test never edits the real HKCU\Environment. It isolates the machine PATH
+// too, because an elevated install writes there and the CI runner is
+// elevated.
 func isolateUserPath(t *testing.T) {
 	t.Helper()
 	// One flat key per test, so deleting it leaves no parent behind.
@@ -30,6 +32,7 @@ func isolateUserPath(t *testing.T) {
 		userEnvironmentKey = orig
 		require.NoError(t, registry.DeleteKey(registry.CURRENT_USER, keyPath))
 	})
+	isolateMachinePath(t)
 }
 
 func TestShimManagerInstallWritesCmdShims(t *testing.T) {
@@ -217,4 +220,131 @@ func TestRegisterUserPathMovesTheShimDirectoryToTheFront(t *testing.T) {
 	entries, _, err = readUserPath()
 	require.NoError(t, err)
 	assert.Equal(t, []string{shimDir, pythonDir, `C:\Tools`}, entries)
+}
+
+// The machine PATH form of the shim directory names the per-user variable,
+// so one machine entry expands to each user's own directory.
+func TestMachinePathEntry(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", `C:\Users\dev\AppData\Local`)
+	t.Setenv("USERPROFILE", `C:\Users\dev`)
+
+	tests := []struct {
+		name, binDir, want string
+	}{
+		{"data directory", `C:\Users\dev\AppData\Local\safedep\pmg\bin`, `%LOCALAPPDATA%\safedep\pmg\bin`},
+		{"legacy home directory", `C:\Users\dev\.pmg\bin`, `%USERPROFILE%\.pmg\bin`},
+		{"case of the prefix does not matter", `c:\users\DEV\appdata\local\safedep\pmg\bin`, `%LOCALAPPDATA%\safedep\pmg\bin`},
+		{"a directory under neither variable stays literal", `D:\tools\pmg\bin`, `D:\tools\pmg\bin`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, machinePathEntry(tt.binDir))
+		})
+	}
+}
+
+// The entry goes after the Windows directories, never ahead of System32,
+// and before every directory an installer added.
+func TestInsertAfterSystemRoot(t *testing.T) {
+	entry := `%LOCALAPPDATA%\safedep\pmg\bin`
+	tests := []struct {
+		name    string
+		entries []string
+		want    []string
+	}{
+		{
+			name: "stock machine PATH",
+			entries: []string{`%SystemRoot%\system32`, `%SystemRoot%`, `%SystemRoot%\System32\Wbem`,
+				`%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\`, `C:\Program Files\nodejs\`},
+			want: []string{`%SystemRoot%\system32`, `%SystemRoot%`, `%SystemRoot%\System32\Wbem`,
+				`%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\`, entry, `C:\Program Files\nodejs\`},
+		},
+		{
+			name:    "expanded Windows directories count too",
+			entries: []string{`C:\WINDOWS\system32`, `C:\Windows`, `C:\Program Files\Git\cmd`},
+			want:    []string{`C:\WINDOWS\system32`, `C:\Windows`, entry, `C:\Program Files\Git\cmd`},
+		},
+		{
+			name:    "no Windows directory puts it first",
+			entries: []string{`C:\Program Files\nodejs\`},
+			want:    []string{entry, `C:\Program Files\nodejs\`},
+		},
+		{
+			name: "empty",
+			want: []string{entry},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, insertAfterSystemRoot(tt.entries, entry, `C:\Windows`))
+		})
+	}
+}
+
+func TestMachinePathRegistry(t *testing.T) {
+	isolateMachinePath(t)
+	entry := `%LOCALAPPDATA%\safedep\pmg\bin`
+	binDir := filepath.Join(os.Getenv("LOCALAPPDATA"), `safedep\pmg\bin`)
+
+	t.Run("registers once after the Windows directories and forces REG_EXPAND_SZ", func(t *testing.T) {
+		require.NoError(t, writeRawPath(machineEnvironmentRoot, machineEnvironmentKey,
+			[]string{`%SystemRoot%\system32`, `C:\Program Files\nodejs\`}, false))
+
+		require.NoError(t, registerMachinePath(entry))
+		require.NoError(t, registerMachinePath(entry))
+
+		entries, expand, err := readRawPath(machineEnvironmentRoot, machineEnvironmentKey)
+		require.NoError(t, err)
+		assert.Equal(t, []string{`%SystemRoot%\system32`, entry, `C:\Program Files\nodejs\`}, entries)
+		assert.True(t, expand)
+
+		registered, err := MachinePathRegistered(binDir)
+		require.NoError(t, err)
+		assert.True(t, registered)
+	})
+
+	t.Run("contains folds case and a trailing separator", func(t *testing.T) {
+		assert.True(t, containsRawEntry([]string{strings.ToUpper(entry) + `\`}, entry))
+		assert.False(t, containsRawEntry([]string{`%LOCALAPPDATA%\safedep\pmg`}, entry))
+	})
+
+	t.Run("unregister removes only the entry and keeps the value", func(t *testing.T) {
+		require.NoError(t, unregisterMachinePath(entry))
+		require.NoError(t, unregisterMachinePath(entry))
+
+		entries, _, err := readRawPath(machineEnvironmentRoot, machineEnvironmentKey)
+		require.NoError(t, err)
+		assert.Equal(t, []string{`%SystemRoot%\system32`, `C:\Program Files\nodejs\`}, entries)
+
+		registered, err := MachinePathRegistered(binDir)
+		require.NoError(t, err)
+		assert.False(t, registered)
+	})
+}
+
+// An elevated install registers the machine entry and an elevated remove
+// deletes it. The GitHub Windows runner is elevated, so this runs in CI.
+func TestShimManagerElevatedInstallRegistersMachinePath(t *testing.T) {
+	if !isElevated() {
+		t.Skip("needs an elevated process")
+	}
+	isolateUserPath(t)
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "safedep", "pmg", "bin")
+
+	mgr := NewShimManager(ShimConfig{
+		BinDir:          binDir,
+		HomeDir:         homeDir,
+		PMGBin:          filepath.Join(homeDir, "pmg.exe"),
+		PackageManagers: []string{"npm"},
+	})
+	require.NoError(t, mgr.Install())
+	registered, err := MachinePathRegistered(binDir)
+	require.NoError(t, err)
+	assert.True(t, registered)
+
+	require.NoError(t, mgr.Remove())
+	registered, err = MachinePathRegistered(binDir)
+	require.NoError(t, err)
+	assert.False(t, registered)
 }

--- a/internal/shim/winpath_windows.go
+++ b/internal/shim/winpath_windows.go
@@ -5,8 +5,10 @@ package shim
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"unsafe"
 
@@ -93,12 +95,7 @@ func registerUserPath(dir string) error {
 	// it wins. A per-user installer that prepends its own directory, as the
 	// python.org installer does, would otherwise shadow the shims until the
 	// user edited PATH by hand. A re-run of `pmg setup install` fixes it.
-	kept := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if !fsutil.SamePath(entry, dir) {
-			kept = append(kept, entry)
-		}
-	}
+	kept := withoutPath(entries, dir)
 	return writeUserPath(append([]string{dir}, kept...), expand)
 }
 
@@ -112,12 +109,7 @@ func unregisterUserPath(dir string) error {
 		return nil
 	}
 
-	kept := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if !fsutil.SamePath(entry, dir) {
-			kept = append(kept, entry)
-		}
-	}
+	kept := withoutPath(entries, dir)
 	if len(kept) == 0 {
 		// The shim entry was the only one. Before the install there was no
 		// value, so leave none behind.
@@ -149,21 +141,120 @@ func userPathContains(dir string) (bool, error) {
 }
 
 func containsPath(entries []string, dir string) bool {
-	for _, entry := range entries {
-		if fsutil.SamePath(entry, dir) {
-			return true
+	return slices.ContainsFunc(entries, func(entry string) bool { return fsutil.SamePath(entry, dir) })
+}
+
+func withoutPath(entries []string, dir string) []string {
+	return slices.DeleteFunc(slices.Clone(entries), func(entry string) bool { return fsutil.SamePath(entry, dir) })
+}
+
+// isElevated reports whether UAC elevated this process. Only an elevated
+// process can write the machine PATH.
+func isElevated() bool { return windows.GetCurrentProcessToken().IsElevated() }
+
+// machinePathEntry is the machine PATH form of a per-user shim directory:
+// the per-user prefix folded back into its variable, so Windows expands the
+// entry for each user and no shared directory is involved. A directory under
+// neither variable is kept as it is.
+func machinePathEntry(binDir string) string {
+	for _, name := range []string{"LOCALAPPDATA", "USERPROFILE"} {
+		prefix := os.Getenv(name)
+		if prefix == "" || !fsutil.PathWithinDir(binDir, prefix) {
+			continue
+		}
+		rel, err := filepath.Rel(prefix, binDir)
+		if err != nil {
+			continue
+		}
+		return `%` + name + `%\` + rel
+	}
+	return binDir
+}
+
+// registerMachinePath adds entry to the machine PATH, which Windows puts
+// ahead of the user PATH, so a manager from a machine-wide installer no
+// longer beats the shims. The value becomes REG_EXPAND_SZ whatever it was,
+// because the entry names a variable.
+func registerMachinePath(entry string) error {
+	entries, _, err := readRawPath(machineEnvironmentRoot, machineEnvironmentKey)
+	if err != nil {
+		return err
+	}
+	if containsRawEntry(entries, entry) {
+		return nil
+	}
+	return writeRawPath(machineEnvironmentRoot, machineEnvironmentKey,
+		insertAfterSystemRoot(entries, entry, os.Getenv("SystemRoot")), true)
+}
+
+// unregisterMachinePath removes entry from the machine PATH. The value is
+// never deleted, because the machine PATH is not PMG's to remove.
+func unregisterMachinePath(entry string) error {
+	entries, expand, err := readRawPath(machineEnvironmentRoot, machineEnvironmentKey)
+	if err != nil {
+		return err
+	}
+	if !containsRawEntry(entries, entry) {
+		return nil
+	}
+	kept := slices.DeleteFunc(slices.Clone(entries), func(e string) bool { return sameRawEntry(e, entry) })
+	return writeRawPath(machineEnvironmentRoot, machineEnvironmentKey, kept, expand)
+}
+
+// MachinePathRegistered reports whether the machine PATH carries the entry
+// for binDir.
+func MachinePathRegistered(binDir string) (bool, error) {
+	entries, _, err := readRawPath(machineEnvironmentRoot, machineEnvironmentKey)
+	if err != nil {
+		return false, err
+	}
+	return containsRawEntry(entries, machinePathEntry(binDir)), nil
+}
+
+// insertAfterSystemRoot places entry after the last %SystemRoot% entry, or
+// first when there is none. Ahead of System32 a user-writable directory
+// would be a PATH hijack for an elevated process. After the Windows entries
+// it still beats every directory a third-party installer added.
+func insertAfterSystemRoot(entries []string, entry, systemRoot string) []string {
+	at := 0
+	for i, e := range entries {
+		if isSystemRootEntry(e, systemRoot) {
+			at = i + 1
 		}
 	}
-	return false
+	return slices.Insert(slices.Clone(entries), at, entry)
+}
+
+func isSystemRootEntry(entry, systemRoot string) bool {
+	upper := strings.ToUpper(entry)
+	if strings.HasPrefix(upper, "%SYSTEMROOT%") {
+		return true
+	}
+	return systemRoot != "" && strings.HasPrefix(upper, strings.ToUpper(systemRoot))
+}
+
+// containsRawEntry compares the unexpanded text. The machine PATH holds the
+// variable reference, and an expansion would only match this user's
+// directory.
+func containsRawEntry(entries []string, entry string) bool {
+	return slices.ContainsFunc(entries, func(e string) bool { return sameRawEntry(e, entry) })
+}
+
+func sameRawEntry(a, b string) bool {
+	return strings.EqualFold(strings.TrimRight(a, `\`), strings.TrimRight(b, `\`))
 }
 
 // readUserPath returns the raw PATH entries and whether the value is
 // REG_EXPAND_SZ. The raw form keeps %USERPROFILE% style references that
 // other tools wrote, so a write does not flatten them.
 func readUserPath() (entries []string, expand bool, err error) {
-	key, err := registry.OpenKey(registry.CURRENT_USER, userEnvironmentKey, registry.QUERY_VALUE)
+	return readRawPath(registry.CURRENT_USER, userEnvironmentKey)
+}
+
+func readRawPath(root registry.Key, keyPath string) (entries []string, expand bool, err error) {
+	key, err := registry.OpenKey(root, keyPath, registry.QUERY_VALUE)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to open HKCU\\%s: %w", userEnvironmentKey, err)
+		return nil, false, fmt.Errorf("failed to open %s: %w", keyPath, err)
 	}
 	defer key.Close()
 
@@ -172,7 +263,7 @@ func readUserPath() (entries []string, expand bool, err error) {
 		return nil, true, nil
 	}
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to read the user PATH: %w", err)
+		return nil, false, fmt.Errorf("failed to read PATH under %s: %w", keyPath, err)
 	}
 
 	return splitRawPath(value), valueType == registry.EXPAND_SZ, nil
@@ -192,9 +283,13 @@ func splitRawPath(value string) []string {
 }
 
 func writeUserPath(entries []string, expand bool) error {
-	key, err := registry.OpenKey(registry.CURRENT_USER, userEnvironmentKey, registry.SET_VALUE)
+	return writeRawPath(registry.CURRENT_USER, userEnvironmentKey, entries, expand)
+}
+
+func writeRawPath(root registry.Key, keyPath string, entries []string, expand bool) error {
+	key, err := registry.OpenKey(root, keyPath, registry.SET_VALUE)
 	if err != nil {
-		return fmt.Errorf("failed to open HKCU\\%s for writing: %w", userEnvironmentKey, err)
+		return fmt.Errorf("failed to open %s for writing: %w", keyPath, err)
 	}
 	defer key.Close()
 
@@ -205,7 +300,7 @@ func writeUserPath(entries []string, expand bool) error {
 		err = key.SetStringValue(pathValueName, value)
 	}
 	if err != nil {
-		return fmt.Errorf("failed to write the user PATH: %w", err)
+		return fmt.Errorf("failed to write PATH under %s: %w", keyPath, err)
 	}
 
 	broadcastEnvironmentChange()


### PR DESCRIPTION
## What this implements

Closes the Node.js MSI gap from #456 and #457. Windows builds a process PATH as the machine value, then the user value, so a manager from a machine-wide installer resolves ahead of the per-user shims, and `pmg setup install` alone could not win. `npm` from the nodejs.org installer, `winget install OpenJS.NodeJS` and Chocolatey is the common case.

## Behaviour

- **`pmg setup install`, elevated.** After the install it does today, PMG writes one `REG_EXPAND_SZ` entry, `%LOCALAPPDATA%\safedep\pmg\bin`, into the machine PATH (`HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`). Windows expands it for each user, so every user gets their own shim directory and nothing shared is writable. A user who never ran `pmg setup install` gets an entry to a directory that does not exist, which is harmless. The entry is written whenever the process is elevated, not only when a manager is shadowed. Already present: nothing is written.
- **Placement.** After the last `%SystemRoot%` entry, or first when there is none. Ahead of `System32` a user-writable directory would be a PATH hijack for an elevated process. After the Windows entries it still beats every directory a third-party installer added.
- **`pmg setup install`, not elevated.** Same as today. When a manager resolves from the machine PATH, the warning says: run `pmg setup install` from a terminal started as administrator. When the entry is already registered and the current shell has the old PATH, it says: open a new terminal.
- **`pmg setup remove`, elevated.** Deletes the entry. The machine PATH value itself is never deleted.
- **`pmg setup remove`, not elevated.** Leaves the entry and says so.
- **`pmg setup doctor`.** The shadowed-manager Fix column carries the same lines as the install warning.

A legacy `~/.pmg/bin` install gets `%USERPROFILE%\.pmg\bin`. A directory under neither variable is written as it is.

## Code

- `internal/shim/winpath_windows.go`: `readRawPath` and `writeRawPath` take a registry root and key, and the user PATH functions call them. New `registerMachinePath`, `unregisterMachinePath`, `MachinePathRegistered`, `machinePathEntry`, `insertAfterSystemRoot`, `isElevated` (`windows.GetCurrentProcessToken().IsElevated()`).
- `internal/shim/script_windows.go`: `installPath` and `removePath` call the machine functions when elevated.
- `cmd/setup/doctor_windows.go`: `shadowedAction` takes whether the entry is registered. New `warnMachinePathLeft` for remove. `shadowedFix` takes the shim directory on both platforms.
- `cmd/setup/setup.go`: `remove` calls `warnMachinePathLeft`.

## Tests

- `TestMachinePathEntry`: data directory, legacy home directory, prefix case, a directory under neither variable.
- `TestInsertAfterSystemRoot`: stock machine PATH, expanded `C:\Windows` entries, no Windows entry, empty.
- `TestMachinePathRegistry`: registers once after the Windows entries and forces `REG_EXPAND_SZ`, contains folds case and a trailing separator, unregister removes only the entry and keeps the value.
- `TestShimManagerElevatedInstallRegistersMachinePath`: gated on `isElevated()`. The GitHub Windows runner is elevated, so it runs in CI.
- `TestShadowedAction`: the two machine-origin messages, user and profile unchanged.
- `isolateUserPath` now isolates the machine key too, so no test on the elevated runner touches the real HKLM PATH.

## Effect on macOS and Linux

None. Every addition is in `_windows.go` files. `shadowedFix` gains the shim directory parameter on both platforms, and the Unix stub still returns an empty string. `go test ./internal/shim/ ./cmd/setup/` passes on macOS.

## Left for later

- The e2e step asserting the machine entry after install and its absence after remove, and the doc change to the MSI bullet in `docs/windows-support.md`. Both files come from #456, so they land here after #456 merges and this branch rebases.
- The MDM Windows script (P8) reuses this: the system-context step installs `pmg.exe` machine-wide and writes the entry by running `pmg setup install` elevated. The user-context step runs `pmg setup install` per user.
- Manual pass, one item: confirm on a real machine that `%LOCALAPPDATA%` in a machine `REG_EXPAND_SZ` entry expands per user on every launch path. #457 records it.

## Dependencies

Based on `main`. Independent of #456 in code. Draft until #456 merges, then rebase for the e2e step and the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119HknYpopU7akRtu6gvct6
